### PR TITLE
AWS SDK V2/Chain: Update query/scan limits & batch

### DIFF
--- a/lib/dynamoid/criteria.rb
+++ b/lib/dynamoid/criteria.rb
@@ -6,11 +6,11 @@ module Dynamoid
   # Allows classes to be queried by where, all, first, and each and return criteria chains.
   module Criteria
     extend ActiveSupport::Concern
-    
+
     module ClassMethods
-      
-      [:where, :all, :first, :last, :each, :eval_limit, :start, :scan_index_forward].each do |meth|
-        # Return a criteria chain in response to a method that will begin or end a chain. For more information, 
+
+      [:where, :all, :first, :last, :each, :record_limit, :scan_limit, :batch, :start, :scan_index_forward].each do |meth|
+        # Return a criteria chain in response to a method that will begin or end a chain. For more information,
         # see Dynamoid::Criteria::Chain.
         #
         # @since 0.2.0
@@ -25,5 +25,5 @@ module Dynamoid
       end
     end
   end
-  
+
 end

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -83,8 +83,19 @@ module Dynamoid #:nodoc:
         end
       end
 
-      def eval_limit(limit)
-        @eval_limit = limit
+      # The record limit which is the limit of evaluated records returned by
+      # the query or scan.
+      def record_limit(limit)
+        @record_limit = limit
+        self
+      end
+
+      # The scan limit which is the limit of records that DynamoDB will
+      # internally query or scan. This is different from the record limit
+      # as with filtering DynamoDB may look at N scanned records but return 0
+      # records if none pass the filter.
+      def scan_limit(limit)
+        @scan_limit = limit
         self
       end
 
@@ -312,7 +323,8 @@ module Dynamoid #:nodoc:
         opts = {}
         opts[:index_name] = @index_name if @index_name
         opts[:select] = 'ALL_ATTRIBUTES'
-        opts[:limit] = @eval_limit if @eval_limit
+        opts[:record_limit] = @record_limit if @record_limit
+        opts[:scan_limit] = @scan_limit if @scan_limit
         opts[:next_token] = start_key if @start
         opts[:scan_index_forward] = @scan_index_forward
         opts
@@ -333,7 +345,8 @@ module Dynamoid #:nodoc:
 
       def scan_opts
         opts = {}
-        opts[:limit] = @eval_limit if @eval_limit
+        opts[:record_limit] = @record_limit if @record_limit
+        opts[:scan_limit] = @scan_limit if @scan_limit
         opts[:next_token] = start_key if @start
         opts[:batch_size] = @batch_size if @batch_size
         opts[:consistent_read] = true if @consistent_read

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -21,86 +21,182 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
   end
 
   #
-  # Tests adapter against ranged tables
+  # Test limit controls in querys and scans
   #
-  shared_examples 'range queries' do
-    before do
-      Dynamoid.adapter.put_item(test_table3, {:id => "1", :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => "1", :range => 3.0})
+  # Since query and scans have different interface, then including this shared example
+  # requires some inputs. You'll also need to define `dynamo_request` which takes in
+  # the `table_name`, `scan_hash`, and `select_opts` as if it were a scan and transform
+  # and call the appropriate query or scan.
+  #
+  # @param [Symbol] request_type the name of the request, either :query or :scan
+  # @param [Hash] request_params the default hash in requests such as that for :query
+  #
+  shared_examples 'correctly handling limits' do |request_type, request_params|
+    context 'multiple name entities' do
+      before(:each) do
+        (1..4).each do |i|
+          Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => i.to_f})
+          Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Pascal', :range => (i + 4).to_f})
+        end
+      end
+
+      it 'returns correct records' do
+        expect(dynamo_request(test_table3, request_params, {}).count).to eq(8)
+      end
+
+      it 'returns correct record limit' do
+        expect(dynamo_request(test_table3, request_params, {record_limit: 1}).count).to eq(1)
+        expect(dynamo_request(test_table3, request_params, {record_limit: 3}).count).to eq(3)
+      end
+
+      it 'returns correct batch' do
+        # Receives 8 times for each item and 1 more for empty page
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(9).times.and_call_original
+        expect(dynamo_request(test_table3, request_params, {batch_size: 1}).count).to eq(8)
+      end
+
+      it 'returns correct batch and paginates in batches' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(3).times.and_call_original
+        expect(dynamo_request(test_table3, request_params, {batch_size: 3}).count).to eq(8)
+      end
+
+      it 'returns correct record limit and batch' do
+        expect(dynamo_request(test_table3, request_params, {record_limit: 1, batch_size: 1}).count).to eq(1)
+      end
+
+      it 'returns correct record limit with filter' do
+        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Josh'}}), {record_limit: 1}).count)
+          .to eq(1)
+      end
+
+      it 'obeys correct scan limit with filter' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(1).times.and_call_original
+        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Josh'}}), {scan_limit: 2}).count).to eq(2)
+      end
+
+      it 'obeys correct scan limit over record limit with filter' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(1).times.and_call_original
+        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Josh'}}), {
+          scan_limit: 2,
+          record_limit: 10, # Won't be able to return more than 2 due to scan limit
+        }).count).to eq(2)
+      end
+
+      it 'obeys correct scan limit with filter with some return' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(1).times.and_call_original
+        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Pascal'}}), {
+          scan_limit: 5,
+        }).count).to eq(1)
+      end
+
+      it 'obeys correct scan limit and batch size with filter with some return' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
+        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Josh'}}), {
+          scan_limit: 3,
+          batch_size: 2, # This would force batching of size 2 for potential of 4 results!
+        }).count).to eq(3)
+      end
+
+      it 'obeys correct scan limit with filter and batching for some return' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(5).times.and_call_original
+        # We should paginate through 5 responses each of size 1 (batch) and
+        # only scan through 5 records at most which with our given filter
+        # should return 1 result since first 4 are Josh and last is Pascal.
+        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Pascal'}}), {
+          batch_size: 1,
+          scan_limit: 5,
+          record_limit: 3,
+        }).count).to eq(1)
+      end
+
+      it 'obeys correct record limit with filter, batching, and scan limit' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(6).times.and_call_original
+        # We should paginate through 6 responses each of size 1 (batch) and
+        # only scan through 6 records at most which with our given filter
+        # should return 2 results, and hit record limit before scan limit.
+        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Pascal'}}), {
+          batch_size: 1,
+          scan_limit: 10,
+          record_limit: 2,
+        }).count).to eq(2)
+      end
     end
 
