### PR TITLE
Fix AWS SDK V2 query to pull in all results

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -447,11 +447,16 @@ module Dynamoid
         q[:key_conditions] = key_conditions
 
         Enumerator.new { |y|
-          result = client.query(q)
+          loop do
+            results = client.query(q)
+            results.items.each { |row| y << result_item_to_hash(row) }
 
-          result.items.each { |r|
-            y << result_item_to_hash(r)
-          }
+            if(lk = results.last_evaluated_key)
+              q[:exclusive_start_key] = lk
+            else
+              break
+            end
+          end
         }
       end
 

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -52,6 +52,12 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     it 'performs query on a table with a range and selects items lte' do
       expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_lte => 3.0).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
     end
+
+    it 'performs query on a table with a range and selects all items' do
+      200.times { |i| Dynamoid.adapter.put_item(test_table3, {:id => "1", :range => i.to_f, :data => "A"*1024*16}) }
+      # 64 of these items will exceed the 1MB result limit thus query won't return all results on first loop
+      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_gte => 0.0).count).to eq(200)
+    end
   end
 
   #


### PR DESCRIPTION
- [Fix] Previously query would only return the first page of data which
  is a maximum of 1MB by DynamoDB. This fix loops to retrieve all
  results beyond the 1MB limit

Note on styling: Rewrote to be similar as `scan` defined below.