### PR TITLE
Added secondary index support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ rdoc
 # jeweler generated
 pkg
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore
 # * Include files you want ignored
@@ -53,3 +53,8 @@ pkg
 
 # For RubyMine:
 .idea
+
+# For Ctags
+.gemtags
+.tags
+.tags_sorted_by_file

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -71,5 +71,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<github-markup>, [">= 0"])
   s.add_development_dependency(%q<pry>, [">= 0"])
   s.add_development_dependency(%q<coveralls>, [">= 0"])
+  s.add_development_dependency(%q<debugger>, [">= 0"])
 end
 

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -71,6 +71,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<github-markup>, [">= 0"])
   s.add_development_dependency(%q<pry>, [">= 0"])
   s.add_development_dependency(%q<coveralls>, [">= 0"])
-  s.add_development_dependency(%q<debugger>, [">= 0"])
 end
 

--- a/lib/dynamoid.rb
+++ b/lib/dynamoid.rb
@@ -11,6 +11,7 @@ require "active_model"
 
 require 'dynamoid/errors'
 require 'dynamoid/fields'
+require 'dynamoid/indexes'
 require 'dynamoid/associations'
 require 'dynamoid/persistence'
 require 'dynamoid/dirty'
@@ -34,11 +35,11 @@ module Dynamoid
     block_given? ? yield(Dynamoid::Config) : Dynamoid::Config
   end
   alias :config :configure
-  
+
   def logger
     Dynamoid::Config.logger
   end
-  
+
   def included_models
     @included_models ||= []
   end

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -25,6 +25,7 @@ module Dynamoid
     include ActiveModel::Serializers::JSON
     include ActiveModel::Serializers::Xml
     include Dynamoid::Fields
+    include Dynamoid::Indexes
     include Dynamoid::Persistence
     include Dynamoid::Finders
     include Dynamoid::Associations

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -50,22 +50,22 @@ module Dynamoid #:nodoc:
       #
       def destroy_all
         ids = []
-        
+
         if key_present?
           ranges = []
           Dynamoid.adapter.query(source.table_name, range_query).collect do |hash|
             ids << hash[source.hash_key.to_sym]
             ranges << hash[source.range_key.to_sym]
           end
-          
+
           Dynamoid.adapter.delete(source.table_name, ids,{:range_key => ranges})
         else
           Dynamoid.adapter.scan(source.table_name, query, scan_opts).collect do |hash|
             ids << hash[source.hash_key.to_sym]
           end
-          
+
           Dynamoid.adapter.delete(source.table_name, ids)
-        end   
+        end
       end
 
       def eval_limit(limit)
@@ -197,7 +197,7 @@ module Dynamoid #:nodoc:
         opts[:scan_index_forward] = @scan_index_forward
         opts
       end
-      
+
       def scan_opts
         opts = {}
         opts[:limit] = @eval_limit if @eval_limit

--- a/lib/dynamoid/errors.rb
+++ b/lib/dynamoid/errors.rb
@@ -1,13 +1,27 @@
 # encoding: utf-8
 module Dynamoid
-  
+
   # All the errors specific to Dynamoid.  The goal is to mimic ActiveRecord.
   module Errors
-    
+
     # Generic Dynamoid error
     class Error < StandardError; end
-    
+
     class MissingRangeKey < Error; end
+
+    class MissingIndex < Error; end
+
+    # InvalidIndex is raised when an invalid index is specified, for example if
+    # specified key attribute(s) or projected attributes do not exist.
+    class InvalidIndex < Error
+      def initialize(item)
+        if (item.is_a? String)
+          super(item)
+        else
+          super("Validation failed: #{item.errors.full_messages.join(", ")}")
+        end
+      end
+    end
 
     # This class is intended to be private to Dynamoid.
     class ConditionalCheckFailedException < Error

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -1,10 +1,16 @@
 # encoding: utf-8
 module Dynamoid #:nodoc:
-
   # All fields on a Dynamoid::Document must be explicitly defined -- if you have fields in the database that are not
   # specified with field, then they will be ignored.
   module Fields
     extend ActiveSupport::Concern
+
+    PERMITTED_KEY_TYPES = [
+      :number,
+      :integer,
+      :string,
+      :datetime
+    ]
 
     # Initialize the attributes we know the class has, in addition to our magic attributes: id, created_at, and updated_at.
     included do

--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -122,14 +122,15 @@ module Dynamoid
       #     table :key => :email
       #     global_secondary_index :hash_key => :age, :range_key => :gender
       #   end
-      #   User.find_all_by_secondary_index(:age => 5, {"rank.lte" => 10})
+      #   User.find_all_by_secondary_index(:age => 5, :range => {"rank.lte" => 10})
       #
       # @param [Hash] eg: {:age => 5}
       # @param [Hash] eg: {"rank.lte" => 10}
       # @param [Hash] options - @TODO support more options in future such as
       #               query filter, projected keys etc
       # @return [Array] an array of all matching items
-      def find_all_by_secondary_index(hash, range = {}, options = {})
+      def find_all_by_secondary_index(hash, options = {})
+        range = options[:range] || {}
         hash_key_field, hash_key_value = hash.first
         range_key_field, range_key_value = range.first
         range_op_mapped = nil