-    it 'performs query on a table with a range and selects items in a range' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_between => [0.0,3.0]).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
-    end
+    #
+    # Tests that even with large records we are paginating to pull more data
+    # even if we hit response data size limits
+    #
+    context 'large records still returns as much data' do
+      before(:each) do
+        # 64 of these items will exceed the 1MB result record_limit thus query won't return all results on first loop
+        # We use :age since :range won't work for filtering in queries
+        200.times do |i|
+          Dynamoid.adapter.put_item(test_table3, {
+            :id => '1',
+            :range => i.to_f,
+            :age => i.to_f,
+            :data => 'A'*1024*16,
+          })
+        end
+      end
 
-    it 'performs query on a table with a range and selects items in a range with :select option' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_between => [0.0,3.0], :select =>  'ALL_ATTRIBUTES').to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
-    end
+      it 'returns correct for limits and scan limit' do
+        expect(dynamo_request(test_table3, request_params, {
+          scan_limit: 100,
+        }).count).to eq(100)
+      end
 
-    it 'performs query on a table with a range and selects items greater than' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_greater_than => 1.0).to_a).to eq [{:id => '1', :range => BigDecimal.new(3)}]
-    end
+      it 'returns correct for scan limit with filtering' do
+        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 90.0} }), {
+          scan_limit: 100,
+        }).count).to eq(10)
+      end
 
-    it 'performs query on a table with a range and selects items less than' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_less_than => 2.0).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}]
-    end
+      it 'returns correct for record limit' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
+        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 5.0} }), {
+          record_limit: 100,
+        }).count).to eq(100)
+      end
 
-    it 'performs query on a table with a range and selects items gte' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_gte => 1.0).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
-    end
+      it 'returns correct record limit with filtering' do
+        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 133.0} }), {
+          record_limit: 100,
+        }).count).to eq(67)
+      end
 
-    it 'performs query on a table with a range and selects items lte' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_lte => 3.0).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
-    end
+      it 'returns correct with batching' do
+        # Since we hit the data size limit 3 times, so we must make 4 requests
+        # which is limitation of DynamoDB and therefore batch limit is
+        # restricted by this limitation as well!
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(4).times.and_call_original
+        expect(dynamo_request(test_table3, request_params, {
+          batch_size: 100,
+        }).count).to eq(200)
+      end
 
-    it 'performs query on a table and returns items based on returns correct limit' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_greater_than => 0.0, :limit => 1).count).to eq(1)
-    end
+      it 'returns correct with batching and record limit beyond data size limit' do
+        # Since we hit limit once, we need to make sure the second request only
+        # requests for as many as we have left for our record limit.
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
+        expect(dynamo_request(test_table3, request_params, {
+          record_limit: 83,
+          batch_size: 100,
+        }).count).to eq(83)
+      end
 
-    it 'performs query on a table with a range and selects all items' do
-      200.times { |i| Dynamoid.adapter.put_item(test_table3, {:id => "1", :range => i.to_f, :data => "A"*1024*16}) }
-      # 64 of these items will exceed the 1MB result limit thus query won't return all results on first loop
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_gte => 0.0).count).to eq(200)
+      it 'returns correct with batching and record limit' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(11).times.and_call_original
+        # Since we do age >= 5.0 we lose the first 5 results so we make 11 paginated requests
+        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 5.0} }), {
+          record_limit: 100,
+          batch_size: 10,
+        }).count).to eq(100)
+      end
     end
   end
