### PR TITLE
Make Dynamoid Rails 5 compatible and help avoid errors when no tables exist yet

### DIFF
--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -64,7 +64,6 @@ Gem::Specification.new do |s|
   
   s.add_runtime_dependency(%q<activemodel>, [">= 4"])
   s.add_runtime_dependency(%q<active_model_serializers>)
-  s.add_runtime_dependency(%q<activemodel-serializers-xml>)
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   s.add_development_dependency(%q<rake>, [">= 0"])

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -61,8 +61,10 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.24"
   s.summary = "Dynamoid is an ORM for Amazon's DynamoDB"
 
-  s.add_runtime_dependency(%q<active_model_serializers>)
+  
   s.add_runtime_dependency(%q<activemodel>, [">= 4"])
+  s.add_runtime_dependency(%q<active_model_serializers>)
+  s.add_runtime_dependency(%q<activemodel-serializers-xml>)
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   s.add_development_dependency(%q<rake>, [">= 0"])

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -61,6 +61,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.24"
   s.summary = "Dynamoid is an ORM for Amazon's DynamoDB"
 
+  s.add_runtime_dependency(%q<active_model_serializers>)
   s.add_runtime_dependency(%q<activemodel>, [">= 4"])
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.24"
   s.summary = "Dynamoid is an ORM for Amazon's DynamoDB"
 
-  s.add_runtime_dependency(%q<activemodel>, ["~> 4"])
+  s.add_runtime_dependency(%q<activemodel>, [">= 4"])
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   s.add_development_dependency(%q<rake>, [">= 0"])

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -19,7 +19,7 @@ module Dynamoid
       if !@tables_.value
         @tables_.swap{|value, args| benchmark('Cache Tables') {list_tables}}
       end
-      @tables_.value
+      @tables_.value || []
     end
 
     # The actual adapter currently in use.

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -23,7 +23,7 @@ module Dynamoid
     include ActiveModel::Naming
     include ActiveModel::Observing if defined?(ActiveModel::Observing)
     include ActiveModel::Serializers::JSON
-    include ActiveModel::Serializers::Xml
+    # include ActiveModel::Serializers::Xml
     include Dynamoid::Fields
     include Dynamoid::Persistence
     include Dynamoid::Finders

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -23,7 +23,6 @@ module Dynamoid
     include ActiveModel::Naming
     include ActiveModel::Observing if defined?(ActiveModel::Observing)
     include ActiveModel::Serializers::JSON
-    # include ActiveModel::Serializers::Xml
     include Dynamoid::Fields
     include Dynamoid::Persistence
     include Dynamoid::Finders


### PR DESCRIPTION
The nil object doesn't have an include? method. In case the tables variable is nil, default it to an empty array so the .include? works.

Remove the inclusion of ActiveModel::Serializers::Xml from components.rb. It's throwing errors and from what I can tell, it's not used anywhere in the codebase. Check my search though: https://github.com/Dynamoid/Dynamoid/search?q=XML&type=Code&utf8=%E2%9C%93

After making these tweaks, I was able to successfully run this gem in Rails 5 without any initial tables.