--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -6,6 +6,16 @@ module Dynamoid
   module Finders
     extend ActiveSupport::Concern
 
+    RANGE_MAP = {
+      'gt'            => :range_greater_than,
+      'lt'            => :range_less_than,
+      'gte'           => :range_gte,
+      'lte'           => :range_lte,
+      'begins_with'   => :range_begins_with,
+      'between'       => :range_between,
+      'eq'            => :range_eq
+    }
+
     module ClassMethods
 
       # Find one or many objects, specified by one id or an array of ids.
@@ -96,6 +106,58 @@ module Dynamoid
       #
       def find_all_by_composite_key(hash_key, options = {})
         Dynamoid.adapter.query(self.table_name, options.merge({hash_value: hash_key})).collect do |item|
+          from_database(item)
+        end
+      end
+
+      # Find all objects by using local secondary or global secondary index
+      #
+      # @example
+      #   class User
+      #     include Dynamoid::Document
+      #     field :email,          :string
+      #     field :age,            :integer
+      #     field :gender,         :string
+      #     field :rank            :number
+      #     table :key => :email
+      #     global_secondary_index :hash_key => :age, :range_key => :gender
+      #   end
+      #   User.find_all_by_secondary_index(:age => 5, {"rank.lte" => 10})
+      #
+      # @param [Hash] eg: {:age => 5}
+      # @param [Hash] eg: {"rank.lte" => 10}
+      # @param [Hash] options - @TODO support more options in future such as
+      #               query filter, projected keys etc
+      # @return [Array] an array of all matching items
+      def find_all_by_secondary_index(hash, range = {}, options = {})
+        hash_key_field, hash_key_value = hash.first
+        range_key_field, range_key_value = range.first
+        range_op_mapped = nil
+
+        if range_key_field
+          range_key_field = range_key_field.to_s
+          range_key_op = "eq"
+          if range_key_field.include?(".")
+            range_key_field, range_key_op = range_key_field.split(".", 2)
+          end
+          range_op_mapped = RANGE_MAP.fetch(range_key_op)
+        end
+
+        # Find the index
+        index = self.find_index(hash_key_field, range_key_field)
+        raise Dynamoid::Errors::MissingIndex if index.nil?
+
+        # query
+        opts = {
+          :hash_key => hash_key_field.to_s,
+          :hash_value => hash_key_value,
+          :index_name => index.name,
+        }
+        if range_key_field
+          opts[:range_key] = range_key_field
+          opts[range_op_mapped] = range_key_value
+        end
+        Dynamoid.adapter.query(self.table_name, opts).map do |item|
           from_database(item)
         end
       end

