### PR TITLE
Remove unuseful warning about item size exceeding limits

### DIFF
--- a/lib/dynamoid.rb
+++ b/lib/dynamoid.rb
@@ -36,8 +36,6 @@ end
 module Dynamoid
   extend self
 
-  MAX_ITEM_SIZE = 65_536
-
   def configure
     block_given? ? yield(Dynamoid::Config) : Dynamoid::Config
   end

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -112,10 +112,6 @@ module Dynamoid #:nodoc:
     #
     # @since 0.2.0
     def write_attribute(name, value)
-      if (size = value.to_s.size) > MAX_ITEM_SIZE
-        Dynamoid.logger.warn "DynamoDB can't store items larger than #{MAX_ITEM_SIZE} and the #{name} field has a length of #{size}."
-      end
-
       if association = @associations[name]
         association.reset
       end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -149,11 +149,10 @@ describe Dynamoid::Fields do
     end
   end
 
-  it "gives a warning when setting a single value larger than the maximum item size" do
-    expect(Dynamoid.logger).to receive(:warn) do |input|
-      expect(input).to include "city field has a length of 66000"
-    end
-    Address.new city: ("Ten chars " * 6_600)
+  it "raises an exception when items size exceeds 400kb" do
+    expect {
+      Address.create(city: "Ten chars " * 500_000)
+    }.to raise_error(Aws::DynamoDB::Errors::ValidationException, 'Item size has exceeded the maximum allowed size')
   end
 
   context '.remove_attribute' do


### PR DESCRIPTION
Dynamodb has some limitations for item and fields size but there is no rules to calculate item size in official documentation

I have found only this explanation:
https://stackoverflow.com/a/9018008/219594

So I propose completely remove any logic related to Dynamoid's size limitations like other ORMs don't do this for RDMSs

Open issue https://github.com/Dynamoid/Dynamoid/issues/60