### PR TITLE
Raw datatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,6 @@ end
 In this example, all saves to `MyTable` will raise an `Dynamoid::Errors::StaleObjectError` if a concurrent process loaded, edited, and saved the same row. Your code should trap this exception, reload the row (so that it will pick up the newest values), and try the save again.
 
 Calls to `update` and `update!` also increment the `lock_version`, however they do not check the existing value. This guarantees that a update operation will raise an exception in a concurrent save operation, however a save operation will never cause an update to fail. Thus, `update` is useful & safe only for doing atomic operations (e.g. increment a value, add/remove from a set, etc), but should not be used in a read-modify-write pattern.
-<<<<<<< 328f2cdbdaa25ff932962056f8c1cd919d017927:README.md
 
 ## Test Environment
 
@@ -385,8 +384,6 @@ Dynamoid.configure do |config|
   config.namespace = "#{Rails.application.railtie_name}_#{Rails.env}"
 end
 ```
-=======
->>>>>>> no_table_namespace from brenden:README.markdown
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gem 'aws-sdk', '~>2'
 
 (or) include the aws-sdk in your Gemfile.
 
-**NOTE:** Dynamoid-1.0 doesn't support aws-sdk Version 1 (Use Dynamoid Major Version 0 for aws-sdk 1)   
+**NOTE:** Dynamoid-1.0 doesn't support aws-sdk Version 1 (Use Dynamoid Major Version 0 for aws-sdk 1)
 
 Configure AWS access:
 [Reference](https://github.com/aws/aws-sdk-ruby)
@@ -60,7 +60,7 @@ Then you need to initialize Dynamoid config to get it going. Put code similar to
     config.warn_on_scan = true # Output a warning to the logger when you perform a scan rather than a query on a table.
     config.read_capacity = 5 # Read capacity for your tables
     config.write_capacity = 5 # Write capacity for your tables
-    config.endpoint = 'http://localhost:3000' # [Optional]. If provided, it communicates with the DB listening at the endpoint. This is useful for testing with [Amazon Local DB] (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html). 
+    config.endpoint = 'http://localhost:3000' # [Optional]. If provided, it communicates with the DB listening at the endpoint. This is useful for testing with [Amazon Local DB] (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html).
   end
 
 ```
@@ -129,20 +129,20 @@ To use a custom type for a field, suppose you have a `Money` type.
 ```ruby
   class Money
     # ... your business logic ...
-    
+
     def dynamoid_dump
       "serialized representation as a string"
     end
-    
+
     def self.dynamoid_load(serialized_str)
       # parse serialized representation and return a Money instance
       Money.new(...)
     end
   end
-  
+
   class User
     include Dynamoid::Document
-    
+
     field :balance, Money
   end
 ```
@@ -155,20 +155,20 @@ add a level of indirection for serializing.)  Example:
 ```ruby
   # Third-party Money class
   class Money; end
-  
+
   class MoneyAdapter
     def self.dynamoid_load(money_serialized_str)
       Money.new(...)
     end
-    
+
     def self.dynamoid_dump(money_obj)
       money_obj.value.to_s
     end
   end
-  
+
   class User
     include Dynamoid::Document
-    
+
     field :balance, MoneyAdapter
   end
 ```
@@ -327,14 +327,14 @@ It also supports .gte and .lte. Turning those into symbols and allowing a Rails 
 
 ## Concurrency
 
-Dynamoid supports basic, ActiveRecord-like optimistic locking on save operations. Simply add a `lock_version` column to your table like so: 
+Dynamoid supports basic, ActiveRecord-like optimistic locking on save operations. Simply add a `lock_version` column to your table like so:
 
 ```ruby
 class MyTable
   ...
-  
+
   field :lock_version, :integer
-  
+
   ...
 end
 ```
@@ -342,7 +342,8 @@ end
 In this example, all saves to `MyTable` will raise an `Dynamoid::Errors::StaleObjectError` if a concurrent process loaded, edited, and saved the same row. Your code should trap this exception, reload the row (so that it will pick up the newest values), and try the save again.
 
 Calls to `update` and `update!` also increment the `lock_version`, however they do not check the existing value. This guarantees that a update operation will raise an exception in a concurrent save operation, however a save operation will never cause an update to fail. Thus, `update` is useful & safe only for doing atomic operations (e.g. increment a value, add/remove from a set, etc), but should not be used in a read-modify-write pattern.
