### PR TITLE
Add config options, use_timestamps and use_namespace

### DIFF
--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -23,6 +23,8 @@ module Dynamoid
     option :use_ssl, :default => true
     option :port, :default => '443'
     option :identity_map, :default => false
+    option :use_namespace, :default => true
+    option :use_timestamps, :default => true
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.
     #

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -131,14 +131,14 @@ module Dynamoid #:nodoc:
     #
     # @since 0.2.0
     def set_created_at
-      self.created_at = DateTime.now
+      self.created_at = DateTime.now if Dynamoid::Config.use_timestamps
     end
 
     # Automatically called during the save callback to set the updated_at time.
     #
     # @since 0.2.0
     def set_updated_at
-      self.updated_at = DateTime.now
+      self.updated_at = DateTime.now if Dynamoid::Config.use_timestamps
     end
 
     def set_type

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -16,7 +16,8 @@ module Dynamoid
     module ClassMethods
 
       def table_name
-        @table_name ||= "#{Dynamoid::Config.namespace}_#{options[:name] || base_class.name.split('::').last.downcase.pluralize}"
+        base_name = options[:name] || base_class.name.split('::').last.downcase.pluralize
+        @table_name ||= (Dynamoid::Config.use_namespace ? "#{Dynamoid::Config.namespace}_#{base_name}" : base_name)
       end
 
       # Creates a table.
@@ -140,7 +141,7 @@ module Dynamoid
     #
     def touch(name = nil)
       now = DateTime.now
-      self.updated_at = now
+      self.updated_at = now if Dynamoid::Config.use_timestamps
       attributes[name] = now if name
       save
     end


### PR DESCRIPTION
When using Dynamoid for existing tables,  default namespace of tables and fields of timestamps may be annoying. I think those should be selectable as follows.

```ruby
Dynamoid.configure do |config|
  config.use_namespace = false # default: true
  config.use_timestamps = false # default: true
end
```