### PR TITLE
Improve querying with scan and query

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,28 @@ Address.all(batch_size: 100).each { |address| address.do_some_work; sleep(0.01) 
 Address.eval_limit(10_000).batch(100). each { … } #batch specified as part of a chain
 ```
 
+You are able to optimize query with condition for sort key. Following
+operators are available: `gt`, `lt`, `gte`, `lte`, `begins_with`, `between` as well as equality:
+
+```ruby
+Address.where(latitude: 10212)
+Address.where('latitude.gt': 10212)
+Address.where('latitude.lt': 10212)
+Address.where('latitude.gte': 10212)
+Address.where('latitude.lte': 10212)
+Address.where('city.begins_with': 'Lon')
+Address.where('latitude.between': [10212, 20000])
+```
+
+You are able filter result on the DynamoDB side and specify conditions for non-key fields.
+There ara avalable additional operators: `in`, `contains`, `not_contains`:
+
+```ruby
+Address.where('city.in': ['London', 'Edenburg', 'Birmingham'])
+Address.where('city.contains': [on])
+Address.where('city.not_contains': [ing])
+```
+
 ### Consistent Reads
 
 Querying supports consistent reading. By default, DynamoDB reads are eventually consistent: if you do a write and then a read immediately afterwards, the results of the previous write may not be reflected. If you need to do a consistent read (that is, you need to read the results of a write immediately) you can do so, but keep in mind that consistent reads are twice as expensive as regular reads for DynamoDB.

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -13,6 +13,21 @@ module Dynamoid
           range_between:      'BETWEEN',
           range_eq:           'EQ'
       }
+
+      # Don't implement NULL and NOT_NULL because it doesn't make seanse -
+      # we declare schema in models
+      FIELD_MAP = {
+          eq:           'EQ',
+          gt:           'GT',
+          lt:           'LT',
+          gte:          'GE',
+          lte:          'LE',
+          begins_with:  'BEGINS_WITH',
+          between:      'BETWEEN',
+          in:           'IN',
+          contains:     'CONTAINS',
+          not_contains: 'NOT_CONTAINS'
+      }
       HASH_KEY  = "HASH".freeze
       RANGE_KEY = "RANGE".freeze
       STRING_TYPE  = "S".freeze
@@ -419,8 +434,8 @@ module Dynamoid
       # @todo Provide support for various other options http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#query-instance_method
       def query(table_name, opts = {})
         table = describe_table(table_name)
-        hk    = (opts[:hash_key].present? ? opts[:hash_key] : table.hash_key).to_s
-        rng   = (opts[:range_key].present? ? opts[:range_key] : table.range_key).to_s
+        hk    = (opts[:hash_key].present? ? opts.delete(:hash_key) : table.hash_key).to_s
+        rng   = (opts[:range_key].present? ? opts.delete(:range_key) : table.range_key).to_s
         q     = opts.slice(
                   :consistent_read,
                   :scan_index_forward,
@@ -464,8 +479,19 @@ module Dynamoid
           }
         end
 
+        query_filter = {}
+        opts.reject {|k,_| k.in? RANGE_MAP.keys}.each do |attr, hash|
+          query_filter[attr] = {
+            comparison_operator: FIELD_MAP[hash.keys[0]],
+            attribute_value_list: [
+              hash.values[0].freeze
+            ].flatten # Flatten as BETWEEN operator specifies array of two elements
+          }
+        end
+
         q[:table_name]     = table_name
         q[:key_conditions] = key_conditions
+        q[:query_filter]   = query_filter
 
         Enumerator.new { |y|
           loop do

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -188,13 +188,8 @@ module Dynamoid #:nodoc:
         opts.merge(query_opts).merge(consistent_opts)
       end
 
-      def query_keys
-        query.keys.collect{|k| k.to_s.split('.').first}
-      end
-
-      # [hash_key] or [hash_key, range_key] is specified in query keys.
       def key_present?
-        query_keys == [source.hash_key.to_s] || (query_keys.to_set == [source.hash_key.to_s, source.range_key.to_s].to_set)
+        query.keys.map(&:to_sym).include?(source.hash_key.to_sym)
       end
 
       def start_key

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -122,16 +122,14 @@ module Dynamoid
                 if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)
                   value
                 else
-                  timestamp_in_utc = value
-                  time_zone = case Dynamoid::Config.application_timezone
-                               when :utc
-                                 'UTC'
-                               when :local
-                                 Time.now.utc_offset
-                               when String
-                                 Dynamoid::Config.application_timezone
-                             end
-                  ActiveSupport::TimeZone[time_zone].at(timestamp_in_utc).to_datetime
+                  case Dynamoid::Config.application_timezone
+                    when :utc
+                      ActiveSupport::TimeZone['UTC'].at(value).to_datetime
+                    when :local
+                      Time.at(value).to_datetime
+                    when String
+                      ActiveSupport::TimeZone[Dynamoid::Config.application_timezone].at(value).to_datetime
+                  end
                 end
               when :date
                 if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -355,21 +355,21 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     it 'performs scan on a table and returns items' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.scan(test_table1, :name => 'Josh').to_a).to eq [{ :id=> '1', :name=>"Josh" }]
+      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ :id=> '1', :name=>"Josh" }]
     end
 
     it 'performs scan on a table and returns items if there are multiple items but only one match' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
 
-      expect(Dynamoid.adapter.scan(test_table1, :name => 'Josh').to_a).to eq [{ :id=> '1', :name=>"Josh" }]
+      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ :id=> '1', :name=>"Josh" }]
     end
 
     it 'performs scan on a table and returns multiple items if there are multiple matches' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.scan(test_table1, :name => 'Josh')).to include({:name=>"Josh", :id=>"2"}, {:name=>"Josh", :id=>"1"})
+      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'})).to include({:name=>"Josh", :id=>"2"}, {:name=>"Josh", :id=>"1"})
     end
 
     it 'performs scan on a table and returns all items if no criteria are specified' do

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -20,9 +20,16 @@ describe Dynamoid::Criteria::Chain do
       chain.all
     end
 
+    it 'Queries when query contains ID' do
+      chain = Dynamoid::Criteria::Chain.new(Address)
+      chain.query = { :id => 'test', city: 'Bucharest' }
+      expect(chain).to receive(:records_via_query)
+      chain.all
+    end
+
     it 'Scans when query includes keys that are neither a hash nor a range' do
       chain = Dynamoid::Criteria::Chain.new(Address)
-      chain.query = { :id => 'test', :city => 'Bucharest' }
+      chain.query = { :city => 'Bucharest' }
       expect(chain).to receive(:records_via_scan)
       chain.all
     end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -42,6 +42,195 @@ describe Dynamoid::Criteria::Chain do
     end
   end
 
+  describe 'Query with keys conditions' do
+    let(:model) {
+      Class.new do
+        include Dynamoid::Document
+        table name: :customer, key: :name
+        range :age, :integer
+      end
+    }
+
+    it 'supports eq' do
+      customer1 = model.create(name: 'Bob', age: 10)
+      customer2 = model.create(name: 'Bob', age: 30)
+
+      expect(model.where(name: 'Bob', age: '10').all).to contain_exactly(customer1)
+    end
+
+    it 'supports lt' do
+      customer1 = model.create(name: 'Bob', age: 5)
+      customer2 = model.create(name: 'Bob', age: 9)
+      customer3 = model.create(name: 'Bob', age: 12)
+
+      expect(model.where(name: 'Bob', 'age.lt' => 10).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports gt' do
+      customer1 = model.create(name: 'Bob', age: 11)
+      customer2 = model.create(name: 'Bob', age: 12)
+      customer3 = model.create(name: 'Bob', age: 9)
+
+      expect(model.where(name: 'Bob', 'age.gt' => 10).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports lte' do
+      customer1 = model.create(name: 'Bob', age: 5)
+      customer2 = model.create(name: 'Bob', age: 9)
+      customer3 = model.create(name: 'Bob', age: 12)
+
+      expect(model.where(name: 'Bob', 'age.lte' => 9).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports gte' do
+      customer1 = model.create(name: 'Bob', age: 11)
+      customer2 = model.create(name: 'Bob', age: 12)
+      customer3 = model.create(name: 'Bob', age: 9)
+
+      expect(model.where(name: 'Bob', 'age.gte' => 11).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports begins_with' do
+      model = Class.new do
+        include Dynamoid::Document
+        table name: :customer, key: :name
+        range :job_title, :string
+      end
+
+      customer1 = model.create(name: 'Bob', job_title: 'Environmental Air Quality Consultant')
+      customer2 = model.create(name: 'Bob', job_title: 'Environmental Project Manager')
+      customer3 = model.create(name: 'Bob', job_title: 'Creative Consultant')
+
+      expect(model.where(name: 'Bob', 'job_title.begins_with' => 'Environmental').all)
+        .to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports between' do
+      customer1 = model.create(name: 'Bob', age: 10)
+      customer2 = model.create(name: 'Bob', age: 20)
+      customer3 = model.create(name: 'Bob', age: 30)
+      customer4 = model.create(name: 'Bob', age: 40)
+
+      expect(model.where(name: 'Bob', 'age.between' => [19, 31]).all).to contain_exactly(customer2, customer3)
+    end
+  end
+
+  # http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.QueryFilter.html?shortFooter=true
+  describe 'Query with not-keys conditions' do
+    let(:model) {
+      Class.new do
+        include Dynamoid::Document
+        table name: :customer, key: :name
+        range :last_name
+        field :age, :integer
+      end
+    }
+
+    it 'supports eq' do
+      customer1 = model.create(name: 'a', last_name: 'a', age: 10)
+      customer2 = model.create(name: 'a', last_name: 'b', age: 30)
+
+      expect(model.where(name: 'a', age: '10').all).to contain_exactly(customer1)
+    end
+
+    it 'supports lt' do
+      customer1 = model.create(name: 'a', last_name: 'a', age: 5)
+      customer2 = model.create(name: 'a', last_name: 'b', age: 9)
+      customer3 = model.create(name: 'a', last_name: 'c', age: 12)
+
+      expect(model.where(name: 'a', 'age.lt' => 10).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports gt' do
+      customer1 = model.create(name: 'a', last_name: 'a', age: 11)
+      customer2 = model.create(name: 'a', last_name: 'b', age: 12)
+      customer3 = model.create(name: 'a', last_name: 'c', age: 9)
+
+      expect(model.where(name: 'a', 'age.gt' => 10).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports lte' do
+      customer1 = model.create(name: 'a', last_name: 'a', age: 5)
+      customer2 = model.create(name: 'a', last_name: 'b', age: 9)
+      customer3 = model.create(name: 'a', last_name: 'c', age: 12)
+
+      expect(model.where(name: 'a', 'age.lte' => 9).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports gte' do
+      customer1 = model.create(name: 'a', last_name: 'a', age: 11)
+      customer2 = model.create(name: 'a', last_name: 'b', age: 12)
+      customer3 = model.create(name: 'a', last_name: 'c', age: 9)
+
+      expect(model.where(name: 'a', 'age.gte' => 11).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports begins_with' do
+      model = Class.new do
+        include Dynamoid::Document
+        table name: :customer, key: :name
+        range :last_name
+        field :job_title, :string
+      end
+
+      customer1 = model.create(name: 'a', last_name: 'a', job_title: 'Environmental Air Quality Consultant')
+      customer2 = model.create(name: 'a', last_name: 'b', job_title: 'Environmental Project Manager')
+      customer3 = model.create(name: 'a', last_name: 'c', job_title: 'Creative Consultant')
+
+      expect(model.where(name: 'a', 'job_title.begins_with' => 'Environmental').all)
+        .to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports between' do
+      customer1 = model.create(name: 'a', last_name: 'a', age: 10)
+      customer2 = model.create(name: 'a', last_name: 'b', age: 20)
+      customer3 = model.create(name: 'a', last_name: 'c', age: 30)
+      customer4 = model.create(name: 'a', last_name: 'd', age: 40)
+
+      expect(model.where(name: 'a', 'age.between' => [19, 31]).all).to contain_exactly(customer2, customer3)
+    end
+
+    it 'supports in' do
+      customer1 = model.create(name: 'a', last_name: 'a', age: 10)
+      customer2 = model.create(name: 'a', last_name: 'b', age: 20)
+      customer3 = model.create(name: 'a', last_name: 'c', age: 30)
+
+      expect(model.where(name: 'a', 'age.in' => [10, 20]).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports contains' do
+      model = Class.new do
+        include Dynamoid::Document
+        table name: :customer, key: :name
+        range :last_name
+        field :job_title, :string
+      end
+
+      customer1 = model.create(name: 'a', last_name: 'a', job_title: 'Environmental Air Quality Consultant')
+      customer2 = model.create(name: 'a', last_name: 'b', job_title: 'Environmental Project Manager')
+      customer3 = model.create(name: 'a', last_name: 'c', job_title: 'Creative Consultant')
+
+      expect(model.where(name: 'a', 'job_title.contains' => 'Consul').all)
+        .to contain_exactly(customer1, customer3)
+    end
+
+    it 'supports not_contains' do
+      model = Class.new do
+        include Dynamoid::Document
+        table name: :customer, key: :name
+        range :last_name
+        field :job_title, :string
+      end
+
+      customer1 = model.create(name: 'a', last_name: 'a', job_title: 'Environmental Air Quality Consultant')
+      customer2 = model.create(name: 'a', last_name: 'b', job_title: 'Environmental Project Manager')
+      customer3 = model.create(name: 'a', last_name: 'c', job_title: 'Creative Consultant')
+
+      expect(model.where(name: 'a', 'job_title.not_contains' => 'Consul').all)
+        .to contain_exactly(customer2)
+    end
+  end
+
   describe 'User' do
     let(:chain) { described_class.new(User) }
 

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -231,6 +231,101 @@ describe Dynamoid::Criteria::Chain do
     end
   end
 
+  # http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.ScanFilter.html?shortFooter=true
+  describe 'Scan conditions ' do
+    let(:model) {
+      Class.new do
+        include Dynamoid::Document
+        table name: :customer
+        field :age, :integer
+        field :job_title, :string
+      end
+    }
+
+    it 'supports eq' do
+      customer1 = model.create(age: 10)
+      customer2 = model.create(age: 30)
+
+      expect(model.where(age: '10').all).to contain_exactly(customer1)
+    end
+
+    it 'supports lt' do
+      customer1 = model.create(age: 5)
+      customer2 = model.create(age: 9)
+      customer3 = model.create(age: 12)
+
+      expect(model.where('age.lt' => 10).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports gt' do
+      customer1 = model.create(age: 11)
+      customer2 = model.create(age: 12)
+      customer3 = model.create(age: 9)
+
+      expect(model.where('age.gt' => 10).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports lte' do
+      customer1 = model.create(age: 5)
+      customer2 = model.create(age: 9)
+      customer3 = model.create(age: 12)
+
+      expect(model.where('age.lte' => 9).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports gte' do
+      customer1 = model.create(age: 11)
+      customer2 = model.create(age: 12)
+      customer3 = model.create(age: 9)
+
+      expect(model.where('age.gte' => 11).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports begins_with' do
+      customer1 = model.create(job_title: 'Environmental Air Quality Consultant')
+      customer2 = model.create(job_title: 'Environmental Project Manager')
+      customer3 = model.create(job_title: 'Creative Consultant')
+
+      expect(model.where('job_title.begins_with' => 'Environmental').all)
+        .to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports between' do
+      customer1 = model.create(age: 10)
+      customer2 = model.create(age: 20)
+      customer3 = model.create(age: 30)
+      customer4 = model.create(age: 40)
+
+      expect(model.where('age.between' => [19, 31]).all).to contain_exactly(customer2, customer3)
+    end
+
+    it 'supports in' do
+      customer1 = model.create(age: 10)
+      customer2 = model.create(age: 20)
+      customer3 = model.create(age: 30)
+
+      expect(model.where('age.in' => [10, 20]).all).to contain_exactly(customer1, customer2)
+    end
+
+    it 'supports contains' do
+      customer1 = model.create(job_title: 'Environmental Air Quality Consultant')
+      customer2 = model.create(job_title: 'Environmental Project Manager')
+      customer3 = model.create(job_title: 'Creative Consultant')
+
+      expect(model.where('job_title.contains' => 'Consul').all)
+        .to contain_exactly(customer1, customer3)
+    end
+
+    it 'supports not_contains' do
+      customer1 = model.create(job_title: 'Environmental Air Quality Consultant')
+      customer2 = model.create(job_title: 'Environmental Project Manager')
+      customer3 = model.create(job_title: 'Creative Consultant')
+
+      expect(model.where('job_title.not_contains' => 'Consul').all)
+        .to contain_exactly(customer2)
+    end
+  end
+
   describe 'User' do
     let(:chain) { described_class.new(User) }
 


### PR DESCRIPTION
Improving:
- use Query instead of Scan if there are no conditions for sort (range) key in `where` clause
- allow all (provided by DynamoDB) condition operators for non-key fields for Query request (added `in`, `contains`, `not_contains`)
- allow all (provided by DynamoDB) condition operators for Scan request - was available only equality condition

So now we can do following queries:

```ruby
Model.where(partition_key: '', 'field1.in': [1, 2, 3]) # => use Query
Model.where('field1.gt': 10, 'field2.begins_with': 'abc') # => use Scan
```

I continue to use deprecated KeyConditions, QueryFilter and ScanFilter. They are limited and should be replaced with KeyConditionExpression and FilterExpression.

Related issue https://github.com/Dynamoid/Dynamoid/issues/6