### PR TITLE
Remove declaration for `logger` option

### DIFF
--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -13,7 +13,6 @@ module Dynamoid
     # All the default options.
     option :adapter, :default => 'aws_sdk_v2'
     option :namespace, :default => defined?(Rails) ? "dynamoid_#{Rails.application.class.parent_name}_#{Rails.env}" : "dynamoid"
-    option :logger, :default => defined?(Rails)
     option :access_key, :default => nil
     option :secret_key, :default => nil
     option :region, :default => nil


### PR DESCRIPTION
Currently there is a declaration of `logger` option which define `logger`, `logger=`, `logger?` and 'reset_logger' methods. getter and setters are overridden later. It breaks `logger?` and `reset_logger' methods and default value is completely ignored.

```
option :logger, :default => defined?(Rails)

...

def logger
  @logger ||= default_logger
end

def logger=(logger)
  case logger
  when false, nil then @logger = nil
  when true then @logger = default_logger
  else
    @logger = logger if logger.respond_to?(:info)
  end
end

```
So not to confuse anybody I believe we have two choses - improve options mechanism and support custom setter/getter or just not to declare logger as option.