### PR TITLE
Fix problems with range query

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -159,6 +159,8 @@ module Dynamoid #:nodoc:
           { :range_gte  => val }
         when 'lte'
           { :range_lte => val }
+        when 'between'
+          { :range_between => val }
         when 'begins_with'
           { :range_begins_with => val }
         end

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -152,13 +152,13 @@ module Dynamoid #:nodoc:
 
         case key.to_s.split('.').last
         when 'gt'
-          { :range_greater_than => val.to_f }
+          { :range_greater_than => val }
         when 'lt'
-          { :range_less_than  => val.to_f }
+          { :range_less_than  => val }
         when 'gte'
-          { :range_gte  => val.to_f }
+          { :range_gte  => val }
         when 'lte'
-          { :range_lte => val.to_f }
+          { :range_lte => val }
         when 'begins_with'
           { :range_begins_with => val }
         end
@@ -166,7 +166,7 @@ module Dynamoid #:nodoc:
 
       def range_query
         opts = { :hash_value => query[source.hash_key] }
-        if key = query.keys.find { |k| k.to_s.include?('.') }
+        query.keys.select { |k| k.to_s.include?('.') }.each do |key|
           opts.merge!(range_hash(key))
         end
         opts.merge(query_opts).merge(consistent_opts)

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -82,7 +82,7 @@ describe Dynamoid::Criteria::Chain do
       post1 = Post.create(:post_id => 'x', :posted_at => time)
       post2 = Post.create(:post_id => 'x', :posted_at => (time + 1.hour))
       chain = Dynamoid::Criteria::Chain.new(Post)
-      query = { :post_id => "x", "posted_at.gt" => time + ts_epsilon }
+      query = { :post_id => "x", "posted_at.gt" => (time + ts_epsilon).to_f }
       resultset = chain.send(:where, query)
       expect(resultset.count).to eq 1
       stored_record = resultset.first

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -76,7 +76,7 @@ describe Dynamoid::Criteria::Chain do
       expect(chain.all).to eq [tweet3]
     end
 
-    it 'finds posts with "where" method' do
+    it 'finds posts with "where" method with "gt" query' do
       ts_epsilon = 0.001 # 1 ms
       time = DateTime.now
       post1 = Post.create(:post_id => 'x', :posted_at => time)
@@ -91,6 +91,40 @@ describe Dynamoid::Criteria::Chain do
       expect(stored_record.attributes[:created_at]).to be_within(ts_epsilon).of(post2.attributes[:created_at])
       expect(stored_record.attributes[:posted_at]).to be_within(ts_epsilon).of(post2.attributes[:posted_at])
       expect(stored_record.attributes[:updated_at]).to be_within(ts_epsilon).of(post2.attributes[:updated_at])
+    end
+
+    it 'finds posts with "where" method with "lt" query' do
+      ts_epsilon = 0.001 # 1 ms
+      time = DateTime.now
+      post1 = Post.create(:post_id => 'x', :posted_at => time)
+      post2 = Post.create(:post_id => 'x', :posted_at => (time + 1.hour))
+      chain = Dynamoid::Criteria::Chain.new(Post)
+      query = { :post_id => "x", "posted_at.lt" => (time + 1.hour - ts_epsilon).to_f }
+      resultset = chain.send(:where, query)
+      expect(resultset.count).to eq 1
+      stored_record = resultset.first
+      expect(stored_record.attributes[:post_id]).to eq post2.attributes[:post_id]
+      # Must use an epsilon to compare timestamps after round-trip: https://github.com/Dynamoid/Dynamoid/issues/2
+      expect(stored_record.attributes[:created_at]).to be_within(ts_epsilon).of(post1.attributes[:created_at])
+      expect(stored_record.attributes[:posted_at]).to be_within(ts_epsilon).of(post1.attributes[:posted_at])
+      expect(stored_record.attributes[:updated_at]).to be_within(ts_epsilon).of(post1.attributes[:updated_at])
+    end
+
+    it 'finds posts with "where" method with "between" query' do
+      ts_epsilon = 0.001 # 1 ms
+      time = DateTime.now
+      post1 = Post.create(:post_id => 'x', :posted_at => time)
+      post2 = Post.create(:post_id => 'x', :posted_at => (time + 1.hour))
+      chain = Dynamoid::Criteria::Chain.new(Post)
+      query = { :post_id => "x", "posted_at.between" => [(time - ts_epsilon).to_f, (time + ts_epsilon).to_f]}
+      resultset = chain.send(:where, query)
+      expect(resultset.count).to eq 1
+      stored_record = resultset.first
+      expect(stored_record.attributes[:post_id]).to eq post2.attributes[:post_id]
+      # Must use an epsilon to compare timestamps after round-trip: https://github.com/Dynamoid/Dynamoid/issues/2
+      expect(stored_record.attributes[:created_at]).to be_within(ts_epsilon).of(post1.attributes[:created_at])
+      expect(stored_record.attributes[:posted_at]).to be_within(ts_epsilon).of(post1.attributes[:posted_at])
+      expect(stored_record.attributes[:updated_at]).to be_within(ts_epsilon).of(post1.attributes[:updated_at])
     end
 
     describe 'destroy' do


### PR DESCRIPTION
https://github.com/Dynamoid/Dynamoid/issues/41

Now it works with query like
```ruby
class SomeModel
  include Dynamoid::Document

  table :name => :some_table, key: :some_hash_id

  range :some_range_id, :string

...

SomeModel.where(some_hash_id: 100,
'some_range_id.gt': 'abcd', 'some_range_id.lt': 'abxy').all


```

Please review :bow:
(@ananthakumaran : You may be the best one)