### PR TITLE
Expose the truncate method on the adapter, test it and fix it.

### DIFF
--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -131,7 +131,7 @@ module Dynamoid
       end
     end
 
-    [:batch_get_item, :delete_item, :delete_table, :get_item, :list_tables, :put_item].each do |m|
+    [:batch_get_item, :delete_item, :delete_table, :get_item, :list_tables, :put_item, :truncate].each do |m|
       # Method delegation with benchmark to the underlying adapter. Faster than relying on method_missing.
       #
       # @since 0.2.0

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -419,7 +419,8 @@ module Dynamoid
         rk    = table.range_key
 
         scan(table_name, {}, {}).each do |attributes|
-          opts = {range_key: attributes[rk.to_sym] } if rk
+          opts = {}
+          opts[:range_key] = attributes[rk.to_sym] if rk
           delete_item(table_name, attributes[hk], opts)
         end
       end

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -353,6 +353,30 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       expect(Dynamoid.adapter.scan(test_table1, {})).to include({:name=>"Josh", :id=>"2"}, {:name=>"Josh", :id=>"1"})
     end
 
+    # Truncate
+    it 'performs truncate on an existing table' do
+      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Pascal'})
+
+      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({:name => 'Josh', :id => '1'})
+      expect(Dynamoid.adapter.get_item(test_table1, '2')).to eq({:name => 'Pascal', :id => '2'})
+
+      Dynamoid.adapter.truncate(test_table1)
+
+      expect(Dynamoid.adapter.get_item(test_table1, '1')).to be_nil
+      expect(Dynamoid.adapter.get_item(test_table1, '2')).to be_nil
+    end
+
+    it 'performs truncate on an existing table with a range key' do
+      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
+      Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
+
+      Dynamoid.adapter.truncate(test_table3)
+
+      expect(Dynamoid.adapter.get_item(test_table3, '1', :range_key => 1.0)).to be_nil
+      expect(Dynamoid.adapter.get_item(test_table3, '2', :range_key => 2.0)).to be_nil
+    end
+    
     it_behaves_like 'correct ordering'
   end
 


### PR DESCRIPTION
The truncate method was already there, but with no access :-( That's sad because it would be pretty handy for one of my projects.

Although when exposing it I found a bug in it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dynamoid/dynamoid/52)
<!-- Reviewable:end -->
