### PR TITLE
Add Chain#last method

### DIFF
--- a/lib/dynamoid/criteria.rb
+++ b/lib/dynamoid/criteria.rb
@@ -9,7 +9,7 @@ module Dynamoid
     
     module ClassMethods
       
-      [:where, :all, :first, :each, :eval_limit, :start, :scan_index_forward].each do |meth|
+      [:where, :all, :first, :last, :each, :eval_limit, :start, :scan_index_forward].each do |meth|
         # Return a criteria chain in response to a method that will begin or end a chain. For more information, 
         # see Dynamoid::Criteria::Chain.
         #

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -54,6 +54,12 @@ module Dynamoid #:nodoc:
         records
       end
 
+      # Returns the last fetched record matched the criteria
+      #
+      def last
+        all.last
+      end
+
       # Destroys all the records matching the criteria.
       #
       def destroy_all

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -8,6 +8,10 @@ describe Dynamoid::Criteria do
     expect(User.where(:name => 'Josh').first).to eq user1
   end
 
+  it 'finds last using where' do
+    expect(User.where(admin: false).last).to eq user2
+  end
+
   it 'finds all using where' do
     expect(User.where(:name => 'Josh').all).to eq [user1]
   end


### PR DESCRIPTION
We have `Chain#first` method but don't have `Chain#last`.

Now we can do
`User.where(admin: true).last`

It may be not useful in production code but looks good in specs