-
-  #
-  # Tests scan_index_forwards flag behavior on range queries
-  #
-  shared_examples 'correct ordering' do
-    before(:each) do
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 1, :range => 1.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 2, :range => 2.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 3, :range => 3.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 4, :range => 4.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 5, :range => 5.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 6, :range => 6.0})
-    end
-
-    it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward true' do
-      query = Dynamoid.adapter.query(test_table4, :hash_value => '1', :range_greater_than => 0, :scan_index_forward => true).to_a
-      expect(query[0]).to eq({:id => '1', :order => 1, :range => BigDecimal.new(1)})
-      expect(query[1]).to eq({:id => '1', :order => 2, :range => BigDecimal.new(2)})
-      expect(query[2]).to eq({:id => '1', :order => 3, :range => BigDecimal.new(3)})
-      expect(query[3]).to eq({:id => '1', :order => 4, :range => BigDecimal.new(4)})
-      expect(query[4]).to eq({:id => '1', :order => 5, :range => BigDecimal.new(5)})
-      expect(query[5]).to eq({:id => '1', :order => 6, :range => BigDecimal.new(6)})
-    end
-
-    it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward false' do
-      query = Dynamoid.adapter.query(test_table4, :hash_value => '1', :range_greater_than => 0, :scan_index_forward => false).to_a
-      expect(query[5]).to eq({:id => '1', :order => 1, :range => BigDecimal.new(1)})
-      expect(query[4]).to eq({:id => '1', :order => 2, :range => BigDecimal.new(2)})
-      expect(query[3]).to eq({:id => '1', :order => 3, :range => BigDecimal.new(3)})
-      expect(query[2]).to eq({:id => '1', :order => 4, :range => BigDecimal.new(4)})
-      expect(query[1]).to eq({:id => '1', :order => 5, :range => BigDecimal.new(5)})
-      expect(query[0]).to eq({:id => '1', :order => 6, :range => BigDecimal.new(6)})
-    end
-  end
-
 
   context 'without a preexisting table' do
-    # CreateTable and DeleteTable
     it 'performs CreateTable and DeleteTable' do
       table = Dynamoid.adapter.create_table('CreateTable', :id, :range_key =>  { :created_at => :number })
 
@@ -128,83 +224,88 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
         Dynamoid.adapter.create_table('table_lsi', :id, {
           :local_secondary_indexes => doc_class.local_secondary_indexes.values,
-          :range_key => { :range => :number }
+          :range_key => { :range => :number },
         })
 
-        # execute
+        # Execute
         resp = Dynamoid.adapter.client.describe_table(table_name: 'table_lsi')
         data = resp.data
         lsi = data.table.local_secondary_indexes.first
 
-        # test
-        expect(Dynamoid::AdapterPlugin::AwsSdkV2::PARSE_TABLE_STATUS.call(resp)).to eq(Dynamoid::AdapterPlugin::AwsSdkV2::TABLE_STATUSES[:active])
-        expect(lsi.index_name).to eql "dynamoid_tests_table_lsi_index_id_range2"
-        expect(lsi.key_schema.map(&:to_hash)).to eql [
-          {:attribute_name=>"id", :key_type=>"HASH"},
-          {:attribute_name=>"range2", :key_type=>"RANGE"}
-        ]
-        expect(lsi.projection.to_hash).to eql ({:projection_type=>"KEYS_ONLY"})
+        # Test
+        expect(Dynamoid::AdapterPlugin::AwsSdkV2::PARSE_TABLE_STATUS.call(resp))
+          .to eq(Dynamoid::AdapterPlugin::AwsSdkV2::TABLE_STATUSES[:active])
+        expect(lsi.index_name).to eq('dynamoid_tests_table_lsi_index_id_range2')
+        expect(lsi.key_schema.map(&:to_hash)).to eq([
+          {:attribute_name => 'id', :key_type => 'HASH'},
+          {:attribute_name => 'range2', :key_type => 'RANGE'},
+        ])
+        expect(lsi.projection.to_hash).to eq({:projection_type => 'KEYS_ONLY'})
       end
 
       it 'creates table with global_secondary_index' do
-        # setup
+        # Setup
         doc_class.table({:name => 'table_gsi', :key => :id})
         doc_class.global_secondary_index ({
           :hash_key => :hash2,
           :range_key => :range2,
           :write_capacity => 10,
-          :read_capacity => 20
-
+          :read_capacity => 20,
         })
         Dynamoid.adapter.create_table('table_gsi', :id, {
           :global_secondary_indexes => doc_class.global_secondary_indexes.values,
-          :range_key => { :range => :number }
+          :range_key => { :range => :number },
         })
 
