### PR TITLE
Add :application_timezone option

### DIFF
--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -30,6 +30,7 @@ module Dynamoid
     option :sync_retry_wait_seconds, :default => 2
     option :convert_big_decimal, :default => false
     option :models_dir, :default => "app/models" # perhaps you keep your dynamoid models in a different directory?
+    option :application_timezone, default: :local # available values - :utc, :local, time zone names
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.
     #

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -118,7 +118,16 @@ module Dynamoid
                 if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)
                   value
                 else
-                  Time.at(value).to_datetime
+                  timestamp_in_utc = value
+                  time_zone = case Dynamoid::Config.application_timezone
+                               when :utc
+                                 'UTC'
+                               when :local
+                                 Time.now.utc_offset
+                               when String
+                                 Dynamoid::Config.application_timezone
+                             end
+                  ActiveSupport::TimeZone[time_zone].at(timestamp_in_utc).to_datetime
                 end
               when :date
                 if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -223,9 +223,29 @@ describe Dynamoid::Persistence do
     end
   end
 
-  it 'dumps datetime attributes' do
-    @user = User.create(:name => 'Josh')
-    expect(@user.send(:dump)[:name]).to eq 'Josh'
+  context 'when dumps datetime attribute' do
+    it 'loads time in local time zone if config.application_timezone == :local', application_timezone: :local do
+      time = Time.now
+      user = User.create(last_logged_in_at: time)
+      user = User.find(user.id)
+      expect(user.last_logged_in_at).to be_a(DateTime)
+      # we can't compare objects directly because lose precision of milliseconds in conversions
+      expect(user.last_logged_in_at.to_s).to eq time.to_datetime.to_s
+    end
+
+    it 'loads time in specified time zone if config.application_timezone == time zone name', application_timezone: 'Hawaii' do
+      time = '2017-06-20 08:00:00 +0300'.to_time
+      user = User.create(last_logged_in_at: time)
+      user = User.find(user.id)
+      expect(user.last_logged_in_at).to eq '2017-06-19 19:00:00 -1000'.to_datetime # Hawaii UTC-10
+    end
+
+    it 'loads time in UTC if config.application_timezone = :utc', application_timezone: :utc do
+      time = '2017-06-20 08:00:00 +0300'.to_time
+      user = User.create(last_logged_in_at: time)
+      user = User.find(user.id)
+      expect(user.last_logged_in_at).to eq '2017-06-20 05:00:00 +0000'.to_datetime
+    end
   end
 
   it 'dumps date attributes' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,4 +70,13 @@ RSpec.configure do |config|
   config.around :each do |ex|
     ex.run_with_retry retry: 3
   end
+
+  config.around :each, :application_timezone do |example|
+    application_timezone_old = Dynamoid::Config.application_timezone
+    Dynamoid::Config.application_timezone = example.metadata[:application_timezone]
+
+    example.run
+
+    Dynamoid::Config.application_timezone = application_timezone_old
+  end
 end


### PR DESCRIPTION
When we load datetime field from the storage it is in the system time zone.

I propose to introduce application time zone like it's done in `ActiveRecord` and `Sequel` and convert all datetime fields into specified time zone.

It doesn't change default behavior because default value is a system time zone.

Examples:

```
Dynamoid::Config.application_timezone = :utc
Dynamoid::Config.application_timezone = :local
Dynamoid::Config.application_timezone = 'Eastern Time (US & Canada)'
```