### PR TITLE
Chain: Only query on GSI if projects all

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -272,8 +272,10 @@ module Dynamoid #:nodoc:
 
         # See if can use any global secondary index
         # Chooses the first GSI found that can be utilized for the query
+        # But only do so if projects ALL attributes otherwise we won't
+        # get back full data
         source.global_secondary_indexes.each do |_, gsi|
-          next unless query_keys.include?(gsi.hash_key.to_s)
+          next unless query_keys.include?(gsi.hash_key.to_s) && gsi.projected_attributes == :all
           @hash_key = gsi.hash_key
           @range_key = gsi.range_key
           @index_name = gsi.name


### PR DESCRIPTION
- [Update] Only choose a GSI in chain `where` if the GSI is defined
  to project all fields. The reason being is that GSI with only
  some keys or just `KEYS_ONLY` will not resolve all fields on the
  objects and therefore can be confusing. Should explicitly query
  with `find_all_by_secondary_index` otherwise leave as TODO to
  deal with such cases.
- [Update] Update README discussing GSI implicit querying with
  `where`.

@pboling Just realized a case where this might not return what you'd expect is if GSI doesn't have all the attributes. So I'd rather do this to keep the end result expected with all field values.

I leave the other case as a TODO since it feels like it'd be pretty involved to implement. I feel like the ideal solution would rely on 2 things:

1. Implementing `select` with Chaining 
2. Implementing the logic to determine if can use GSI
  * Determining if table is just the GSI keys then would be okay to use GSI
  * Determining if `select` overlaps with GSI keys then would be okay to use GSI
  * If not, then querying GSI but then knowing to query base table for remaining attributes in `select` or if no `select` then all attributes.

I believe this is the ideal solution for underlying `where` since we'd expect the fully realized objects if we did `where` rather than partials.

Finally I believe this is not necessary for Local Secondary Indexes since from docs:

> When you query a local secondary index, the query can also retrieve attributes that are not projected into the index. DynamoDB will automatically fetch these attributes from the base table, but at a greater latency and with higher provisioned throughput costs.

I did not test this because you have to create the local secondary indexes while creating table and didn't have the time to build such out. 

Side note: Not sure if it's issue with DynamoDB Locally or with testing suite but when I tried testing these things locally in specs it returned all fields but when I tested in a production like environment, I found it returned only the keys specified like expected.