--- a/lib/dynamoid/indexes.rb
+++ b/lib/dynamoid/indexes.rb
@@ -1,0 +1,273 @@
+module Dynamoid
+  module Indexes
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :local_secondary_indexes
+      class_attribute :global_secondary_indexes
+      self.local_secondary_indexes = {}
+      self.global_secondary_indexes = {}
+    end
+
+    module ClassMethods
+      # Defines a Global Secondary index on a table. Keys can be specified as
+      # hash-only, or hash & range.
+      #
+      # @param [Hash] options options to pass for this table
+      # @option options [Symbol] :name the name for the index; this still gets
+      #         namespaced.  If not specified, will use a default name.
+      # @option options [Symbol] :hash_key the index hash key column.
+      # @option options [Symbol] :range_key the index range key column (if
+      #         applicable).
+      # @option options [Symbol, Array<Symbol>] :projected_attributes table
+      #         attributes to project for this index. Can be :keys_only, :all
+      #         or an array of included fields. If not specified, defaults to
+      #         :keys_only.
+      # @option options [Integer] :read_capacity set the read capacity for the
+      #         index; does not work on existing indexes.
+      # @option options [Integer] :write_capacity set the write capacity for
+      #         the index; does not work on existing indexes.
+      def global_secondary_index(options={})
+        unless options.present?
+          raise Dynamoid::Errors::InvalidIndex.new('empty index definition')
+        end
+
+        unless options[:hash_key].present?
+          raise Dynamoid::Errors::InvalidIndex.new(
+            'A global secondary index requires a :hash_key to be specified'
+          )
+        end
+
+        index_opts = {
+            :read_capacity => Dynamoid::Config.read_capacity,
+            :write_capacity => Dynamoid::Config.write_capacity
+        }.merge(options)
+
+        index_opts[:dynamoid_class] = self
+        index_opts[:type] = :global_secondary
+
+        index = Dynamoid::Indexes::Index.new(index_opts)
+        gsi_key = index_key(options[:hash_key], options[:range_key])
+        self.global_secondary_indexes[gsi_key] = index
+        self
+      end
+
+
+      # Defines a local secondary index on a table. Will use the same primary
+      # hash key as the table.
+      #
+      # @param [Hash] options options to pass for this index.
+      # @option options [Symbol] :name the name for the index; this still gets
+      #         namespaced. If not specified, a name is automatically generated.
+      # @option options [Symbol] :range_key the range key column for the index.
+      # @option options [Symbol, Array<Symbol>] :projected_attributes table
+      #         attributes to project for this index. Can be :keys_only, :all
+      #         or an array of included fields. If not specified, defaults to
+      #         :keys_only.
+      def local_secondary_index(options={})
+        unless options.present?
+          raise Dynamoid::Errors::InvalidIndex.new('empty index definition')
+        end
+
+        primary_hash_key = self.hash_key
+        primary_range_key = self.range_key
+        index_range_key = options[:range_key]
+
+        unless index_range_key.present?
+          raise Dynamoid::Errors::InvalidIndex.new('A local secondary index '\
+            'requires a :range_key to be specified')
+        end
+
+        if primary_range_key.present? && index_range_key == primary_range_key
+          raise Dynamoid::Errors::InvalidIndex.new('A local secondary index'\
+            ' must use a different :range_key than the primary key')
+        end
+
+        index_opts = options.merge({
+          :dynamoid_class => self,
+          :type => :local_secondary,
+          :hash_key => primary_hash_key
+        })
+
+        index = Dynamoid::Indexes::Index.new(index_opts)
+        key = index_key(primary_hash_key, index_range_key)
+        self.local_secondary_indexes[key] = index
+        self
+      end
+
+
+      def find_index(hash, range=nil)
+        index = self.indexes[index_key(hash, range)]
+        index
+      end
+
+
+      # Returns true iff the provided hash[,range] key combo is a local
+      # secondary index.
+      #
+      # @param [Symbol] hash hash key name.
+      # @param [Symbol] range range key name.
+      # @return [Boolean] true iff provided keys correspond to a local
+      #         secondary index.
+      def is_local_secondary_index?(hash, range=nil)
+        self.local_secondary_indexes[index_key(hash, range)].present?
+      end
+
+
+      # Returns true iff the provided hash[,range] key combo is a global
+      # secondary index.
+      #
+      # @param [Symbol] hash hash key name.
+      # @param [Symbol] range range key name.
+      # @return [Boolean] true iff provided keys correspond to a global
+      #         secondary index.
+      def is_global_secondary_index?(hash, range=nil)
+        self.global_secondary_indexes[index_key(hash, range)].present?
+      end
+
+
+      # Generates a convenient lookup key name for a hash/range index.
+      # Should normally not be used directly.
+      #
+      # @param [Symbol] hash hash key name.
+      # @param [Symbol] range range key name.
+      # @return [String] returns "hash" if hash only, "hash_range" otherwise.
+      def index_key(hash, range=nil)
+        name = hash.to_s
+        if range.present?
+          name += "_#{range.to_s}"
+        end
+        name
+      end
+
+
+      # Generates a default index name.
+      #
+      # @param [Symbol] hash hash key name.
+      # @param [Symbol] range range key name.
+      # @return [String] index name of the form "table_name_index_index_key".
+      def index_name(hash, range=nil)
+        "#{self.table_name}_index_#{self.index_key(hash, range)}"
+      end
+
+
+      # Convenience method to return all indexes on the table.
+      #
+      # @return [Hash<String, Object>] the combined hash of global and local
+      #         secondary indexes.
+      def indexes
+        self.local_secondary_indexes.merge(self.global_secondary_indexes)
+      end
+
+      def indexed_hash_keys
+        self.global_secondary_indexes.map do |name, index|
+          index.hash_key.to_s
+        end
+      end
+    end
+
+
+    # Represents the attributes of a DynamoDB index.
+    class Index
+      include ActiveModel::Validations
+
+      PROJECTION_TYPES = [:keys_only, :all].to_set
+      DEFAULT_PROJECTION_TYPE = :keys_only
+
+      attr_accessor :name, :dynamoid_class, :type, :hash_key, :range_key,
+          :hash_key_schema, :range_key_schema, :projected_attributes,
+          :read_capacity, :write_capacity
+
+
+      validate do
+        validate_index_type
+        validate_hash_key
+        validate_range_key
+        validate_projected_attributes
+      end
+
+
+      def initialize(attrs={})
+        unless attrs[:dynamoid_class].present?
+          raise Dynamoid::Errors::InvalidIndex.new(':dynamoid_class is required')
+        end
+
+        @dynamoid_class = attrs[:dynamoid_class]
+        @type = attrs[:type]
+        @hash_key = attrs[:hash_key]
+        @range_key = attrs[:range_key]
+        @name = attrs[:name] || @dynamoid_class.index_name(@hash_key, @range_key)
+        @projected_attributes =
+            attrs[:projected_attributes] || DEFAULT_PROJECTION_TYPE
+        @read_capacity = attrs[:read_capacity]
+        @write_capacity = attrs[:write_capacity]
+
+        raise Dynamoid::Errors::InvalidIndex.new(self) unless self.valid?
+      end
+
+
+      # Convenience method to determine the projection type for an index.
+      # Projection types are: :keys_only, :all, :include.
+      #
+      # @return [Symbol] the projection type.
+      def projection_type
+        if @projected_attributes.is_a? Array
+          :include
+        else
+          @projected_attributes
+        end
+      end
+
+
+      private
+
+        def validate_projected_attributes
+          unless (@projected_attributes.is_a?(Array) ||
+                  PROJECTION_TYPES.include?(@projected_attributes))
+            errors.add(:projected_attributes, 'Invalid projected attributes specified.')
+          end
+        end
+
+        def validate_index_type
+          unless (@type.present? &&
+            [:local_secondary, :global_secondary].include?(@type))
+              errors.add(:type, 'Invalid index :type specified')
+          end
+        end
+
+        def validate_range_key
+          if @range_key.present?
+            range_field_attributes = @dynamoid_class.attributes[@range_key]
+            if range_field_attributes.present?
+              range_key_type = range_field_attributes[:type]
+              if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(range_key_type)
+                @range_key_schema = {
+                  @range_key => @dynamoid_class.dynamo_type(range_key_type)
+                }
+              else
+                errors.add(:range_key, 'Index :range_key is not a valid key type')
+              end
+            else
+              errors.add(:range_key, "No such field #{@range_key} defined on table")
+            end
+          end
+        end
+
+        def validate_hash_key
+          hash_field_attributes = @dynamoid_class.attributes[@hash_key]
+          if hash_field_attributes.present?
+            hash_field_type = hash_field_attributes[:type]
+            if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(hash_field_type)
+              @hash_key_schema = {
+                @hash_key => @dynamoid_class.dynamo_type(hash_field_type)
+              }
+            else
+              errors.add(:hash_key, 'Index :hash_key is not a valid key type')
+            end
+          else
+            errors.add(:hash_key, "No such field #{@hash_key} defined on table")
+          end
+        end
+    end
+  end
+end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -27,7 +27,7 @@ module Dynamoid
       # @option options [Integer] :read_capacity set the read capacity for the table; does not work on existing tables
       # @option options [Integer] :write_capacity set the write capacity for the table; does not work on existing tables
       # @option options [Hash] {range_key => :type} a hash of the name of the range key and a symbol of its type
