### PR TITLE
Documenting validation skipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ end
 
 To see more usage and examples of ActiveModel validations, check out the [ActiveModel validation documentation](http://api.rubyonrails.org/classes/ActiveModel/Validations.html).
 
+If you want to bypass model validation, pass `validate: false` to `save` call:
+
+```ruby
+model.save(validate: false)
+```
+
 ### Callbacks
 
 Dynamoid also employs ActiveModel callbacks. Right now, callbacks are defined on ```save```, ```update```, ```destroy```, which allows you to do ```before_``` or ```after_``` any of those.

--- a/spec/dynamoid/validations_spec.rb
+++ b/spec/dynamoid/validations_spec.rb
@@ -45,4 +45,16 @@ describe Dynamoid::Validations do
     doc = doc_class.create!(:name => 'test')
     expect(doc.errors).to be_empty
   end
+
+  it 'does not validate when saves if `validate` option is false' do
+    model = Class.new do
+      include Dynamoid::Document
+      table name: :documents
+
+      field :name
+      validates :name, presence: true
+    end
+
+    expect(model.new.save(validate: false)).to be_persisted
+  end
 end


### PR DESCRIPTION
Document `model.save(validate: false)` to skip validation