### PR TITLE
make find return array once array argument passed in

### DIFF
--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -16,16 +16,18 @@ module Dynamoid
       #
       # @since 0.2.0
       def find(*ids)
-
+        
         options = if ids.last.is_a? Hash
                     ids.slice!(-1)
                   else
                     {}
                   end
+        expects_array = ids.first.kind_of?(Array)
 
         ids = Array(ids.flatten.uniq)
         if ids.count == 1
-          self.find_by_id(ids.first, options)
+          result = self.find_by_id(ids.first, options)
+          expects_array ? [result] : result
         else
           find_all(ids)
         end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -53,21 +53,21 @@ describe Dynamoid::Criteria::Chain do
 
   it 'finds records with an index' do
     chain.query = {:name => 'Josh'}
-    expect(chain.send(:records_with_index)).to eq user
+    expect(chain.send(:records_with_index)).to eq [user]
 
     chain.query = {:email => 'josh@joshsymonds.com'}
-    expect(chain.send(:records_with_index)).to eq user
+    expect(chain.send(:records_with_index)).to eq [user]
 
     chain.query = {:name => 'Josh', :email => 'josh@joshsymonds.com'}
-    expect(chain.send(:records_with_index)).to eq user
+    expect(chain.send(:records_with_index)).to eq [user]
   end
 
   it 'returns records with an index for a ranged query' do
     chain.query = {:name => 'Josh', "created_at.gt" => time - 1.day}
-    expect(chain.send(:records_with_index)).to eq user
+    expect(chain.send(:records_with_index)).to eq [user]
 
     chain.query = {:name => 'Josh', "created_at.lt" => time + 1.day}
-    expect(chain.send(:records_with_index)).to eq user
+    expect(chain.send(:records_with_index)).to eq [user]
   end
 
   it 'finds records without an index' do

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -26,6 +26,14 @@ describe Dynamoid::Finders do
     expect(Set.new(Address.find(address.id, address2.id))).to eq Set.new([address, address2])
   end
 
+  it 'returns array if passed in array' do
+    expect(Address.find([address.id])).to eq [address]
+  end
+
+  it 'returns object if non array id is passed in' do
+    expect(Address.find(address.id)).to eq address
+  end
+
   # TODO: ATM, adapter sets consistent read to be true for all query. Provide option for setting consistent_read option
   #it 'sends consistent option to the adapter' do
   #  expects(Dynamoid::Adapter).to receive(:get_item).with { |table_name, key, options| options[:consistent_read] == true }


### PR DESCRIPTION
The change I made is to make the gem's finders::finder behave more like an active::record find. In particular, I made so that find(["#id"]) return [Object] instead of just Object