### PR TITLE
Enable to save without updating timestamps

### DIFF
--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -23,6 +23,7 @@ module Dynamoid
     option :use_ssl, :default => true
     option :port, :default => '443'
     option :identity_map, :default => false
+    option :timestamps, :default => true
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.
     #

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -137,14 +137,14 @@ module Dynamoid #:nodoc:
     #
     # @since 0.2.0
     def set_created_at
-      self.created_at = DateTime.now
+      self.created_at = DateTime.now if Dynamoid::Config.timestamps
     end
 
     # Automatically called during the save callback to set the updated_at time.
     #
     # @since 0.2.0
     def set_updated_at
-      self.updated_at = DateTime.now
+      self.updated_at = DateTime.now if Dynamoid::Config.timestamps
     end
 
     def set_type

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -81,6 +81,35 @@ describe Dynamoid::Persistence do
     end
   end
 
+  context 'with timestamps set to false' do
+    def reload_address
+      Object.send(:remove_const, 'Address')
+      load 'app/models/address.rb'
+    end
+
+    timestamps = Dynamoid::Config.timestamps
+
+    before do
+      reload_address
+      Dynamoid.configure do |config|
+        config.timestamps = false
+      end
+    end
+
+    after do
+      reload_address
+      Dynamoid.configure do |config|
+        config.timestamps = timestamps
+      end
+    end
+
+    it 'sets nil to created_at and updated_at' do
+      address = Address.create
+      expect(address.created_at).to be_nil
+      expect(address.updated_at).to be_nil
+    end
+  end
+
   it 'deletes an item completely' do
     @user = User.create(:name => 'Josh')
     @user.destroy


### PR DESCRIPTION
Enable to configure that as below:
```
Dynamoid.configure do |config|
  config.timestamps = false # default: true
end
```