-      #
+      # @option options [Symbol] :hash_key_type the dynamo type of the hash key (:string or :number)
       # @since 0.4.0
       def create_table(options = {})
         if self.range_key
@@ -40,7 +40,10 @@ module Dynamoid
           :table_name => self.table_name,
           :write_capacity => self.write_capacity,
           :read_capacity => self.read_capacity,
-          :range_key => range_key_hash
+          :range_key => range_key_hash,
+          :hash_key_type => dynamo_type(attributes[self.hash_key][:type]),
+          :local_secondary_indexes => self.local_secondary_indexes.values,
+          :global_secondary_indexes => self.global_secondary_indexes.values
         }.merge(options)
 
         Dynamoid.adapter.create_table(options[:table_name], options[:id], options)

--- a/spec/app/models/post.rb
+++ b/spec/app/models/post.rb
@@ -2,8 +2,14 @@ class Post
   include Dynamoid::Document
 
   table name: :posts, key: :post_id, read_capacity: 200, write_capacity:  200
-  
+
   range :posted_at, :datetime
 
   field :body
+  field :length
+  field :name
+
+  local_secondary_index :range_key => :name
+  global_secondary_index :hash_key => :name, :range_key => :posted_at
+  global_secondary_index :hash_key => :length
 end

--- a/spec/app/models/user.rb
+++ b/spec/app/models/user.rb
@@ -1,6 +1,6 @@
 class User
   include Dynamoid::Document
-  
+
   field :name
   field :email
   field :password

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -156,4 +156,122 @@ describe Dynamoid::Finders do
     end
 
   end
