### PR TITLE
Support to Rails 5

### DIFF
--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -62,7 +62,8 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.24"
   s.summary = "Dynamoid is an ORM for Amazon's DynamoDB"
 
-  s.add_runtime_dependency(%q<activemodel>, ["~> 4"])
+  s.add_runtime_dependency(%q<activemodel>, [">= 4"])
+  s.add_runtime_dependency(%q<active_model_serializers>)  
   s.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   s.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   s.add_development_dependency(%q<rake>, [">= 0"])

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -19,7 +19,7 @@ module Dynamoid
       if !@tables_.value
         @tables_.swap{|value, args| benchmark('Cache Tables') {list_tables}}
       end
-      @tables_.value
+      @tables_.value || []
     end
 
     # The actual adapter currently in use.

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -23,7 +23,7 @@ module Dynamoid
     include ActiveModel::Naming
     include ActiveModel::Observing if defined?(ActiveModel::Observing)
     include ActiveModel::Serializers::JSON
-    include ActiveModel::Serializers::Xml
+    #include ActiveModel::Serializers::Xml
     include Dynamoid::Fields
     include Dynamoid::Indexes
     include Dynamoid::Persistence


### PR DESCRIPTION
* Changed gemspec to support rails 5.
* Added **active_model_serializers** into gemspec
* Removed **include ActiveModel::Serializers::Xml** from *Components.rb* because it wont work on rails 5