-        # execute
+        # Execute
         resp = Dynamoid.adapter.client.describe_table(table_name: 'table_gsi')
         data = resp.data
         gsi = data.table.global_secondary_indexes.first
 
-        # test
-        expect(Dynamoid::AdapterPlugin::AwsSdkV2::PARSE_TABLE_STATUS.call(resp)).to eq(Dynamoid::AdapterPlugin::AwsSdkV2::TABLE_STATUSES[:active])
-        expect(gsi.index_name).to eql "dynamoid_tests_table_gsi_index_hash2_range2"
-        expect(gsi.key_schema.map(&:to_hash)).to eql [
-          {:attribute_name=>"hash2", :key_type=>"HASH"},
-          {:attribute_name=>"range2", :key_type=>"RANGE"}
-        ]
-        expect(gsi.projection.to_hash).to eql ({:projection_type=>"KEYS_ONLY"})
-        expect(gsi.provisioned_throughput.write_capacity_units).to eql 10
-        expect(gsi.provisioned_throughput.read_capacity_units).to eql 20
+        # Test
+        expect(Dynamoid::AdapterPlugin::AwsSdkV2::PARSE_TABLE_STATUS.call(resp))
+          .to eq(Dynamoid::AdapterPlugin::AwsSdkV2::TABLE_STATUSES[:active])
+        expect(gsi.index_name).to eq('dynamoid_tests_table_gsi_index_hash2_range2')
+        expect(gsi.key_schema.map(&:to_hash)).to eq([
+          {:attribute_name => 'hash2', :key_type => 'HASH'},
+          {:attribute_name => 'range2', :key_type => 'RANGE'},
+        ])
+        expect(gsi.projection.to_hash).to eq({:projection_type => 'KEYS_ONLY'})
+        expect(gsi.provisioned_throughput.write_capacity_units).to eq(10)
+        expect(gsi.provisioned_throughput.read_capacity_units).to eq(20)
       end
     end
   end
 
-
   context 'with a preexisting table' do
-    # GetItem, PutItem and DeleteItem
-    it "performs GetItem for an item that does not exist" do
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to be_nil
-    end
+    describe 'GetItem' do
+      it 'performs GetItem for an item that does not exist' do
+        expect(Dynamoid.adapter.get_item(test_table1, '1')).to be_nil
+      end
 
-    it "performs GetItem for an item that does exist" do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+      it 'performs GetItem for an item that does exist' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({:name => 'Josh', :id => '1'})
+        expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({:name => 'Josh', :id => '1'})
 
-      Dynamoid.adapter.delete_item(test_table1, '1')
+        Dynamoid.adapter.delete_item(test_table1, '1')
 
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to be_nil
-    end
+        expect(Dynamoid.adapter.get_item(test_table1, '1')).to be_nil
+      end
 
-    it 'performs GetItem for an item that does exist with a range key' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 2.0})
+      it 'performs GetItem for an item that does exist with a range key' do
+        Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 2.0})
 
-      expect(Dynamoid.adapter.get_item(test_table3, '1', :range_key => 2.0)).to eq({:name => 'Josh', :id => '1', :range => 2.0})
+        expect(Dynamoid.adapter.get_item(test_table3, '1', :range_key => 2.0)).to eq({
+          :name => 'Josh',
+          :id => '1',
+          :range => 2.0,
+        })
 
-      Dynamoid.adapter.delete_item(test_table3, '1', :range_key => 2.0)
+        Dynamoid.adapter.delete_item(test_table3, '1', :range_key => 2.0)
 
-      expect(Dynamoid.adapter.get_item(test_table3, '1', :range_key => 2.0)).to be_nil
+        expect(Dynamoid.adapter.get_item(test_table3, '1', :range_key => 2.0)).to be_nil
+      end
     end
 
     it 'performs DeleteItem for an item that does not exist' do
@@ -219,212 +320,322 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({:id => '1', :name => 'Josh'})
     end
 
