### PR TITLE
Fix warning about scan operation

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -139,7 +139,7 @@ module Dynamoid #:nodoc:
       def records_via_scan
         if Dynamoid::Config.warn_on_scan
           Dynamoid.logger.warn 'Queries without an index are forced to use scan and are generally much slower than indexed queries!'
-          Dynamoid.logger.warn "You can index this query by adding this to #{source.to_s.downcase}.rb: index [#{source.attributes.sort.collect{|attr| ":#{attr}"}.join(', ')}]"
+          Dynamoid.logger.warn "You can index this query by adding this to #{source.to_s.downcase}.rb: index [#{query.keys.sort.collect{|attr| ":#{attr}"}.join(', ')}]"
         end
 
         if @consistent_read

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -85,4 +85,21 @@ describe Dynamoid::Criteria do
     end.to raise_error(Dynamoid::Errors::InvalidQuery)
   end
 
+
+  context 'when scans and warn_on_scan config option is true' do
+    before do
+      @warn_on_scan = Dynamoid::Config.warn_on_scan
+      Dynamoid::Config.warn_on_scan = true
+    end
+    after do
+      Dynamoid::Config.warn_on_scan = @warn_on_scan
+    end
+
+    it 'logs warnings' do
+      expect(Dynamoid.logger).to receive(:warn).with('Queries without an index are forced to use scan and are generally much slower than indexed queries!')
+      expect(Dynamoid.logger).to receive(:warn).with('You can index this query by adding this to user.rb: index [:name, :password]')
+
+      User.where(name: 'x', password: 'password').all
+    end
+  end
 end


### PR DESCRIPTION
When model makes scan and  `Dynamoid::Config.warn_on_scan option` is true (by default) we log some warnings.

We try to log a list of attributes to build index on, but actually we log all the model field definitions:

>You can index this query by adding this to adapter.rb: index [:[:created_at, {:type=>:datetime}], ...

Assume we have to log attributes from a query passed to `where` method.

e.g. for the code
`User.where(name: 'x', password: 'password').all`

We will log
`# => ... user.rb: index [:name, :password]`