### PR TITLE
Store document in DocumentNotValid error instance variable

### DIFF
--- a/lib/dynamoid/errors.rb
+++ b/lib/dynamoid/errors.rb
@@ -53,8 +53,11 @@ module Dynamoid
     end
 
     class DocumentNotValid < Error
+      attr_reader :document
+
       def initialize(document)
         super("Validation failed: #{document.errors.full_messages.join(", ")}")
+        @document = document
       end
     end
 

--- a/spec/dynamoid/validations_spec.rb
+++ b/spec/dynamoid/validations_spec.rb
@@ -36,7 +36,9 @@ describe Dynamoid::Validations do
     doc_class.field :name
     doc_class.validates_presence_of :name
     doc = doc_class.new
-    expect { doc.save! }.to raise_error(Dynamoid::Errors::DocumentNotValid)
+    expect { doc.save! }.to raise_error(Dynamoid::Errors::DocumentNotValid) do |error|
+      expect(error.document).to eq doc
+    end
 
     expect { doc_class.create! }.to raise_error(Dynamoid::Errors::DocumentNotValid)
 


### PR DESCRIPTION
I faced with issue where my code need details about validation error.

So here I added **document** to DocumentNotValid error in order to get error details in client code.