### PR TITLE
Don’t override document timestamps

### DIFF
--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -161,14 +161,16 @@ module Dynamoid #:nodoc:
     #
     # @since 0.2.0
     def set_created_at
-      self.created_at = DateTime.now.in_time_zone(Time.zone) if Dynamoid::Config.timestamps
+      self.created_at ||= DateTime.now.in_time_zone(Time.zone) if Dynamoid::Config.timestamps
     end
 
     # Automatically called during the save callback to set the updated_at time.
     #
     # @since 0.2.0
     def set_updated_at
-      self.updated_at = DateTime.now.in_time_zone(Time.zone) if Dynamoid::Config.timestamps
+      if Dynamoid::Config.timestamps && !self.updated_at_changed?
+        self.updated_at = DateTime.now.in_time_zone(Time.zone)
+      end
     end
 
     def set_type

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -87,10 +87,43 @@ describe Dynamoid::Fields do
       expect(address.id).to eq original_id
     end
 
-    it 'should update only created_at when no params are passed' do
+    it 'should update only updated_at when no params are passed' do
       initial_updated_at = address.updated_at
       address.update_attributes([])
       expect(address.updated_at).to_not eq initial_updated_at
+    end
+
+    context 'when timestamps are specified' do
+      it 'uses specified created_at at creation' do
+        time = Time.now - 1.day
+        address = Address.create!(created_at: time)
+        expect(address.created_at).to eq(time)
+      end
+
+      it 'uses specified updated_at at creation' do
+        time = Time.now - 1.day
+        address = Address.create!(updated_at: time)
+        expect(address.updated_at).to eq(time)
+      end
+
+      it 'uses specified updated_at at updating' do
+        time = Time.now - 1.day
+
+        expect do
+          address.city = 'foobar'
+          address.updated_at = time
+          address.save!
+        end.to change { address.updated_at }.to(time)
+      end
+
+      it 'changes updated_at at updating' do
+        expect do
+          address.city = 'foobar'
+          address.save!
+        end.to change { address.updated_at }
+
+        expect(address.updated_at).to be_present
+      end
     end
 
     it 'adds in dirty methods for attributes' do


### PR DESCRIPTION
Currently `Dynamoid` sets `created_at`/`updated_at` fields and overrides specified values e.g.

```
Document.create(name: 'foobar', created_at: '...', updated_at: '...')
```

specified values of timestamps are ignored.

This PR fixes the behaviour.