### PR TITLE
Enable creating tables with no namespace prefix

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,7 +56,7 @@ Then you need to initialize Dynamoid config to get it going. Put code similar to
 ```ruby
   Dynamoid.configure do |config|
     config.adapter = 'aws_sdk_v2' # This adapter establishes a connection to the DynamoDB servers using Amazon's own AWS gem.
-    config.namespace = "dynamoid_app_development" # To namespace tables created by Dynamoid from other tables you might have.
+    config.namespace = "dynamoid_app_development" # To namespace tables created by Dynamoid from other tables you might have. Set to nil to avoid namespacing.
     config.warn_on_scan = true # Output a warning to the logger when you perform a scan rather than a query on a table.
     config.read_capacity = 100 # Read capacity for your tables
     config.write_capacity = 20 # Write capacity for your tables

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -16,7 +16,15 @@ module Dynamoid
     module ClassMethods
 
       def table_name
-        @table_name ||= "#{Dynamoid::Config.namespace}_#{options[:name] || base_class.name.split('::').last.downcase.pluralize}"
+        table_base_name = options[:name] || base_class.name.split('::').last
+          .downcase.pluralize
+        table_prefix = if Dynamoid::Config.namespace.nil? then
+          ''
+        else
+          "#{Dynamoid::Config.namespace}_"
+        end
+
+        @table_name ||= "#{table_prefix}#{table_base_name}"
       end
 
       # Creates a table.

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -53,6 +53,34 @@ describe Dynamoid::Persistence do
     expect(Address.table_name).to eq 'dynamoid_tests_addresses'
   end
 
+  context 'with namespace set to nil' do
+    def reload_address
+      Object.send(:remove_const, 'Address')
+      load 'app/models/address.rb'
+    end
+
+    namespace = Dynamoid::Config.namespace
+
+    before do
+      reload_address
+      Dynamoid.configure do |config|
+        config.namespace = nil
+      end
+    end
+
+    after do
+      reload_address
+      Dynamoid.configure do |config|
+        config.namespace = namespace
+      end
+    end
+
+    it 'does not add a namespace prefix to table names' do
+      table_name = Address.table_name
+      expect(table_name).to eq 'addresses'
+    end
+  end
+
   it 'deletes an item completely' do
     @user = User.create(:name => 'Josh')
     @user.destroy


### PR DESCRIPTION
This PR allows table namespacing to be avoided when the namespace config option is set to nil. It fixes issue #5.