### PR TITLE
Rename `eval_limit` -> `record_limit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 * Remove support for Dynamoid's (pseudo)indexes, now that DynamoDB offers
   local and global indexes.
 * Rename :float field type to :number.
-* Rename Chain#limit to Chain#eval_limit.
+* Rename Chain#limit to Chain#record_limit.
 
 Housekeeping:
 

--- a/README.md
+++ b/README.md
@@ -346,19 +346,21 @@ But keep in mind Dynamoid -- and document-based storage systems in general -- ar
 You can also limit the number of evaluated records, or select a record from which to start, to support pagination:
 
 ```ruby
-Address.eval_limit(5).start(address) # Only 5 addresses.
+Address.record_limit(5).start(address) # Only 5 addresses.
 ```
 
 For large queries that return many rows, Dynamoid can use AWS' support for requesting documents in batches:
 
 ```ruby
-#Do some maintenance on the entire table without flooding DynamoDB
+# Do some maintenance on the entire table without flooding DynamoDB
 Address.all(batch_size: 100).each { |address| address.do_some_work; sleep(0.01) }
-Address.eval_limit(10_000).batch(100). each { … } #batch specified as part of a chain
+Address.record_limit(10_000).batch(100). each { … } # Batch specified as part of a chain
 ```
 
-You are able to optimize query with condition for sort key. Following
-operators are available: `gt`, `lt`, `gte`, `lte`, `begins_with`, `between` as well as equality:
+#### Sort Conditions and Filters
+
+You are able to optimize query with condition for sort key. Following operators are available: `gt`, `lt`, `gte`, `lte`,
+ `begins_with`, `between` as well as equality:
 
 ```ruby
 Address.where(latitude: 10212)

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ For large queries that return many rows, Dynamoid can use AWS' support for reque
 ```ruby
 # Do some maintenance on the entire table without flooding DynamoDB
 Address.all(batch_size: 100).each { |address| address.do_some_work; sleep(0.01) }
-Address.record_limit(10_000).batch(100). each { … } # Batch specified as part of a chain
+Address.record_limit(10_000).batch(100).each { … } # Batch specified as part of a chain
 ```
 
 #### Sort Conditions and Filters

--- a/lib/dynamoid/criteria.rb
+++ b/lib/dynamoid/criteria.rb
@@ -9,7 +9,7 @@ module Dynamoid
     
     module ClassMethods
       
-      [:where, :all, :first, :last, :each, :eval_limit, :start, :scan_index_forward].each do |meth|
+      [:where, :all, :first, :last, :each, :record_limit, :start, :scan_index_forward].each do |meth|
         # Return a criteria chain in response to a method that will begin or end a chain. For more information, 
         # see Dynamoid::Criteria::Chain.
         #

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -83,8 +83,10 @@ module Dynamoid #:nodoc:
         end
       end
 
-      def eval_limit(limit)
-        @eval_limit = limit
+      # The record limit is the limit of evaluated records returned by the
+      # query or scan.
+      def record_limit(limit)
+        @record_limit = limit
         self
       end
 
@@ -312,7 +314,7 @@ module Dynamoid #:nodoc:
         opts = {}
         opts[:index_name] = @index_name if @index_name
         opts[:select] = 'ALL_ATTRIBUTES'
-        opts[:limit] = @eval_limit if @eval_limit
+        opts[:record_limit] = @record_limit if @record_limit
         opts[:next_token] = start_key if @start
         opts[:scan_index_forward] = @scan_index_forward
         opts
@@ -333,7 +335,7 @@ module Dynamoid #:nodoc:
 
       def scan_opts
         opts = {}
-        opts[:limit] = @eval_limit if @eval_limit
+        opts[:record_limit] = @record_limit if @record_limit
         opts[:next_token] = start_key if @start
         opts[:batch_size] = @batch_size if @batch_size
         opts[:consistent_read] = true if @consistent_read

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -54,7 +54,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs query on a table and returns items based on returns correct limit' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_greater_than => 0.0, :limit => 1).count).to eq(1)
+      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_greater_than => 0.0, :record_limit => 1).count).to eq(1)
     end
 
     it 'performs query on a table with a range and selects all items' do
@@ -389,7 +389,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       Dynamoid.adapter.put_item(test_table1, {:id => '3', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table1, {:id => '4', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.scan(test_table1, {}, {limit: 1}).count).to eq(1)
+      expect(Dynamoid.adapter.scan(test_table1, {}, {record_limit: 1}).count).to eq(1)
     end
 
     it 'performs scan on a table and returns correct batch' do
@@ -407,7 +407,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       Dynamoid.adapter.put_item(test_table1, {:id => '3', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table1, {:id => '4', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.scan(test_table1, {}, {limit: 1, batch_size: 1}).count).to eq(1)
+      expect(Dynamoid.adapter.scan(test_table1, {}, {record_limit: 1, batch_size: 1}).count).to eq(1)
     end
 
     # Truncate

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -736,7 +736,8 @@ describe Dynamoid::Criteria::Chain do
 
     it 'limits evaluated records' do
       chain.query = {}
-      expect(chain.eval_limit(1).count).to eq 1
+      expect(chain.record_limit(1).count).to eq 1
+      expect(chain.record_limit(2).count).to eq 2
     end
 
     it 'finds tweets with a start' do

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -58,7 +58,7 @@ describe Dynamoid::Criteria do
 
   it 'returns N records' do
     5.times { |i| User.create(:name => 'Josh', :email => 'josh_#{i}@joshsymonds.com') }
-    expect(User.eval_limit(2).all.size).to eq(2)
+    expect(User.record_limit(2).all.size).to eq(2)
   end
 
   # TODO This test is broken using the AWS SDK adapter.


### PR DESCRIPTION
- [Update] Change `eval_limit` to `record_limit` to avoid the stigma
  of `eval` keyword and to be clear when later introducing the
  `scan_limit`.

Part 1 of https://github.com/Dynamoid/Dynamoid/pull/180 with split for rename of `eval_limit` to `record_limit`.

I'll include the new tests from https://github.com/Dynamoid/Dynamoid/pull/180 in the other PR to follow.

Thanks!