### PR TITLE
Rails 5 Serialization issue resolved

### DIFF
--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.24"
   s.summary = "Dynamoid is an ORM for Amazon's DynamoDB"
 
-  s.add_runtime_dependency(%q<activemodel>, ["~> 4"])
+  s.add_runtime_dependency(%q<activemodel>, [">= 5.0.0.beta3"])
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   s.add_development_dependency(%q<rake>, [">= 0"])

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -63,7 +63,8 @@ Gem::Specification.new do |s|
   s.summary = "Dynamoid is an ORM for Amazon's DynamoDB"
 
   s.add_runtime_dependency(%q<activemodel>, [">= 5.0.0.beta3"])
-  s.add_runtime_dependency(%q<activemodel-serializers-xml>, [">= 0"])
+  s.add_runtime_dependency(%q<active_model_serializers>, [">= 0.8.0"])
+  s.add_runtime_dependency(%q<activemodel-serializers-xml>)
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   s.add_development_dependency(%q<rake>, [">= 0"])

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.24"
   s.summary = "Dynamoid is an ORM for Amazon's DynamoDB"
 
-  s.add_runtime_dependency(%q<activemodel>, [">= 5"])
+  s.add_runtime_dependency(%q<activemodel>, [">= 5.0.0.beta3"])
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   s.add_development_dependency(%q<rake>, [">= 0"])

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -63,6 +63,7 @@ Gem::Specification.new do |s|
   s.summary = "Dynamoid is an ORM for Amazon's DynamoDB"
 
   s.add_runtime_dependency(%q<activemodel>, [">= 5.0.0.beta3"])
+  s.add_runtime_dependency(%q<activemodel-serializers-xml>, [">= 0"])
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   s.add_development_dependency(%q<rake>, [">= 0"])

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.24"
   s.summary = "Dynamoid is an ORM for Amazon's DynamoDB"
 
-  s.add_runtime_dependency(%q<activemodel>, [">= 5.0.0.beta3"])
+  s.add_runtime_dependency(%q<activemodel>, [">= 5"])
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   s.add_development_dependency(%q<rake>, [">= 0"])

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -63,7 +63,6 @@ Gem::Specification.new do |s|
   s.summary = "Dynamoid is an ORM for Amazon's DynamoDB"
 
   s.add_runtime_dependency(%q<activemodel>, [">= 5.0.0.beta3"])
-  s.add_runtime_dependency(%q<active_model_serializers>, [">= 0.8.0"])
   s.add_runtime_dependency(%q<activemodel-serializers-xml>)
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -19,7 +19,7 @@ module Dynamoid
       if !@tables_.value
         @tables_.swap{|value, args| benchmark('Cache Tables') {list_tables}}
       end
-      @tables_.value
+      @tables_.value || []
     end
 
     # The actual adapter currently in use.

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -23,7 +23,6 @@ module Dynamoid
     include ActiveModel::Naming
     include ActiveModel::Observing if defined?(ActiveModel::Observing)
     include ActiveModel::Serializers::JSON
-    include ActiveModel::Serializers::Xml
     include Dynamoid::Fields
     include Dynamoid::Indexes
     include Dynamoid::Persistence

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -23,6 +23,7 @@ module Dynamoid
     include ActiveModel::Naming
     include ActiveModel::Observing if defined?(ActiveModel::Observing)
     include ActiveModel::Serializers::JSON
+    include ActiveModel::Serializers::Xml if defined?(ActiveModel::Serializers::Xml)
     include Dynamoid::Fields
     include Dynamoid::Indexes
     include Dynamoid::Persistence

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'activemodel-serializers-xml'
 module Dynamoid
 
   # All modules that a Document is composed of are defined in this
@@ -23,7 +24,7 @@ module Dynamoid
     include ActiveModel::Naming
     include ActiveModel::Observing if defined?(ActiveModel::Observing)
     include ActiveModel::Serializers::JSON
-    include ActiveModel::Serializers::Xml if defined?(ActiveModel::Serializers::Xml)
+    include ActiveModel::Serializers::Xml
     include Dynamoid::Fields
     include Dynamoid::Indexes
     include Dynamoid::Persistence


### PR DESCRIPTION
Fixed issue with serialization in rails 5.  The problem was serialization had been moved to it's own gem which required adding it to the spec gem.  It also needed to be required in the components.rb file.  Hopefully this helps you as rails 5 is released!
