### PR TITLE
Use hash_key instead of id in association target ids.

### DIFF
--- a/lib/dynamoid/associations/belongs_to.rb
+++ b/lib/dynamoid/associations/belongs_to.rb
@@ -29,14 +29,14 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def associate_target(object)
-        object.update_attribute(target_attribute, target_ids.merge(Array(source.id)))
+        object.update_attribute(target_attribute, target_ids.merge(Array(source.hash_key)))
       end
 
       # Disassociate a source object from this association.
       #
       # @since 0.2.0      
       def disassociate_target(object)
-        source.update_attribute(source_attribute, target_ids - Array(source.id))
+        source.update_attribute(source_attribute, target_ids - Array(source.hash_key))
       end
     end
   end

--- a/lib/dynamoid/associations/has_and_belongs_to_many.rb
+++ b/lib/dynamoid/associations/has_and_belongs_to_many.rb
@@ -24,7 +24,7 @@ module Dynamoid #:nodoc:
       # @since 0.2.0
       def associate_target(object)
         ids = object.send(target_attribute) || Set.new
-        object.update_attribute(target_attribute, ids.merge(Array(source.id)))
+        object.update_attribute(target_attribute, ids.merge(Array(source.hash_key)))
       end
 
       # Disassociate a source object from this association.
@@ -32,7 +32,7 @@ module Dynamoid #:nodoc:
       # @since 0.2.0
       def disassociate_target(object)
         ids = object.send(target_attribute) || Set.new
-        object.update_attribute(target_attribute, ids - Array(source.id))
+        object.update_attribute(target_attribute, ids - Array(source.hash_key))
       end
     end
   end

--- a/lib/dynamoid/associations/has_many.rb
+++ b/lib/dynamoid/associations/has_many.rb
@@ -23,7 +23,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0                  
       def associate_target(object)
-        object.update_attribute(target_attribute, Set[source.id])
+        object.update_attribute(target_attribute, Set[source.hash_key])
       end
       
       # Disassociate a source object from this association.

--- a/lib/dynamoid/associations/has_one.rb
+++ b/lib/dynamoid/associations/has_one.rb
@@ -24,7 +24,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def associate_target(object)
-        object.update_attribute(target_attribute, Set[source.id])
+        object.update_attribute(target_attribute, Set[source.hash_key])
       end
 
       # Disassociate a source object from this association.

--- a/lib/dynamoid/associations/many_association.rb
+++ b/lib/dynamoid/associations/many_association.rb
@@ -52,7 +52,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def delete(object)
-        source.update_attribute(source_attribute, source_ids - Array(object).collect(&:id))
+        source.update_attribute(source_attribute, source_ids - Array(object).collect(&:hash_key))
         Array(object).each {|o| self.send(:disassociate_target, o)} if target_association
         object
       end
@@ -67,7 +67,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def <<(object)
-        source.update_attribute(source_attribute, source_ids.merge(Array(object).collect(&:id)))
+        source.update_attribute(source_attribute, source_ids.merge(Array(object).collect(&:hash_key)))
         Array(object).each {|o| self.send(:associate_target, o)} if target_association
         object
       end

--- a/lib/dynamoid/associations/single_association.rb
+++ b/lib/dynamoid/associations/single_association.rb
@@ -9,7 +9,7 @@ module Dynamoid #:nodoc:
 
       def setter(object)
         delete
-        source.update_attribute(source_attribute, Set[object.id])
+        source.update_attribute(source_attribute, Set[object.hash_key])
         self.send(:associate_target, object) if target_association
         object
       end

--- a/spec/app/models/subscription.rb
+++ b/spec/app/models/subscription.rb
@@ -1,6 +1,7 @@
 class Subscription
   include Dynamoid::Document
-
+  table :key => :subs_id
+  
   field :length, :integer
 
   belongs_to :magazine

--- a/spec/dynamoid/associations/association_spec.rb
+++ b/spec/dynamoid/associations/association_spec.rb
@@ -110,7 +110,7 @@ describe Dynamoid::Associations::Association do
     subscription2 = magazine.subscriptions.create
     subscription3 = magazine.subscriptions.create
 
-    expect(magazine.subscriptions.collect(&:id).sort).to eq [subscription1.id, subscription2.id, subscription3.id].sort
+    expect(magazine.subscriptions.collect(&:hash_key).sort).to eq [subscription1.hash_key, subscription2.hash_key, subscription3.hash_key].sort
   end
 
   it 'works for camel-cased associations' do
@@ -146,7 +146,7 @@ describe Dynamoid::Associations::Association do
     expect(subscription2.reload.magazine_ids).to be_present
 
     magazine.subscriptions = subscription3
-    expect(magazine.subscriptions_ids).to eq Set[subscription3.id]
+    expect(magazine.subscriptions_ids).to eq Set[subscription3.hash_key]
 
     expect(subscription1.reload.magazine_ids).to be_blank
     expect(subscription2.reload.magazine_ids).to be_blank


### PR DESCRIPTION
When use custom `key` in model, we are not able to connect or look up associations. 
`ArgumentError: set types only support String, Numeric, or IO objects` exception raise because the association class trying to write an empty `Set` to dynamodb.

Please review this PR.