### PR TITLE
Change values of read/write capacity in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,8 +58,8 @@ Then you need to initialize Dynamoid config to get it going. Put code similar to
     config.adapter = 'aws_sdk_v2' # This adapter establishes a connection to the DynamoDB servers using Amazon's own AWS gem.
     config.namespace = "dynamoid_app_development" # To namespace tables created by Dynamoid from other tables you might have. Set to nil to avoid namespacing.
     config.warn_on_scan = true # Output a warning to the logger when you perform a scan rather than a query on a table.
-    config.read_capacity = 100 # Read capacity for your tables
-    config.write_capacity = 20 # Write capacity for your tables
+    config.read_capacity = 5 # Read capacity for your tables
+    config.write_capacity = 5 # Write capacity for your tables
     config.endpoint = 'http://localhost:3000' # [Optional]. If provided, it communicates with the DB listening at the endpoint. This is useful for testing with [Amazon Local DB] (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html). 
   end
 
@@ -86,7 +86,7 @@ Dynamoid has some sensible defaults for you when you create a new table, includi
 class User
   include Dynamoid::Document
 
-  table :name => :awesome_users, :key => :user_id, :read_capacity => 400, :write_capacity => 400
+  table :name => :awesome_users, :key => :user_id, :read_capacity => 5, :write_capacity => 5
 end
 ```
 


### PR DESCRIPTION
Fix #61 
```5``` is the default value to create a new table in AWS Web Console.