### PR TITLE
fix query attribute behavior for booleans

### DIFF
--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -45,7 +45,15 @@ module Dynamoid #:nodoc:
         self.attributes = attributes.merge(name => {:type => type}.merge(options))
 
         define_method(named) { read_attribute(named) }
-        define_method("#{named}?") { !read_attribute(named).nil? }
+        define_method("#{named}?") do
+          value = read_attribute(named)
+          case value
+          when true        then true
+          when false, nil  then false
+          else
+            !value.nil?
+          end
+        end
         define_method("#{named}=") {|value| write_attribute(named, value) }
       end
 

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -13,11 +13,7 @@ describe Dynamoid::Fields do
   end
 
   it 'declares a query attribute' do
-    expect(address.city?).to be_falsey
 
-    address.city = 'Chicago'
-
-    expect(address.city?).to be_truthy
   end
 
   it 'automatically declares id' do
@@ -30,6 +26,29 @@ describe Dynamoid::Fields do
     address.reload
     expect(address.created_at).to be_a DateTime
     expect(address.updated_at).to be_a DateTime
+  end
+
+  context 'query attributes' do
+    it 'are declared' do
+      expect(address.city?).to be_falsey
+
+      address.city = 'Chicago'
+
+      expect(address.city?).to be_truthy
+    end
+
+    it 'return false when boolean attributes are nil or false' do
+      address.deliverable = nil
+      expect(address.deliverable?).to be_falsey
+
+      address.deliverable = false
+      expect(address.deliverable?).to be_falsey
+    end
+
+    it 'return true when boolean attributes are true' do
+      address.deliverable = true
+      expect(address.deliverable?).to be_truthy
+    end
   end
 
   context 'with a saved address' do


### PR DESCRIPTION
The current behavior of query attributes seems unexpected for booleans set to false:

```ruby
address.deliverable = false
address.deliverable?
=> true # because deliverable is not nil
```

This pull request changes the behavior to match ActiveRecord's:

```ruby
address.deliverable = false
address.deliverable?
=> false
```