### PR TITLE
Store dates as days count since 1970-01-01

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -13,6 +13,8 @@ module Dynamoid
     attr_accessor :new_record
     alias :new_record? :new_record
 
+    UNIX_EPOCH_DATE = Date.new(1970, 1, 1)
+
     module ClassMethods
 
       def table_name
@@ -135,7 +137,7 @@ module Dynamoid
                 if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)
                   value.to_date
                 else
-                  Date.new(1970, 1, 1) + value.to_i
+                  UNIX_EPOCH_DATE + value.to_i
                 end
               when :boolean
                 # persisted as 't', but because undump is called during initialize it can come in as true
@@ -177,7 +179,7 @@ module Dynamoid
             when :datetime
               !value.nil? ? value.to_time.to_f : nil
             when :date
-              !value.nil? ? (value.to_date - Date.new(1970, 1, 1)).to_i : nil
+              !value.nil? ? (value.to_date - UNIX_EPOCH_DATE).to_i : nil
             when :serialized
               options[:serializer] ? options[:serializer].dump(value) : value.to_yaml
             when :raw

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -13,7 +13,7 @@ module Dynamoid
     attr_accessor :new_record
     alias :new_record? :new_record
 
-    UNIX_EPOCH_DATE = Date.new(1970, 1, 1)
+    UNIX_EPOCH_DATE = Date.new(1970, 1, 1).freeze
 
     module ClassMethods
 

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -135,7 +135,7 @@ module Dynamoid
                 if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)
                   value.to_date
                 else
-                  Time.at(value).to_date
+                  Date.new(1970, 1, 1) + value.to_i
                 end
               when :boolean
                 # persisted as 't', but because undump is called during initialize it can come in as true
@@ -177,7 +177,7 @@ module Dynamoid
             when :datetime
               !value.nil? ? value.to_time.to_f : nil
             when :date
-              !value.nil? ? value.to_time.to_i: nil
+              !value.nil? ? (value.to_date - Date.new(1970, 1, 1)).to_i : nil
             when :serialized
               options[:serializer] ? options[:serializer].dump(value) : value.to_yaml
             when :raw

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -248,9 +248,13 @@ describe Dynamoid::Persistence do
     end
   end
 
-  it 'dumps date attributes' do
-    @user = Address.create(:registered_on => '2017-06-18'.to_date)
-    expect(@user.send(:dump)[:registered_on]).to eq '2017-06-18'.to_time.to_i
+  it 'dumps date attributes', :wip do
+    address = Address.create(:registered_on => '2017-06-18'.to_date)
+    expect(Address.find(address.id).registered_on).to eq '2017-06-18'.to_date
+
+    # check internal format - days since 1970-01-01
+    expect(Address.find(address.id).send(:dump)[:registered_on])
+      .to eq ('2017-06-18'.to_date - Date.new(1970, 1, 1)).to_i
   end
 
   it 'dumps integer attributes' do


### PR DESCRIPTION
Currently we have an issue with storing `date` fields.

`date` fields are stored as Unix timestamps. We convert date to time and vise versa so take into account current time zone. If system time zone changes we can get shift +/- 1 day

I propose to store not seconds but days since Unix epoch `01-01-1970`