### PR TITLE
Allow consistent reading for Scan request

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -521,9 +521,11 @@ module Dynamoid
       def scan(table_name, scan_hash, select_opts = {})
         limit = select_opts.delete(:limit)
         batch = select_opts.delete(:batch_size)
+        consistent_read = select_opts.delete(:consistent_read)
 
         request = { table_name: table_name }
         request[:limit] = batch || limit if batch || limit
+        request[:consistent_read] = true if consistent_read
 
         if scan_hash.present?
           request[:scan_filter] = scan_hash.reduce({}) do |memo, (attr, cond)|

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -148,10 +148,6 @@ module Dynamoid #:nodoc:
           Dynamoid.logger.warn "You can index this query by adding this to #{source.to_s.downcase}.rb: index [#{query.keys.sort.collect{|attr| ":#{attr}"}.join(', ')}]"
         end
 
-        if @consistent_read
-          raise Dynamoid::Errors::InvalidQuery, 'Consistent read is not supported by SCAN operation'
-        end
-
         Enumerator.new do |yielder|
           Dynamoid.adapter.scan(source.table_name, scan_query, scan_opts).each do |hash|
             yielder.yield source.from_database(hash)
@@ -271,6 +267,7 @@ module Dynamoid #:nodoc:
         opts[:limit] = @eval_limit if @eval_limit
         opts[:next_token] = start_key if @start
         opts[:batch_size] = @batch_size if @batch_size
+        opts[:consistent_read] = true if @consistent_read
         opts
       end
     end

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -83,10 +83,10 @@ describe Dynamoid::Criteria do
     Tweet.where(:tweet_id => 'xx', :group => 'two').all
   end
 
-  it 'raises exception when consistent_read is used with scan' do
+  it 'does not raise exception when consistent_read is used with scan' do
     expect do
       User.where(:password => 'password').consistent.first
-    end.to raise_error(Dynamoid::Errors::InvalidQuery)
+    end.not_to raise_error(Dynamoid::Errors::InvalidQuery)
   end
 
 


### PR DESCRIPTION
Currently only Query request can make consistent read but according to documentation Scan can read consistently too.

(http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html) 