### PR TITLE
Rails 5 compatibility, and empty tables default

### DIFF
--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   else
     spec.add_runtime_dependency(%q<activemodel>, ["~> 5"])
   end
+  spec.add_runtime_dependency(%q<activemodel-serializers-xml>)
   spec.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   spec.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   spec.add_development_dependency(%q<rake>, [">= 10"])

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -39,9 +39,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   if Gem::Version.new(RUBY_VERSION) > Gem::Version.new("2.2.2")
-    spec.add_runtime_dependency(%q<activemodel>, [">= 4"])
+    spec.add_runtime_dependency(%q<activemodel>, [">= 5"])
   else
-    spec.add_runtime_dependency(%q<activemodel>, ["~> 4"])
+    spec.add_runtime_dependency(%q<activemodel>, ["~> 5"])
   end
   spec.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
   spec.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -19,7 +19,7 @@ module Dynamoid
       if !@tables_.value
         @tables_.swap{|value, args| benchmark('Cache Tables') { list_tables } }
       end
-      @tables_.value
+      @tables_.value || []
     end
 
     # The actual adapter currently in use.


### PR DESCRIPTION
This replicates [a stale pull request](https://github.com/Dynamoid/Dynamoid/pull/69) against the Dynamoid project. We need this functionality now, so we should use our own fork until the official repo is caught up.

Makes the gem rails 5 compatible, and adds a sensible default value from the `tables` method when the dynamodb tables haven't yet been created