### PR TITLE
Fix type to projected_attributes of index

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -526,7 +526,7 @@ module Dynamoid
         }
 
         # If the projection type is include, specify the non key attributes
-        if index.projection_type == "INCLUDE"
+        if index.projection_type == :include
           hash[:projection][:non_key_attributes] = index.projected_attributes
         end
 


### PR DESCRIPTION
if using Array for projected_attributes, miss type.