### PR TITLE
Fix storing empty array as nil

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -397,7 +397,7 @@ module Dynamoid
         options ||= {}
 
         object.each do |k, v|
-          next if v.nil? || (v.respond_to?(:empty?) && v.empty?)
+          next if v.nil? || ((v.is_a?(Set) || v.is_a?(String)) && v.empty?)
           item[k.to_s] = v
         end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -302,6 +302,21 @@ describe Dynamoid::Persistence do
     expect(u.favorite_colors).to eq Set.new
   end
 
+  it 'supports array being empty' do
+    user = User.create(todo_list: [])
+    expect(User.find(user.id).todo_list).to eq []
+  end
+
+  it 'saves empty set as nil' do
+    tweet = Tweet.create(group: "one", tags: [])
+    expect(Tweet.find_by_tweet_id(tweet.tweet_id).tags).to eq nil
+  end
+
+  it 'saves empty string as nil' do
+    user = User.create(name: '')
+    expect(User.find(user.id).name).to eq nil
+  end
+
   it 'supports container types being nil' do
     u = User.create(name: 'Philip')
     u.todo_list = nil


### PR DESCRIPTION
Dynamoid stores empty collections (strings, arrays, sets...) as nil but according to documentations only string and set can't be nil

http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Document

Open issue https://github.com/Dynamoid/Dynamoid/issues/8