### PR TITLE
Add `date` attribute type

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ These fields will not change an existing table: so specifying a new read_capacit
 You'll have to define all the fields on the model and the data type of each field. Every field on the object must be included here; if you miss any they'll be completely bypassed during DynamoDB's initialization and will not appear on the model objects.
 
 By default, fields are assumed to be of type ```:string```. Other built-in types are
-```:integer```, ```:number```, ```:set```, ```:array```, ```:datetime```, ```:boolean```, ```:raw``` and ```:serialized```.
+```:integer```, ```:number```, ```:set```, ```:array```, ```:datetime```, ```date```, ```:boolean```, ```:raw``` and ```:serialized```.
 ```raw``` type means you can store Ruby Array, Hash, String and numbers.
 If built-in types do not suit you, you can use a custom field type represented by an arbitrary class, provided that the class supports a compatible serialization interface.
 The primary use case for using a custom field type is to represent your business logic with high-level types, while ensuring portability or backward-compatibility of the serialized representation.

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -30,7 +30,7 @@ module Dynamoid #:nodoc:
       # Specify a field for a document.
       #
       # Its type determines how it is coerced when read in and out of the datastore.
-      # You can specify :integer, :number, :set, :array, :datetime, and :serialized,
+      # You can specify :integer, :number, :set, :array, :datetime, :date and :serialized,
       # or specify a class that defines a serialization strategy.
       #
       # If you specify a class for field type, Dynamoid will serialize using

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -120,6 +120,12 @@ module Dynamoid
                 else
                   Time.at(value).to_datetime
                 end
+              when :date
+                if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)
+                  value.to_date
+                else
+                  Time.at(value).to_date
+                end
               when :boolean
                 # persisted as 't', but because undump is called during initialize it can come in as true
                 if value == 't' || value == true
@@ -159,6 +165,8 @@ module Dynamoid
               !value.nil? ? value : nil
             when :datetime
               !value.nil? ? value.to_time.to_f : nil
+            when :date
+              !value.nil? ? value.to_time.to_i: nil
             when :serialized
               options[:serializer] ? options[:serializer].dump(value) : value.to_yaml
             when :raw

--- a/spec/app/models/address.rb
+++ b/spec/app/models/address.rb
@@ -6,6 +6,7 @@ class Address
   field :deliverable, :boolean
   field :latitude, :number
   field :config, :raw
+  field :registered_on, :date
 
   field :lock_version, :integer #Provides Optimistic Locking
 

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -14,6 +14,7 @@ describe Dynamoid::Document do
                                       deliverable: nil,
                                       latitude: nil,
                                       config: nil,
+                                      registered_on: nil,
                                       lock_version: nil})
   end
 
@@ -38,6 +39,7 @@ describe Dynamoid::Document do
                                       deliverable: nil,
                                       latitude: nil,
                                       config: nil,
+                                      registered_on: nil,
                                       lock_version: nil})
   end
 
@@ -54,6 +56,7 @@ describe Dynamoid::Document do
                                       deliverable: nil,
                                       latitude: nil,
                                       config: nil,
+                                      registered_on: nil,
                                       lock_version: nil})
   end
 

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -111,6 +111,7 @@ describe Dynamoid::Fields do
                                         deliverable: {type: :boolean},
                                         latitude: {type: :number},
                                         config: {type: :raw},
+                                        registered_on: {type: :date},
                                         lock_version: {type: :integer}})
     end
   end

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -228,6 +228,11 @@ describe Dynamoid::Persistence do
     expect(@user.send(:dump)[:name]).to eq 'Josh'
   end
 
+  it 'dumps date attributes' do
+    @user = Address.create(:registered_on => '2017-06-18'.to_date)
+    expect(@user.send(:dump)[:registered_on]).to eq '2017-06-18'.to_time.to_i
+  end
+
   it 'dumps integer attributes' do
     @subscription = Subscription.create(:length => 10)
     expect(@subscription.send(:dump)[:length]).to eq 10
@@ -259,6 +264,13 @@ describe Dynamoid::Persistence do
 
   it 'dumps and undumps a BigDecimal in number field' do
     expect(Address.undump(Address.new(latitude: BigDecimal.new(123.45, 3)).send(:dump))[:latitude]).to eq 123
+  end
+
+  it 'dumps and undumps a date' do
+    date = '2017-06-18'.to_date
+    expect(
+      Address.undump(Address.new(registered_on: date).send(:dump))[:registered_on]
+    ).to eq date
   end
 
   it 'supports empty containers in `serialized` fields' do


### PR DESCRIPTION
We have `datetime` type but it's comfortable to work with dates too without storing date value in `datetime` column and manual convertation.

Now we can define date fields:
```
field :when_happened,      :date
```