-    # BatchGetItem
-    it 'passes options to underlying BatchGet call' do
-      pending "at the moment passing the options to underlying batch get is not supported"
-      expect_any_instance_of(Aws::DynamoDB::Client).to receive(:batch_get_item).with(:request_items => {test_table1 => {:keys => [{'id' => '1'}, {'id' => '2'}], :consistent_read => true}}).and_call_original
-      described_class.batch_get_item({test_table1 => ['1', '2']}, :consistent_read => true)
-    end
-
-    it "performs BatchGetItem with singular keys" do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table2, {:id => '1', :name => 'Justin'})
-
-      results = Dynamoid.adapter.batch_get_item(test_table1 => '1', test_table2 => '1')
-      expect(results.size).to eq 2
-      expect(results[test_table1]).to include({:name => 'Josh', :id => '1'})
-      expect(results[test_table2]).to include({:name => 'Justin', :id => '1'})
-    end
-
-    it "performs BatchGetItem with multiple keys" do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
-
-      results = Dynamoid.adapter.batch_get_item(test_table1 => ['1', '2'])
-      expect(results.size).to eq 1
-      expect(results[test_table1]).to include({:name => 'Josh', :id => '1'})
-      expect(results[test_table1]).to include({:name => 'Justin', :id => '2'})
-    end
-
-    it 'performs BatchGetItem with one ranged key' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
-
-      results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0]])
-      expect(results.size).to eq 1
-      expect(results[test_table3]).to include({:name => 'Josh', :id => '1', :range => 1.0})
-    end
-
-    it 'performs BatchGetItem with multiple ranged keys' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
-
-      results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0],['2', 2.0]])
-      expect(results.size).to eq 1
-
-      expect(results[test_table3]).to include({:name => 'Josh', :id => '1', :range => 1.0})
-      expect(results[test_table3]).to include({:name => 'Justin', :id => '2', :range => 2.0})
-    end
-
-    it 'performs BatchGetItem with ranges of 100 keys' do
-      table_ids = []
-
-      (1..101).each do |i|
-        id, range = i.to_s, i.to_f
-        Dynamoid.adapter.put_item(test_table3, {:id => id, :name => "Josh_#{i}", :range => range})
-        table_ids << [id, range]
+    describe 'BatchGetItem' do
+      it 'passes options to underlying BatchGet call' do
+        pending 'at the moment passing the options to underlying batch get is not supported'
+        expect_any_instance_of(Aws::DynamoDB::Client)
+          .to receive(:batch_get_item)
+          .with(:request_items => {
+            test_table1 => {:keys => [{'id' => '1'}, {'id' => '2'}], :consistent_read => true}
+          }).and_call_original
+        described_class.batch_get_item({test_table1 => ['1', '2']}, :consistent_read => true)
       end
 
-      results = Dynamoid.adapter.batch_get_item(test_table3 => table_ids)
+      it 'performs BatchGetItem with singular keys' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+        Dynamoid.adapter.put_item(test_table2, {:id => '1', :name => 'Justin'})
 
-      expect(results.size).to eq 1
+        results = Dynamoid.adapter.batch_get_item(test_table1 => '1', test_table2 => '1')
+        expect(results.size).to eq(2)
+        expect(results[test_table1]).to include({:name => 'Josh', :id => '1'})
+        expect(results[test_table2]).to include({:name => 'Justin', :id => '1'})
+      end
 
-      expect(results[test_table3]).to include({:name => 'Josh_101', :id => '101', :range => 101.0})
+      it 'performs BatchGetItem with multiple keys' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+        Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
+
+        results = Dynamoid.adapter.batch_get_item(test_table1 => ['1', '2'])
+        expect(results.size).to eq(1)
+        expect(results[test_table1]).to include({:name => 'Josh', :id => '1'})
+        expect(results[test_table1]).to include({:name => 'Justin', :id => '2'})
+      end
+
+      it 'performs BatchGetItem with one ranged key' do
+        Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
+        Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
+
+        results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0]])
+        expect(results.size).to eq(1)
+        expect(results[test_table3]).to include({:name => 'Josh', :id => '1', :range => 1.0})
+      end
+
+      it 'performs BatchGetItem with multiple ranged keys' do
+        Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
+        Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
+
+        results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0],['2', 2.0]])
+        expect(results.size).to eq(1)
+
+        expect(results[test_table3]).to include({:name => 'Josh', :id => '1', :range => 1.0})
+        expect(results[test_table3]).to include({:name => 'Justin', :id => '2', :range => 2.0})
+      end
+
+      it 'performs BatchGetItem with ranges of 100 keys' do
+        table_ids = []
+
+        (1..101).each do |i|
+          id, range = i.to_s, i.to_f
+          Dynamoid.adapter.put_item(test_table3, {:id => id, :name => "Josh_#{i}", :range => range})
+          table_ids << [id, range]
+        end
+
+        results = Dynamoid.adapter.batch_get_item(test_table3 => table_ids)
+
+        expect(results.size).to eq(1)
+
+        expect(results[test_table3]).to include({:name => 'Josh_101', :id => '101', :range => 101.0})
+      end
     end
 
-    # BatchDeleteItem
-    it "performs BatchDeleteItem with singular keys" do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table2, {:id => '1', :name => 'Justin'})
+    describe 'BatchDeleteItem' do
+      it 'performs BatchDeleteItem with singular keys' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+        Dynamoid.adapter.put_item(test_table2, {:id => '1', :name => 'Justin'})
 