+
+
+  describe '.find_all_by_secondary_index' do
+    def time_to_f(time)
+      time.to_time.to_f
+    end
+
+    it 'returns exception if index could not be found' do
+      Post.create(:post_id => 1, :posted_at => Time.now)
+      expect do
+        Post.find_all_by_secondary_index(:posted_at => Time.now.to_i)
+      end.to raise_exception(Dynamoid::Errors::MissingIndex)
+    end
+
+    context 'local secondary index' do
+      it 'queries the local secondary index' do
+        time = DateTime.now
+        p1 = Post.create(:name => "p1", :post_id => 1, :posted_at => time)
+        p2 = Post.create(:name => "p2", :post_id => 1, :posted_at => time + 1.day)
+        p3 = Post.create(:name => "p3", :post_id => 2, :posted_at => time)
+
+        posts = Post.find_all_by_secondary_index(
+          {:post_id => p1.post_id},
+          {:name => "p1"}
+        )
+        post = posts.first
+
+        expect(posts.count).to eql 1
+        expect(post.name).to eql "p1"
+        expect(post.post_id).to eql "1"
+      end
+    end
+
+    context 'global secondary index' do
+      it 'queries gsi with hash key' do
+        time = DateTime.now
+        p1 = Post.create(:post_id => 1, :posted_at => time, :length => "10")
+        p2 = Post.create(:post_id => 2, :posted_at => time, :length => "30")
+        p3 = Post.create(:post_id => 3, :posted_at => time, :length => "10")
+
+        posts = Post.find_all_by_secondary_index(:length => "10")
+        expect(posts.map(&:post_id).sort).to eql ["1", "3"]
+      end
+
+      it 'queries gsi with hash and range key' do
+        time = DateTime.now
+        p1 = Post.create(:post_id => 1, :posted_at => time, :name => "post1")
+        p2 = Post.create(:post_id => 2, :posted_at => time + 1.day, :name => "post1")
+        p3 = Post.create(:post_id => 3, :posted_at => time, :name => "post3")
+
+        posts = Post.find_all_by_secondary_index(
+          {:name => "post1"},
+          {:posted_at => time_to_f(time)}
+        )
+        expect(posts.map(&:post_id).sort).to eql ["1"]
+      end
+    end
+
+    describe 'custom range queries' do
+      describe 'string comparisons' do
+        it 'filters based on begins_with operator' do
+          time = DateTime.now
+          Post.create(:post_id => 1, :posted_at => time, :name => "fb_post")
+          Post.create(:post_id => 1, :posted_at => time + 1.day, :name => "blog_post")
+
+          posts = Post.find_all_by_secondary_index(
+            {:post_id => "1"}, {"name.begins_with" => "blog_"}
+          )
+          expect(posts.map(&:name)).to eql ["blog_post"]
+        end
+      end
+
+      describe 'numeric comparisons' do
+        before(:each) do
+          @time = DateTime.now
+          p1 = Post.create(:post_id => 1, :posted_at => @time, :name => "post")
+          p2 = Post.create(:post_id => 2, :posted_at => @time + 1.day, :name => "post")
+          p3 = Post.create(:post_id => 3, :posted_at => @time + 2.days, :name => "post")
+        end
+
+        it 'filters based on gt (greater than)' do
+          posts = Post.find_all_by_secondary_index(
+            {:name => "post"}, {"posted_at.gt" => time_to_f(@time + 1.day)}
+          )
+          expect(posts.map(&:post_id).sort).to eql ["3"]
+        end
+
+        it 'filters based on lt (less than)' do
+          posts = Post.find_all_by_secondary_index(
+            {:name => "post"}, {"posted_at.lt" => time_to_f(@time + 1.day)}
+          )
+          expect(posts.map(&:post_id).sort).to eql ["1"]
+        end
+
+        it 'filters based on gte (greater than or equal to)' do
+          posts = Post.find_all_by_secondary_index(
+            {:name => "post"}, {"posted_at.gte" => time_to_f(@time + 1.day)}
+          )
+          expect(posts.map(&:post_id).sort).to eql ["2", "3"]
+        end
+
+        it 'filters based on lte (less than or equal to)' do
+          posts = Post.find_all_by_secondary_index(
+            {:name => "post"}, {"posted_at.lte" => time_to_f(@time + 1.day)}
+          )
+          expect(posts.map(&:post_id).sort).to eql ["1", "2"]
+        end
+
+        it 'filters based on between operator' do
+          between = [time_to_f(@time - 1.day), time_to_f(@time + 1.5.day)]
+          posts = Post.find_all_by_secondary_index(
+            {:name => "post"}, {"posted_at.between" => between}
+          )
+          expect(posts.map(&:post_id).sort).to eql ["1", "2"]
+        end
+      end
+    end
+  end
 end

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -179,7 +179,7 @@ describe Dynamoid::Finders do
 
         posts = Post.find_all_by_secondary_index(
           {:post_id => p1.post_id},
-          {:name => "p1"}
+          :range => {:name => "p1"}
         )
         post = posts.first
 
@@ -208,7 +208,7 @@ describe Dynamoid::Finders do
 
         posts = Post.find_all_by_secondary_index(
           {:name => "post1"},
-          {:posted_at => time_to_f(time)}
+          :range =>  {:posted_at => time_to_f(time)}
         )
         expect(posts.map(&:post_id).sort).to eql ["1"]
       end
@@ -222,7 +222,7 @@ describe Dynamoid::Finders do
           Post.create(:post_id => 1, :posted_at => time + 1.day, :name => "blog_post")
 
           posts = Post.find_all_by_secondary_index(
-            {:post_id => "1"}, {"name.begins_with" => "blog_"}
+            {:post_id => "1"}, :range => {"name.begins_with" => "blog_"}
           )
           expect(posts.map(&:name)).to eql ["blog_post"]
         end
@@ -238,28 +238,32 @@ describe Dynamoid::Finders do
 
         it 'filters based on gt (greater than)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => "post"}, {"posted_at.gt" => time_to_f(@time + 1.day)}
+            {:name => "post"},
+            :range => {"posted_at.gt" => time_to_f(@time + 1.day)}
           )
           expect(posts.map(&:post_id).sort).to eql ["3"]
         end
 
         it 'filters based on lt (less than)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => "post"}, {"posted_at.lt" => time_to_f(@time + 1.day)}
+            {:name => "post"},
+            :range => {"posted_at.lt" => time_to_f(@time + 1.day)}
           )
           expect(posts.map(&:post_id).sort).to eql ["1"]
         end
 
         it 'filters based on gte (greater than or equal to)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => "post"}, {"posted_at.gte" => time_to_f(@time + 1.day)}
+            {:name => "post"},
+            :range => {"posted_at.gte" => time_to_f(@time + 1.day)}
           )
           expect(posts.map(&:post_id).sort).to eql ["2", "3"]
         end
 
         it 'filters based on lte (less than or equal to)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => "post"}, {"posted_at.lte" => time_to_f(@time + 1.day)}
+            {:name => "post"},
+            :range => {"posted_at.lte" => time_to_f(@time + 1.day)}
           )
           expect(posts.map(&:post_id).sort).to eql ["1", "2"]
         end
