### PR TITLE
Added support for hash, binary and sets

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -404,7 +404,7 @@ module Dynamoid
 
       STRING_TYPE  = "S".freeze
       NUM_TYPE     = "N".freeze
-      BOOLEAN_TYPE = "B".freeze
+      BINARY_TYPE = "B".freeze
 
       #Converts from symbol to the API string for the given data type
       # E.g. :number -> 'N'
@@ -412,8 +412,7 @@ module Dynamoid
         case(type)
         when :string  then STRING_TYPE
         when :number  then NUM_TYPE
-        when :datetime then NUM_TYPE
-        when :boolean then BOOLEAN_TYPE
+        when :binary then BINARY_TYPE
         else raise "Unknown type: #{type}"
         end
       end

--- a/lib/dynamoid/errors.rb
+++ b/lib/dynamoid/errors.rb
@@ -1,13 +1,15 @@
 # encoding: utf-8
 module Dynamoid
-  
+
   # All the errors specific to Dynamoid.  The goal is to mimic ActiveRecord.
   module Errors
-    
+
     # Generic Dynamoid error
     class Error < StandardError; end
-    
+
     class MissingRangeKey < Error; end
+
+    class InvalidField < Error; end
 
     # This class is intended to be private to Dynamoid.
     class ConditionalCheckFailedException < Error

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -178,6 +178,19 @@ describe Dynamoid::Fields do
     end
   end
 
+
+  describe 'unknown field type' do
+    it 'raise invalid field exception' do
+      expect {
+        Class.new do
+          include Dynamoid::Document
+          table :name => :addresses
+          field :address, :bad_type_specifier
+        end
+      }.to raise_error(Dynamoid::Errors::InvalidField)
+    end
+  end
+
   context 'single table inheritance' do
     it "has only base class fields on the base class" do
       expect(Vehicle.attributes.keys.to_set).to eq Set.new([:type, :description, :created_at, :updated_at, :id])

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -199,21 +199,19 @@ describe Dynamoid::Persistence do
 
         field :city
         field :options, :serialized
-        field :deliverable, :bad_type_specifier
       end
     end
 
     it 'raises when undumping a column with an unknown field type' do
       expect do
-        clazz.new(:deliverable => true) #undump is called here
+        clazz.undump_field('test', {:type => :bad_type_specifier})
       end.to raise_error(ArgumentError)
     end
 
     it 'raises when dumping a column with an unknown field type' do
       doc = clazz.new
-      doc.deliverable = true
       expect do
-        doc.dump
+        doc.send(:dump, 'test', {:type => :bad_type_specifier})
       end.to raise_error(ArgumentError)
     end
   end


### PR DESCRIPTION
This is just for initial review, I will add more specs if you guys are ok with the changes. 

I have also added additional type checking to ensure that only correct types are allowed to save. Eg: If you pass an array to an integer field, it will save nil, this is similar to how active record does it.

Here is a summary of the mappings

Dynamoid type | Ruby type | AWS DynamoDB type
-----------------|-----------------|------------------
integer | Integer | Number
number | BigDecimal | Number
string | String | String
datetime | DateTime | Number
boolean | true/false | Boolean
serialized | String | String
array | Array | List
hash | Hash | Map
set | Set | Type is based on first element in the set
string_set | Set of Strings | String Set
number_set | Set of BigDecimal | Number Set
binary_set | Set of StringIO | Binary Set

I think calling undump when an object is initialized is not needed and adds unnecessary complexity. It should only be called when an item is loaded from database. The aws-sdk gem already does a lot of the unmarshalling on its end. This could be a breaking change though.