-      Dynamoid.adapter.batch_delete_item(test_table1 => ['1'], test_table2 => ['1'])
+        Dynamoid.adapter.batch_delete_item(test_table1 => ['1'], test_table2 => ['1'])
 
-      results = Dynamoid.adapter.batch_get_item(test_table1 => '1', test_table2 => '1')
-      expect(results.size).to eq 2
+        results = Dynamoid.adapter.batch_get_item(test_table1 => '1', test_table2 => '1')
+        expect(results.size).to eq(2)
 
-      expect(results[test_table1]).to be_blank
-      expect(results[test_table2]).to be_blank
+        expect(results[test_table1]).to be_blank
+        expect(results[test_table2]).to be_blank
+      end
+
+      it 'performs BatchDeleteItem with multiple keys' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+        Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
+
+        Dynamoid.adapter.batch_delete_item(test_table1 => ['1', '2'])
+
+        results = Dynamoid.adapter.batch_get_item(test_table1 => ['1', '2'])
+
+        expect(results.size).to eq(1)
+        expect(results[test_table1]).to be_blank
+      end
+
+      it 'performs BatchDeleteItem with one ranged key' do
+        Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
+        Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
+
+        Dynamoid.adapter.batch_delete_item(test_table3 => [['1', 1.0]])
+        results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0]])
+
+        expect(results.size).to eq(1)
+        expect(results[test_table3]).to be_blank
+      end
+
+      it 'performs BatchDeleteItem with multiple ranged keys' do
+        Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
+        Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
+
+        Dynamoid.adapter.batch_delete_item(test_table3 => [['1', 1.0],['2', 2.0]])
+        results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0],['2', 2.0]])
+
+        expect(results.size).to eq(1)
+        expect(results[test_table3]).to be_blank
+      end
     end
 
-    it "performs BatchDeleteItem with multiple keys" do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
-
-      Dynamoid.adapter.batch_delete_item(test_table1 => ['1', '2'])
-
-      results = Dynamoid.adapter.batch_get_item(test_table1 => ['1', '2'])
-
-      expect(results.size).to eq 1
-      expect(results[test_table1]).to be_blank
-    end
-
-    it 'performs BatchDeleteItem with one ranged key' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
-
-      Dynamoid.adapter.batch_delete_item(test_table3 => [['1', 1.0]])
-      results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0]])
-
-      expect(results.size).to eq 1
-      expect(results[test_table3]).to be_blank
-    end
-
-    it 'performs BatchDeleteItem with multiple ranged keys' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
-
-      Dynamoid.adapter.batch_delete_item(test_table3 => [['1', 1.0],['2', 2.0]])
-      results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0],['2', 2.0]])
-
-      expect(results.size).to eq 1
-      expect(results[test_table3]).to be_blank
-    end
-
-    # ListTables
     it 'performs ListTables' do
-      #Force creation of the tables
+      # Force creation of the tables for let statements
       test_table1; test_table2; test_table3; test_table4
 
-      expect(Dynamoid.adapter.list_tables).to include test_table1
-      expect(Dynamoid.adapter.list_tables).to include test_table2
+      expect(Dynamoid.adapter.list_tables).to include(test_table1)
+      expect(Dynamoid.adapter.list_tables).to include(test_table2)
     end
 