- 
+<<<<<<< 328f2cdbdaa25ff932962056f8c1cd919d017927:README.md
+
 ## Test Environment
 
 In test environment you will most likely want to clean the database between test runs to keep tests completely isolated. This can be achieved like so
@@ -384,6 +385,8 @@ Dynamoid.configure do |config|
   config.namespace = "#{Rails.application.railtie_name}_#{Rails.env}"
 end
 ```
+=======
+>>>>>>> no_table_namespace from brenden:README.markdown
 
 ## Credits
 
@@ -422,9 +425,9 @@ Running the tests is fairly simple. You should have an instance of DynamoDB runn
     ```shell
     bin/start_dynamodblocal
     ```
- 
+
  * and lastly, use `rake` to run the tests.
- 
+
     ```shell
     rake
     ```

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -26,6 +26,7 @@ module Dynamoid
     option :timestamps, :default => true
     option :sync_retry_max_times, :default => 60 # a bit over 2 minutes
     option :sync_retry_wait_seconds, :default => 2
+    option :convert_big_decimal, :default => false
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.
     #

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -103,7 +103,7 @@ module Dynamoid
                 value.to_a
               when :raw
                 if value.is_a?(Hash)
-                  transform_hash(value)
+                  undump_hash(value)
                 else
                   value
                 end
@@ -148,13 +148,13 @@ module Dynamoid
 
       private
 
-            def transform_hash(hash)
+      def undump_hash(hash)
         {}.tap do |h|
-          hash.each { |key, value| h[key.to_sym] = transform(value) }
+          hash.each { |key, value| h[key.to_sym] = undump_hash_value(value) }
         end
       end
 
-      def transform(val)
+      def undump_hash_value(val)
         case val
         when BigDecimal
           if Dynamoid::Config.convert_big_decimal
@@ -163,9 +163,9 @@ module Dynamoid
             val
           end
         when Hash
-          transform_hash(val)
+          undump_hash(val)
         when Array
-          val.map { |v| transform(v) }
+          val.map { |v| undump_hash_value(v) }
         else
           val
         end

--- a/spec/app/models/address.rb
+++ b/spec/app/models/address.rb
@@ -1,10 +1,11 @@
 class Address
   include Dynamoid::Document
-  
+
   field :city
   field :options, :serialized
   field :deliverable, :boolean
   field :latitude, :number
+  field :config, :raw
 
   field :lock_version, :integer #Provides Optimistic Locking
 

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -13,6 +13,7 @@ describe Dynamoid::Document do
                                       options: nil,
                                       deliverable: nil,
                                       latitude: nil,
+                                      config: nil,
                                       lock_version: nil})
   end
 
@@ -36,6 +37,7 @@ describe Dynamoid::Document do
                                       options: nil,
                                       deliverable: nil,
                                       latitude: nil,
+                                      config: nil,
                                       lock_version: nil})
   end
 
@@ -51,6 +53,7 @@ describe Dynamoid::Document do
                                       options: nil,
                                       deliverable: nil,
                                       latitude: nil,
+                                      config: nil,
                                       lock_version: nil})
   end
 

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -110,6 +110,7 @@ describe Dynamoid::Fields do
                                         options: {type: :serialized},
                                         deliverable: {type: :boolean},
                                         latitude: {type: :number},
+                                        config: {type: :raw},
                                         lock_version: {type: :integer}})
     end
   end

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -124,7 +124,7 @@ describe Dynamoid::Persistence do
   end
 
   it 'keeps raw Hash attributes as a Hash' do
-    config = {acres: 5, trees: {cyprus: 30, poplar: 10, joshua: 1}, horses: ['Lucky', 'Dummy'], lake: 1, tennis_court: 1}
+    config = {:acres => 5, :trees => {:cyprus => 30, :poplar => 10, :joshua => 1}, :horses => ['Lucky', 'Dummy'], :lake => 1, :tennis_court => 1}
     @addr = Address.new(:config => config)
     expect(@addr.send(:dump)[:config]).to eq config
   end
@@ -423,10 +423,10 @@ describe Dynamoid::Persistence do
   end
 
   describe ':raw datatype persistence' do
-    subject { Address.new()}
+    subject { Address.new() }
 
     it 'it persists raw Hash and reads the same back' do
-      config = {acres: 5, trees: {cyprus: 30, poplar: 10, joshua: 1}, horses: ['Lucky', 'Dummy'], lake: 1, tennis_court: 1}
+      config = {:acres => 5, :trees => {:cyprus => 30, :poplar => 10, :joshua => 1}, :horses => ['Lucky', 'Dummy'], :lake => 1, :tennis_court => 1}
       subject.config = config
       subject.save!
       subject.reload

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -123,6 +123,12 @@ describe Dynamoid::Persistence do
     expect(@user.send(:dump)[:name]).to eq 'Josh'
   end
 
+  it 'keeps raw Hash attributes as Hash' do
+    config = {acres: 5, trees: {cyprus: 30, poplar: 10, joshua: 1}, horses: ['Lucky', 'Dummy'], lake: 1, tennis_court: 1}
+    @addr = Address.new(:config => config)
+    expect(@addr.send(:dump)[:config]).to eq config
+  end
+
   it 'dumps datetime attributes' do
     @user = User.create(:name => 'Josh')
     expect(@user.send(:dump)[:name]).to eq 'Josh'

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -123,8 +123,26 @@ describe Dynamoid::Persistence do
     expect(@user.send(:dump)[:name]).to eq 'Josh'
   end
 
-  it 'keeps raw Hash attributes as Hash' do
+  it 'keeps raw Hash attributes as a Hash' do
     config = {acres: 5, trees: {cyprus: 30, poplar: 10, joshua: 1}, horses: ['Lucky', 'Dummy'], lake: 1, tennis_court: 1}
+    @addr = Address.new(:config => config)
+    expect(@addr.send(:dump)[:config]).to eq config
+  end
+
+  it 'keeps raw Array attributes as an Array' do
+    config = ['windows', 'roof', 'doors']
+    @addr = Address.new(:config => config)
+    expect(@addr.send(:dump)[:config]).to eq config
+  end
+
+  it 'keeps raw String attributes as a String' do
+    config = 'Configy'
+    @addr = Address.new(:config => config)
+    expect(@addr.send(:dump)[:config]).to eq config
+  end
+
+  it 'keeps raw Number attributes as a Number' do
+    config = 100
     @addr = Address.new(:config => config)
     expect(@addr.send(:dump)[:config]).to eq config
   end
@@ -401,6 +419,55 @@ describe Dynamoid::Persistence do
         expect(v).to include(c)
         expect(v).to include(s)
       }
+    end
+  end
+
+  describe ':raw datatype persistence' do
+    subject { Address.new()}
+
+    it 'it persists raw Hash and reads the same back' do
+      config = {acres: 5, trees: {cyprus: 30, poplar: 10, joshua: 1}, horses: ['Lucky', 'Dummy'], lake: 1, tennis_court: 1}
+      subject.config = config
+      subject.save!
+      subject.reload
+      expect(subject.config).to eq config
+    end
+
+    it 'it persists raw Array and reads the same back' do
+      config = ['windows', 'doors', 'roof']
+      subject.config = config
+      subject.save!
+      subject.reload
+      expect(subject.config).to eq config
+    end
+
+    it 'it persists raw Number and reads the same back' do
+      config = 100
+      subject.config = config
+      subject.save!
+      subject.reload
+      expect(subject.config).to eq config
+    end
+
+    it 'it persists raw String and reads the same back' do
+      config = 'Configy'
+      subject.config = config
+      subject.save!
+      subject.reload
+      expect(subject.config).to eq config
+    end
+
+    it 'it persists raw value, then reads back, then deletes the value by setting to nil, persists and reads the nil back' do
+      config = 'To become nil'
+      subject.config = config
+      subject.save!
+      subject.reload
+      expect(subject.config).to eq config
+
+      subject.config = nil
+      subject.save!
+      subject.reload
+      expect(subject.config).to be_nil
     end
   end
 


### PR DESCRIPTION
we really needed native type that picks up existing models on DynamoDB. AWS's SDK V2 already has a support for persisting datatypes to dynamo, so why not utilize it.
This is rebased PR in favor of closed #64 