### PR TITLE
Update Readme.md - add description of `raw` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ These fields will not change an existing table: so specifying a new read_capacit
 You'll have to define all the fields on the model and the data type of each field. Every field on the object must be included here; if you miss any they'll be completely bypassed during DynamoDB's initialization and will not appear on the model objects.
 
 By default, fields are assumed to be of type ```:string```. Other built-in types are
-```:integer```, ```:number```, ```:set```, ```:array```, ```:datetime```, ```:boolean```, and ```:serialized```.
+```:integer```, ```:number```, ```:set```, ```:array```, ```:datetime```, ```:boolean```, ```:raw``` and ```:serialized```.
+```raw``` type means you can store Ruby Array, Hash, String and numbers.
 If built-in types do not suit you, you can use a custom field type represented by an arbitrary class, provided that the class supports a compatible serialization interface.
 The primary use case for using a custom field type is to represent your business logic with high-level types, while ensuring portability or backward-compatibility of the serialized representation.
 


### PR DESCRIPTION
Readme missing information about `raw` type, so I have added `raw` into list of correct types and added following short description based on specs:

> `raw` type means you can store Ruby Array, Hash, String and numbers.