### PR TITLE
Better manage and cache tables

### DIFF
--- a/lib/dynamoid/adapter/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter/aws_sdk_v2.rb
@@ -104,9 +104,9 @@ module Dynamoid
       # @since 1.0.0
       def create_table(table_name, key = :id, options = {})
         Dynamoid.logger.info "Creating #{table_name} table. This could take a while."
-        read_capacity = options.delete(:read_capacity) || Dynamoid::Config.read_capacity
-        write_capacity = options.delete(:write_capacity) || Dynamoid::Config.write_capacity
-        range_key = options.delete(:range_key)
+        read_capacity = options[:read_capacity] || Dynamoid::Config.read_capacity
+        write_capacity = options[:write_capacity] || Dynamoid::Config.write_capacity
+        range_key = options[:range_key]
         
         key_schema = [
           { attribute_name: key.to_s, key_type: HASH_KEY }
@@ -176,7 +176,7 @@ module Dynamoid
         table    = describe_table(table_name)
         range_key = options.delete(:range_key)
 
-        item = client.get_item(table_name: table_name, 
+        item = client.get_item(table_name: table_name,
           key: key_stanza(table, key, range_key)
         )[:item]
         item ? result_item_to_hash(item) : nil
@@ -257,7 +257,7 @@ module Dynamoid
       # @option opts [Number] :range_gte find range keys greater than or equal to this
       # @option opts [Number] :range_lte find range keys less than or equal to this
       #
-      # @return [Enumerator] an iterator of all matching items
+      # @return [Enumerable] matching items
       #
       # @since 1.0.0
       #
@@ -307,6 +307,7 @@ module Dynamoid
 
         Enumerator.new { |y|
           result = client.query(q)
+
           result.items.each { |r|
             y << result_item_to_hash(r)
           }
@@ -330,7 +331,7 @@ module Dynamoid
       # @param [String] table_name the name of the table
       # @param [Hash] scan_hash a hash of attributes: matching records will be returned by the scan
       #
-      # @return [Enumerator] an iterator of all matching items
+      # @return [Enumerable] matching items
       #
       # @since 1.0.0
       #
@@ -354,6 +355,7 @@ module Dynamoid
           # Batch loop, pulls multiple requests until done using the start_key
           loop do
             results = client.scan(request)
+
             results.data[:items].each { |row| y << result_item_to_hash(row) }
 
             if((lk = results[:last_evaluated_key]) && batch)

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -42,16 +42,7 @@ module Dynamoid
           :range_key => range_key_hash
         }.merge(options)
 
-        return true if table_exists?(options[:table_name])
-
-        Dynamoid::Adapter.tables << options[:table_name] if Dynamoid::Adapter.create_table(options[:table_name], options[:id], options)
-      end
-
-      # Does a table with this name exist?
-      #
-      # @since 0.2.0
-      def table_exists?(table_name)
-        Dynamoid::Adapter.tables ? Dynamoid::Adapter.tables.include?(table_name) : false
+        Dynamoid::Adapter.create_table(options[:table_name], options[:id], options)
       end
 
       def from_database(attrs = {})
@@ -156,7 +147,7 @@ module Dynamoid
     # @since 0.2.0
     def save(options = {})
       self.class.create_table
-      
+
       if new_record?
         conditions = { :unless_exists => [self.class.hash_key]}
         conditions[:unless_exists] << range_key if(range_key)

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -1,10 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Dynamoid::Criteria do
-  before(:all) do
-    Magazine.create_table
-  end
-
   let!(:user1) {User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')}
   let!(:user2) {User.create(:name => 'Justin', :email => 'justin@joshsymonds.com')}
 
@@ -20,15 +16,21 @@ describe Dynamoid::Criteria do
     expect(Set.new(User.all)).to eq Set.new([user1, user2])
     expect(User.all.first.new_record).to be_falsey
   end
-  
-  it 'returns empty attributes for where' do
-    expect(Magazine.where(:name => 'Josh').all).to eq []
+
+  context 'Magazine table' do
+    before(:each) do
+      Magazine.create_table
+    end
+
+    it 'returns empty attributes for where' do
+      expect(Magazine.where(:name => 'Josh').all).to eq []
+    end
+
+    it 'returns empty attributes for all' do
+      expect(Magazine.all).to eq []
+    end
   end
-  
-  it 'returns empty attributes for all' do
-    expect(Magazine.all).to eq []
-  end
-  
+
   it 'passes each to all members' do
     User.each do |u|
       expect(u.id == user1.id || u.id == user2.id).to be_truthy

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -112,6 +112,7 @@ describe Dynamoid::Finders do
     end
 
     it 'should return an empty array when fields exist but nothing is found' do
+      User.create_table
       array = User.find_all_by_password('Test')
 
       expect(array).to be_empty

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,14 +39,9 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Dynamoid::Adapter.list_tables.each do |table|
-      Dynamoid::Adapter.truncate(table) if table =~ /^#{Dynamoid::Config.namespace}/
-    end
-  end
-
-  config.after(:suite) do
-    Dynamoid::Adapter.list_tables.each do |table|
       Dynamoid::Adapter.delete_table(table) if table =~ /^#{Dynamoid::Config.namespace}/
     end
+    Dynamoid::Adapter.tables.clear
   end
 end
 


### PR DESCRIPTION
For my future code that dynamically creates models for unit tests, I needed to delete all tables between every test.  Otherwise unit tests would sometimes (depending on their run order) have a disagreement between a model and its database table structure.

Upon modifying the test suite to delete tables between every test, I uncovered some bugs and imperfections:
1) Dynamoid creates a table only on `.create` or `#save`.  Meanwhile, querying a non-existent table raises an exception.  I update some unit tests to first create the table they query.
2) Dynamoid::Adapter.create_table would modify its options hash by deleting keys.  Rspec, meanwhile, would re-create the same-named table with a now-different options hash.  This caused some tests to fail in an order-dependent way.  I update `.create_table` to not modify its options hash.
3) Dynamoid::Adapter would cache its list of tables so as not to re-create a table it remembers about.  But this list would be used and modified in Dynamoid::Persistence.  I refactored some code such that now only Dynamoid::Adapter is responsible for referencing and maintaining the cache.