@@ -267,7 +271,8 @@ describe Dynamoid::Finders do
         it 'filters based on between operator' do
           between = [time_to_f(@time - 1.day), time_to_f(@time + 1.5.day)]
           posts = Post.find_all_by_secondary_index(
-            {:name => "post"}, {"posted_at.between" => between}
+            {:name => "post"},
+            :range => {"posted_at.between" => between}
           )
           expect(posts.map(&:post_id).sort).to eql ["1", "2"]
         end

--- a/spec/dynamoid/indexes_spec.rb
+++ b/spec/dynamoid/indexes_spec.rb
@@ -1,0 +1,407 @@
+require 'spec_helper'
+
+describe Dynamoid::Indexes do
+  let(:doc_class) do
+    Class.new do
+      include Dynamoid::Document
+    end
+  end
+
+  describe 'base behaviour' do
+    it 'has a local secondary indexes hash' do
+      expect(doc_class).to respond_to(:local_secondary_indexes)
+    end
+    it 'has a global secondary indexes hash' do
+      expect(doc_class).to respond_to(:global_secondary_indexes)
+    end
+  end
+
+  describe '.global_secondary_index' do
+    context 'with a correct definition' do
+      before(:each) do
+        @dummy_index = double('Dynamoid::Indexes::Index')
+        allow(Dynamoid::Indexes::Index).to receive(:new).and_return(@dummy_index)
+      end
+
+      it 'adds the index to the global_secondary_indexes hash' do
+        index_key = doc_class.index_key(:some_hash_field)
+        doc_class.global_secondary_index(:hash_key => :some_hash_field)
+
+        expected_index = doc_class.global_secondary_indexes[index_key]
+        expect(expected_index).to eq(@dummy_index)
+      end
+
+      it 'with a range key, also adds the index to the global_secondary_indexes hash' do
+        index_key = doc_class.index_key(:some_hash_field, :some_range_field)
+        doc_class.global_secondary_index({
+          :hash_key => :some_hash_field,
+          :range_key => :some_range_field
+        })
+
+        expected_index = doc_class.global_secondary_indexes[index_key]
+        expect(expected_index).to eq(@dummy_index)
+      end
+
+      context 'with optional parameters' do
+        context 'with a hash-only index' do
+          let(:doc_class_with_gsi) do
+            doc_class.global_secondary_index(:hash_key => :secondary_hash_field)
+          end
+
+          it 'creates the index with the correct options' do
+            test_class = doc_class_with_gsi
+            index_opts = {
+              :dynamoid_class => test_class,
+              :type => :global_secondary,
+              :read_capacity => Dynamoid::Config.read_capacity,
+              :write_capacity => Dynamoid::Config.write_capacity,
+              :hash_key => :secondary_hash_field
+            }
+            expect(Dynamoid::Indexes::Index).to have_received(:new).with(index_opts)
+          end
+
+          it 'adds the index to the global_secondary_indexes hash' do
+            test_class = doc_class_with_gsi
+            index_key = "secondary_hash_field"
+            expect(test_class.global_secondary_indexes.keys).to eql [index_key]
+            expect(test_class.global_secondary_indexes[index_key]).to eq(@dummy_index)
+          end
+        end
+
+        context 'with a hash and range index' do
+          let(:doc_class_with_gsi) do
+            doc_class.global_secondary_index({
+              :hash_key => :secondary_hash_field,
+              :range_key => :secondary_range_field
+            })
+          end
+
+          it 'creates the index with the correct options' do
+            test_class = doc_class_with_gsi
+            index_opts = {
+              :dynamoid_class => test_class,
+              :type => :global_secondary,
+              :read_capacity => Dynamoid::Config.read_capacity,
+              :write_capacity => Dynamoid::Config.write_capacity,
+              :hash_key => :secondary_hash_field,
+              :range_key => :secondary_range_field
+            }
+            expect(Dynamoid::Indexes::Index).to have_received(:new).with(index_opts)
+          end
+
+          it 'adds the index to the global_secondary_indexes hash' do
+            test_class = doc_class_with_gsi
+            index_key = "secondary_hash_field_secondary_range_field"
+            expect(test_class.global_secondary_indexes[index_key]).to eq(@dummy_index)
+          end
+        end
+      end
+    end
+
+    context 'with an improper definition' do
+      it 'with a blank definition, throws an error' do
+        expect do
+          doc_class.global_secondary_index
+        end.to raise_error(Dynamoid::Errors::InvalidIndex, /empty index/)
+      end
+      it 'with no :hash_key, throws an error' do
+        expect do
+          doc_class.global_secondary_index(:range_key => :something)
+        end.to raise_error(
+          Dynamoid::Errors::InvalidIndex, /hash_key.*specified/)
+      end
+    end
+  end
+
+  describe '.local_secondary_index' do
+    context 'with correct parameters' do
+      before(:each) do
+        @dummy_index = double('Dynamoid::Indexes::Index')
+        allow(Dynamoid::Indexes::Index).to receive(:new).and_return(@dummy_index)
+      end
+
+      let(:doc_class_with_lsi) do
+        Class.new do
+          include Dynamoid::Document
+          table :name => :mytable, :key => :some_hash_field
+          range :some_range_field #@WHAT
+
+          local_secondary_index(:range_key => :secondary_range_field)
+        end
+      end
+
+      it 'creates the index with the correct options' do
+        test_class = doc_class_with_lsi
+        index_opts = {
+          :dynamoid_class => test_class,
+          :type => :local_secondary,
+          :hash_key => :some_hash_field,
+          :range_key => :secondary_range_field
+        }
+        expect(Dynamoid::Indexes::Index).to have_received(:new).with(index_opts)
+      end
+      it 'adds the index to the local_secondary_indexes hash' do
+        test_class = doc_class_with_lsi
+        index_key = "some_hash_field_secondary_range_field"
+        expect(test_class.local_secondary_indexes.keys).to eql [index_key]
+        expect(test_class.local_secondary_indexes[index_key]).to eq(@dummy_index)
+      end
+    end
+
+    context 'with an improper definition' do
+      let(:doc_class_with_table) do
+        Class.new do
+          include Dynamoid::Document
+          table :name => :mytable, :key => :some_hash_field
+          range :some_range_field
+        end
+      end
+
+      it 'with a blank definition, throws an error' do
+        expect do
+          doc_class.local_secondary_index
+        end.to raise_error(Dynamoid::Errors::InvalidIndex, /empty/)
+      end
+
+      it 'throws an error if the range_key isn`t specified' do
+        test_class = doc_class_with_table
+        expect do
+          test_class.local_secondary_index(:projected_attributes => :all)
+        end.to raise_error(Dynamoid::Errors::InvalidIndex, /range_key.*specified/)
+      end
+
+      it 'throws an error if the range_key is the same as the primary range key' do
+        test_class = doc_class_with_table
+        expect do
+          test_class.local_secondary_index(:range_key => :some_range_field)
+        end.to raise_error(Dynamoid::Errors::InvalidIndex, /different.*:range_key/)
+      end
+    end
+  end
+
+  describe '.index_key' do
+    context 'when hash specified' do
+      it 'generates an index key of the form <hash> if only hash is specified' do
+        index_key = doc_class.index_key(:some_hash_field)
+        expect(index_key).to eq("some_hash_field")
+      end
+    end
+
+    context 'when hash and range specified' do
+      it 'generates an index key of the form <hash>_<range>' do
+        index_key = doc_class.index_key(:some_hash_field, :some_range_field)
+        expect(index_key).to eq("some_hash_field_some_range_field")
+      end
+
+      it 'generates an index key of the form <hash> when range is nil' do
+        index_key = doc_class.index_key(:some_hash_field, nil)
+        expect(index_key).to eq("some_hash_field")
+      end
+    end
+  end
+
+  describe '.index_name' do
+    let(:doc_class) do
+      Class.new do
+        include Dynamoid::Document
+        table :name => :mytable
+      end
+    end
+
+    it 'generates an index name of the form <table_name>_index_<index_key>' do
+      expect(doc_class).to receive(:index_key).and_return('whoa_an_index_key')
+      index_name = doc_class.index_name(:some_hash_field, :some_range_field)
+      expect(index_name).to eq("#{doc_class.table_name}_index_whoa_an_index_key")
+    end
+  end
+
+
+  # Index nested class.
+  describe 'Index' do
+    describe '#initialize' do
+      let(:doc_class) do
+        Class.new do
+          include Dynamoid::Document
+          table :name => :mytable, :key => :some_hash_field
+
+          field :primary_hash_field
+          field :primary_range_field
+          field :secondary_hash_field
+          field :secondary_range_field
+          field :array_field, :array
+        end
+      end
+
+      context 'validation' do
+        it 'throws an error when :dynamoid_class is not specified' do
+          expect do
+            Dynamoid::Indexes::Index.new
+          end.to raise_error(Dynamoid::Errors::InvalidIndex, /dynamoid_class.*required/)
+        end
+
+        it 'throws an error if :type is invalid' do
+          expect do
+            Dynamoid::Indexes::Index.new(
+              :dynamoid_class => doc_class,
+              :hash_key => :primary_hash_field,
+              :type => :garbage)
+          end.to raise_error(Dynamoid::Errors::InvalidIndex, /Invalid.*:type/)
+        end
+
+        it 'throws an error when :hash_key is not a table attribute' do
+          expect do
+            Dynamoid::Indexes::Index.new(
+              :dynamoid_class => doc_class,
+              :hash_key => :garbage,
+              :type => :global_secondary)
+          end.to raise_error(Dynamoid::Errors::InvalidIndex, /No such field/)
+        end
+
+        it 'throws an error when :hash_key is of invalid type' do
+          expect do
+            Dynamoid::Indexes::Index.new(
+              :dynamoid_class => doc_class,
+              :hash_key => :array_field,
+              :type => :global_secondary)
+          end.to raise_error(Dynamoid::Errors::InvalidIndex, /hash_key.*/)
+        end
+
+        it 'throws an error when :range_key is of invalid type' do
+          expect do
+            Dynamoid::Indexes::Index.new(
+              :dynamoid_class => doc_class,
+              :hash_key => :primary_hash_field,
+              :type => :global_secondary,
+              :range_key => :array_field)
+          end.to raise_error(Dynamoid::Errors::InvalidIndex, /range_key.*/)
+        end
+
+        it 'throws an error when :range_key is not a table attribute' do
+          expect do
+           Dynamoid::Indexes::Index.new(
+              :dynamoid_class => doc_class,
+              :hash_key => :primary_hash_field,
+              :type => :global_secondary,
+              :range_key => :garbage)
+          end.to raise_error(Dynamoid::Errors::InvalidIndex, /No such field/)
+        end
+
+        it 'throws an error if :projected_attributes are invalid' do
+          expect do
+            Dynamoid::Indexes::Index.new(
+              :dynamoid_class => doc_class,
+              :hash_key => :primary_hash_field,
+              :type => :global_secondary,
+              :projected_attributes => :garbage)
+          end.to raise_error(Dynamoid::Errors::InvalidIndex, /Invalid projected attributes/)
+        end
+      end
+
+
+      context 'correct parameters' do
+        context 'with only required params' do
+          let(:defaults_index) do
+            Dynamoid::Indexes::Index.new(
+                :dynamoid_class => doc_class,
+                :hash_key => :primary_hash_field,
+                :range_key => :secondary_range_field,
+                :type => :local_secondary
+            )
+          end
+
+          it 'sets name to the default index name' do
+            expected_name = doc_class.index_name(
+              :primary_hash_field,
+              :secondary_range_field
+            )
+            expect(defaults_index.name).to eq(expected_name)
+          end
+
+          it 'sets the hash_key_schema' do
+            expected = {:primary_hash_field => :string}
+            expect(defaults_index.hash_key_schema).to eql expected
+          end
+
+          it 'sets the range_key_schema' do
+            expected = {:secondary_range_field => :string}
+            expect(defaults_index.range_key_schema).to eql expected
+          end
+
+          it 'sets projected attributes to the default :keys_only' do
+            expect(defaults_index.projected_attributes).to eq(:keys_only)
+          end
+
+          it 'sets all provided attributes' do
+            expect(defaults_index.dynamoid_class).to eq(doc_class)
+            expect(defaults_index.type).to eq(:local_secondary)
+            expect(defaults_index.hash_key).to eq(:primary_hash_field)
+            expect(defaults_index.range_key).to eq(:secondary_range_field)
+          end
+        end
+
+        context 'with other params specified' do
+          let(:other_index) do
+            Dynamoid::Indexes::Index.new(
+                :dynamoid_class => doc_class,
+                :name => :mont_blanc,
+                :hash_key => :secondary_hash_field,
+                :type => :global_secondary,
+                :projected_attributes => [:secondary_hash_field, :array_field],
+                :read_capacity => 100,
+                :write_capacity => 200
+            )
+          end
+          it 'sets the provided attributes' do
+            expect(other_index.dynamoid_class).to eq(doc_class)
+            expect(other_index.name).to eq(:mont_blanc)
+            expect(other_index.type).to eq(:global_secondary)
+            expect(other_index.hash_key).to eq(:secondary_hash_field)
+            expect(other_index.range_key.present?).to eq(false)
+            expect(other_index.read_capacity).to eq(100)
+            expect(other_index.write_capacity).to eq(200)
+            expect(other_index.projected_attributes).to eq(
+              [:secondary_hash_field, :array_field])
+          end
+        end
+
+      end
+    end
+
+
+    describe '#projection_type' do
+      let(:doc_class) do
+        Class.new do
+          include Dynamoid::Document
+
+          table :name => :mytable, :key => :primary_hash_field
+
+          field :primary_hash_field
+          field :secondary_hash_field
+          field :array_field, :array
+        end
+      end
+
+      it 'projection type is :include' do
+        projection_include = Dynamoid::Indexes::Index.new(
+            :dynamoid_class => doc_class,
+            :hash_key => :secondary_hash_field,
+            :type => :global_secondary,
+            :projected_attributes => [:secondary_hash_field, :array_field]
+        ).projection_type
+        expect(projection_include).to eq(:include)
+      end
+
+      it 'projection type is :all' do
+        projection_all = Dynamoid::Indexes::Index.new(
+            :dynamoid_class => doc_class,
+            :hash_key => :secondary_hash_field,
+            :type => :global_secondary,
+            :projected_attributes => :all
+        ).projection_type
+
+        expect(projection_all).to eq(:all)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Class definition

```ruby
Class Post
  include Dynamoid::Document
  table name: :posts, key: :post_id, read_capacity: 200, write_capacity:  200
  range :posted_at, :datetime
  
  field :body, :string
  field :length, :string
  field :name, :string

  local_secondary_index :range_key => :name, :projected_attributes => :keys_only
  global_secondary_index :hash_key => :name, :range_key => :posted_at
  global_secondary_index :hash_key => :length, :read_capacity => 1, :write_capacity => 1
end

# Types of projected attributes
# - :keys_only
# - :all
# - [:body, :length, ...]
```

Query

The method will figure out which secondary index to use based on the parameters. If it cannot find an index, it will raise an exception.

```ruby
User.find_all_by_secondary_index(
  {:name => 'John'}, # hash
  :range => {"posted_at.lte" => Time.now.to_f} # range (optional)
)
```

Warning: The where clause is not yet supported. It needs more work for it to intelligently pick the right index.