-    # Query
-    it 'performs query on a table and returns items' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+    describe 'Query' do
+      it 'performs query on a table and returns items' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.query(test_table1, :hash_value => '1').first).to eq({ :id=> '1', :name=>"Josh" })
+        expect(Dynamoid.adapter.query(test_table1, :hash_value => '1').first).to eq({:id=> '1', :name => 'Josh'})
+      end
+
+      it 'performs query on a table and returns items if there are multiple items' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+        Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
+
+        expect(Dynamoid.adapter.query(test_table1, :hash_value => '1').first).to eq({:id=> '1', :name=>'Josh'})
+      end
+
+      #
+      # Tests adapter against ranged tables
+      #
+      context 'performs range queries' do
+        before(:each) do
+          Dynamoid.adapter.put_item(test_table3, {:id => '1', :range => 1.0})
+          Dynamoid.adapter.put_item(test_table3, {:id => '1', :range => 3.0})
+        end
+
+        it 'performs query on a table with a range and selects items in a range' do
+          expect(Dynamoid.adapter.query(test_table3, {
+            :hash_value => '1',
+            :range_between => [0.0,3.0]
+          }).to_a).to eq([
+            {:id => '1', :range => BigDecimal.new(1)},
+            {:id => '1', :range => BigDecimal.new(3)},
+          ])
+        end
+
+        it 'performs query on a table with a range and selects items in a range with :select option' do
+          expect(Dynamoid.adapter.query(test_table3, {
+            :hash_value => '1',
+            :range_between => [0.0,3.0],
+            :select =>  'ALL_ATTRIBUTES'
+          }).to_a).to eq([
+            {:id => '1', :range => BigDecimal.new(1)},
+            {:id => '1', :range => BigDecimal.new(3)},
+          ])
+        end
+
+        it 'performs query on a table with a range and selects items greater than' do
+          expect(Dynamoid.adapter.query(test_table3, {
+            :hash_value => '1',
+            :range_greater_than => 1.0
+          }).to_a).to eq([
+            {:id => '1', :range => BigDecimal.new(3)},
+          ])
+        end
+
+        it 'performs query on a table with a range and selects items less than' do
+          expect(Dynamoid.adapter.query(test_table3, {
+            :hash_value => '1',
+            :range_less_than => 2.0
+          }).to_a).to eq([
+            {:id => '1', :range => BigDecimal.new(1)},
+          ])
+        end
+
+        it 'performs query on a table with a range and selects items gte' do
+          expect(Dynamoid.adapter.query(test_table3, {
+            :hash_value => '1',
+            :range_gte => 1.0
+          }).to_a).to eq([
+            {:id => '1', :range => BigDecimal.new(1)},
+            {:id => '1', :range => BigDecimal.new(3)},
+          ])
+        end
+
+        it 'performs query on a table with a range and selects items lte' do
+          expect(Dynamoid.adapter.query(test_table3, {
+            :hash_value => '1',
+            :range_lte => 3.0
+          }).to_a).to eq([
+            {:id => '1', :range => BigDecimal.new(1)},
+            {:id => '1', :range => BigDecimal.new(3)},
+          ])
+        end
+
+        it 'performs query on a table and returns items based on returns correct record limit' do
+          expect(Dynamoid.adapter.query(test_table3, {
+            :hash_value => '1',
+            :range_greater_than => 0.0,
+            :record_limit => 1,
+          }).count).to eq(1)
+        end
+
+        it 'performs query on a table with a range and selects all items' do
+          200.times { |i| Dynamoid.adapter.put_item(test_table3, {:id => '1', :range => i.to_f, :data => 'A'*1024*16}) }
+          # 64 of these items will exceed the 1MB result record_limit thus query won't return all results on first loop
+          expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_gte => 0.0).count).to eq(200)
+        end
+      end
+
+      #
+      # Tests scan_index_forwards flag behavior on range queries
+      #
+      context 'performs correct ordering' do
+        before(:each) do
+          (1..6).each do |i|
+            Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => i, :range => i.to_f})
+          end
+        end
+
+        it 'performs query on a table with a range with scan_index_forward true' do
+          records = Dynamoid.adapter.query(test_table4, {
+            :hash_value => '1',
+            :range_greater_than => 0,
+            :scan_index_forward => true,
+          }).to_a
+          # Should see in ascending order
+          (0..5).each do |i|
+            expect(records[i]).to eq({:id => '1', :order => i + 1, :range => BigDecimal.new(i + 1)})
+          end
+        end
+
+        it 'performs query on a table with a range with scan_index_forward false' do
+          records = Dynamoid.adapter.query(test_table4, {
+            :hash_value => '1',
+            :range_greater_than => 0,
+            :scan_index_forward => false
+          }).to_a
+          # Should see in descending order
+          (0..5).each do |i|
+            expect(records[i]).to eq({:id => '1', :order => 6 - i, :range => BigDecimal.new(6 - i)})
+          end
+        end
+      end
+
+      it_behaves_like 'correctly handling limits', :query, {:hash_value => '1'} do
+        def dynamo_request(table_name, scan_hash = {}, select_opts = {})
+          Dynamoid.adapter.query(table_name, scan_hash.merge(select_opts))
+        end
+      end
     end
 
-    it 'performs query on a table and returns items if there are multiple items' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
+    describe 'Scan' do
+      it 'performs scan on a table and returns items' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.query(test_table1, :hash_value => '1').first).to eq({ :id=> '1', :name=>"Josh" })
+        expect(Dynamoid.adapter.scan(test_table1, name: {:eq => 'Josh'}).to_a).to eq([{ :id => '1', :name => 'Josh' }])
+      end
+
+      it 'performs scan on a table and returns items if there are multiple items but only one match' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+        Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
+
+        expect(Dynamoid.adapter.scan(test_table1, name: {:eq => 'Josh'}).to_a).to eq([{ :id=> '1', :name => 'Josh' }])
+      end
+
+      it 'performs scan on a table and returns multiple items if there are multiple matches' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+        Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
+
+        expect(Dynamoid.adapter.scan(test_table1, name: {:eq => 'Josh'}))
+          .to include({:name => 'Josh', :id => '2'}, {:name => 'Josh', :id => '1'})
+      end
+
+      it 'performs scan on a table and returns all items if no criteria are specified' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+        Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
+
+        expect(Dynamoid.adapter.scan(test_table1, {}))
+          .to include({:name => 'Josh', :id => '2'}, {:name => 'Josh', :id => '1'})
+      end
+
+      it_behaves_like 'correctly handling limits', :scan, {} do
+        def dynamo_request(table_name, scan_hash = {}, select_opts = {})
+          Dynamoid.adapter.scan(table_name, scan_hash, select_opts)
+        end
+      end
     end
 
