### PR TITLE
Use the `rvm` key to specify Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 gemfile:
   - Gemfile
   - Gemfile_activemodel4
-ruby:
+rvm:
   - 1.9.3
   - 2.1.6
 script: bundle exec rake unattended_spec


### PR DESCRIPTION
See http://docs.travis-ci.com/user/languages/ruby/#Choosing-Ruby-versions-and-implementations-to-test-against