### PR TITLE
Support field accessors overriding by extentions

### DIFF
--- a/lib/dynamoid/associations.rb
+++ b/lib/dynamoid/associations.rb
@@ -19,7 +19,7 @@ module Dynamoid
     
     # Create the association tracking attribute and initialize it to an empty hash.
     included do
-      class_attribute :associations
+      class_attribute :associations, instance_accessor: false
       
       self.associations = {}
     end

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -8,7 +8,7 @@ module Dynamoid #:nodoc:
     include Dynamoid::Components
 
     included do
-      class_attribute :options, :read_only_attributes, :base_class
+      class_attribute :options, :read_only_attributes, :base_class, instance_accessor: false
       self.options = {}
       self.read_only_attributes = []
       self.base_class = self

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -120,6 +120,10 @@ module Dynamoid #:nodoc:
     #
     # @since 0.2.0
     def initialize(attrs = {})
+      # we need this hack for Rails 4.0 only
+      # because `run_callbacks` calls `attributes` getter while it is still nil
+      @attributes = {}
+
       run_callbacks :initialize do
         @new_record = true
         @attributes ||= {}

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -15,7 +15,7 @@ module Dynamoid #:nodoc:
 
     # Initialize the attributes we know the class has, in addition to our magic attributes: id, created_at, and updated_at.
     included do
-      class_attribute :attributes
+      class_attribute :attributes, instance_accessor: false
       class_attribute :range_key
 
       self.attributes = {}

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -51,17 +51,19 @@ module Dynamoid #:nodoc:
         end
         self.attributes = attributes.merge(name => {:type => type}.merge(options))
 
-        define_method(named) { read_attribute(named) }
-        define_method("#{named}?") do
-          value = read_attribute(named)
-          case value
-          when true        then true
-          when false, nil  then false
-          else
-            !value.nil?
+        generated_methods.module_eval do
+          define_method(named) { read_attribute(named) }
+          define_method("#{named}?") do
+            value = read_attribute(named)
+            case value
+            when true        then true
+            when false, nil  then false
+            else
+              !value.nil?
+            end
           end
+          define_method("#{named}=") {|value| write_attribute(named, value) }
         end
-        define_method("#{named}=") {|value| write_attribute(named, value) }
       end
 
       def range(name, type = :string)
@@ -80,9 +82,22 @@ module Dynamoid #:nodoc:
       def remove_field(field)
         field = field.to_sym
         attributes.delete(field) or raise "No such field"
-        remove_method field
-        remove_method :"#{field}="
-        remove_method :"#{field}?"
+
+        generated_methods.module_eval do
+          remove_method field
+          remove_method :"#{field}="
+          remove_method :"#{field}?"
+        end
+      end
+
+      private
+
+      def generated_methods
+        @generated_methods ||= begin
+          Module.new.tap do |mod|
+            include(mod)
+          end
+        end
       end
     end
 

--- a/lib/dynamoid/indexes.rb
+++ b/lib/dynamoid/indexes.rb
@@ -3,8 +3,8 @@ module Dynamoid
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :local_secondary_indexes
-      class_attribute :global_secondary_indexes
+      class_attribute :local_secondary_indexes, instance_accessor: false
+      class_attribute :global_secondary_indexes, instance_accessor: false
       self.local_secondary_indexes = {}
       self.global_secondary_indexes = {}
     end

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -58,21 +58,21 @@ describe Dynamoid::Document do
   end
 
   it 'allows interception of write_attribute on load' do
-    class Model
+    klass = Class.new do
       include Dynamoid::Document
       field :city
       def city=(value); self[:city] = value.downcase; end
     end
-    expect(Model.new(:city => "Chicago").city).to eq "chicago"
+    expect(klass.new(:city => "Chicago").city).to eq "chicago"
   end
 
   it 'ignores unknown fields (does not raise error)' do
-    class Model
+    klass = Class.new do
       include Dynamoid::Document
       field :city
     end
 
-    model = Model.new(:unknown_field => "test", :city => "Chicago")
+    model = klass.new(:unknown_field => "test", :city => "Chicago")
     expect(model.city).to eql "Chicago"
   end
 

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -215,4 +215,36 @@ describe Dynamoid::Fields do
     end
   end
 
+  context 'extention overides field accessors' do
+    let(:klass) {
+      extention = Module.new do
+        def name
+          super.upcase
+        end
+
+        def name=(s)
+          super(s.try(:downcase))
+        end
+      end
+
+      Class.new do
+        include Dynamoid::Document
+        include extention
+
+        field :name
+      end
+    }
+
+    it 'can access new setter' do
+      address = klass.new
+      address.name = 'AB cd'
+      expect(address[:name]).to eq('ab cd')
+    end
+
+    it 'can access new getter' do
+      address = klass.new
+      address.name = 'ABcd'
+      expect(address.name).to eq('ABCD')
+    end
+  end
 end


### PR DESCRIPTION
Currently when you declare fields in a model we generate fields accessors right in the model class.
If we want to write an extension (as a separate module) which should override field getter/setter and add some functionality we aren't able to do this.

Example of such extension is `simple_enum` project (https://github.com/lwe/simple_enum).

There is a solution. We can find it in the `mongoid` project: getters and setters declare in a separate module which includes as early as possible so any other module is able to override generated methods.

`mongoid` approach:
module creation - https://github.com/mongodb/mongoid/blob/master/lib/mongoid/fields.rb#L412
dynamic method declaration - https://github.com/mongodb/mongoid/blob/master/lib/mongoid/fields.rb#L412 

Example of using extension:

```ruby
module Extention
  def name
    super.upcase
  end

  def name=(s)
    super(s.try(:downcase))
  end
end

class User
  include Dynamoid::Document
  include extention

  field :name
end

user = User.new(name: 'AB cd')
user.name
#=> 'AB CD'

```