-    it_behaves_like 'range queries'
+    describe 'Truncate' do
+      it 'performs truncate on an existing table' do
+        Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+        Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Pascal'})
 
-    # Scan
-    it 'performs scan on a table and returns items' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+        expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({:name => 'Josh', :id => '1'})
+        expect(Dynamoid.adapter.get_item(test_table1, '2')).to eq({:name => 'Pascal', :id => '2'})
 
-      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ :id=> '1', :name=>"Josh" }]
-    end
+        Dynamoid.adapter.truncate(test_table1)
 
-    it 'performs scan on a table and returns items if there are multiple items but only one match' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
+        expect(Dynamoid.adapter.get_item(test_table1, '1')).to be_nil
+        expect(Dynamoid.adapter.get_item(test_table1, '2')).to be_nil
+      end
 
-      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ :id=> '1', :name=>"Josh" }]
-    end
-
-    it 'performs scan on a table and returns multiple items if there are multiple matches' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
-
-      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'})).to include({:name=>"Josh", :id=>"2"}, {:name=>"Josh", :id=>"1"})
-    end
-
-    it 'performs scan on a table and returns all items if no criteria are specified' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
-
-      expect(Dynamoid.adapter.scan(test_table1, {})).to include({:name=>"Josh", :id=>"2"}, {:name=>"Josh", :id=>"1"})
-    end
-
-    it 'performs scan on a table and returns correct limit' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '3', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '4', :name => 'Josh'})
-
-      expect(Dynamoid.adapter.scan(test_table1, {}, {limit: 1}).count).to eq(1)
-    end
-
-    it 'performs scan on a table and returns correct batch' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '3', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '4', :name => 'Josh'})
-
-      expect(Dynamoid.adapter.scan(test_table1, {}, {batch_size: 1}).count).to eq(4)
-    end
-
-    it 'performs scan on a table and returns correct limit and batch' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '3', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '4', :name => 'Josh'})
-
-      expect(Dynamoid.adapter.scan(test_table1, {}, {limit: 1, batch_size: 1}).count).to eq(1)
-    end
-
-    # Truncate
-    it 'performs truncate on an existing table' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Pascal'})
-
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({:name => 'Josh', :id => '1'})
-      expect(Dynamoid.adapter.get_item(test_table1, '2')).to eq({:name => 'Pascal', :id => '2'})
-
-      Dynamoid.adapter.truncate(test_table1)
-
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to be_nil
-      expect(Dynamoid.adapter.get_item(test_table1, '2')).to be_nil
-    end
-
-    it 'performs truncate on an existing table with a range key' do
+      it 'performs truncate on an existing table with a range key' do
       Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
       Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
 
@@ -433,8 +644,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       expect(Dynamoid.adapter.get_item(test_table3, '1', :range_key => 1.0)).to be_nil
       expect(Dynamoid.adapter.get_item(test_table3, '2', :range_key => 2.0)).to be_nil
     end
-
-    it_behaves_like 'correct ordering'
+    end
   end
 
   # DescribeTable

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -736,7 +736,7 @@ describe Dynamoid::Criteria::Chain do
 
     it 'limits evaluated records' do
       chain.query = {}
-      expect(chain.eval_limit(1).count).to eq 1
+      expect(chain.record_limit(1).count).to eq 1
     end
 
     it 'finds tweets with a start' do

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -58,7 +58,7 @@ describe Dynamoid::Criteria do
 
   it 'returns N records' do
     5.times { |i| User.create(:name => 'Josh', :email => 'josh_#{i}@joshsymonds.com') }
-    expect(User.eval_limit(2).all.size).to eq(2)
+    expect(User.record_limit(2).all.size).to eq(2)
   end
 
   # TODO This test is broken using the AWS SDK adapter.


### PR DESCRIPTION
- [Update] Chain: Changed `eval_limit` to `record_limit` to better
  reflect the limitation on returned records.
- [New] Chain: Added `scan_limit` to allow limiting the number
  of scanned elements and more control over underlying
  query.
- [New] AWS SDK V2: Added `batch_size` option for `query` to
  take advantage of the `batch` method from Chain.
- [Fix] AWS SDK V2: Fix issue where scan could return more
  results than limited. For example having `batch_size` of
  50 and a `record_limit` (was `eval_limit`) of 80 could
  return 100 records since batching would requests in sets
  of 50! Applied similar logic correctly to query.

Cleaning up for https://github.com/Dynamoid/Dynamoid/issues/85 and addressing updates for https://github.com/Dynamoid/Dynamoid/pull/172