### PR TITLE
Added Rails.root. Unable to find models without it.

### DIFF
--- a/lib/dynamoid/tasks/database.rake
+++ b/lib/dynamoid/tasks/database.rake
@@ -5,7 +5,7 @@ namespace :dynamoid do
   desc "Creates DynamoDB tables, one for each of your Dynamoid models - does not modify pre-existing tables"
   task :create_tables => :environment do
     # Load models so Dynamoid will be able to discover tables expected.
-    Dir[ File.join(Dynamoid::Config.models_dir, "*.rb") ].sort.each { |file| require file }
+    Dir[ File.join(Rails.root, Dynamoid::Config.models_dir, "*.rb") ].sort.each { |file| require file }
     if Dynamoid.included_models.any?
       tables = Dynamoid::Tasks::Database.create_tables
       result = tables[:created].map{ |c| "#{c} created" } + tables[:existing].map{ |e| "#{e} already exists" }


### PR DESCRIPTION
The rake task would not work for me until I added `Rails.root` to the `File.join`. This was true on two different machines running Rails 5.

Not sure what else you want to know for this minor change :)