### PR TITLE
AWS SDK V2 and Chain: Add `scan_limit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,10 +343,29 @@ u.addresses.where(:city => 'Chicago').all
 
 But keep in mind Dynamoid -- and document-based storage systems in general -- are not drop-in replacements for existing relational databases. The above query does not efficiently perform a conditional join, but instead finds all the user's addresses and naively filters them in Ruby. For large associations this is a performance hit compared to relational database engines.
 
-You can also limit the number of evaluated records, or select a record from which to start, to support pagination:
+#### Limits
+
+There are three types of limits that you can query with:
+
+1. `record_limit` - The number of evaluated records that are returned by the query.
+2. `scan_limit` - The number of scanned records that DynamoDB will look at before returning.
+3. `batch_size` - The number of records requested to DynamoDB per underlying request, good for large queries!
+
+Using these in various combinations results in the underlying requests to be made in the smallest size possible and
+the query returns once `record_limit` or `scan_limit` is satisfied. It will attempt to batch whenever possible.
+
+You can thus limit the number of evaluated records, or select a record from which to start, to support pagination:
 
 ```ruby
-Address.record_limit(5).start(address) # Only 5 addresses.
+Address.record_limit(5).start(address) # Only 5 addresses starting at `address`
+```
+
+If you are potentially running over a large data set and this is especially true when using certain filters, you may
+want to consider limiting the number of scanned records (the number of records DynamoDB infrastructure looks through
+when evaluating data to return):
+
+```ruby
+Address.scan_limit(5).start(address) # Only scan at most 5 records and return what's found starting from `address`
 ```
 
 For large queries that return many rows, Dynamoid can use AWS' support for requesting documents in batches:
@@ -354,13 +373,16 @@ For large queries that return many rows, Dynamoid can use AWS' support for reque
 ```ruby
 # Do some maintenance on the entire table without flooding DynamoDB
 Address.all(batch_size: 100).each { |address| address.do_some_work; sleep(0.01) }
-Address.record_limit(10_000).batch(100).each { … } # Batch specified as part of a chain
+Address.record_limit(10_000).batch(100). each { … } # Batch specified as part of a chain
 ```
+
+The implication of batches is that the underlying requests are done in the batch sizes to make the request and responses
+more manageable.
 
 #### Sort Conditions and Filters
 
 You are able to optimize query with condition for sort key. Following operators are available: `gt`, `lt`, `gte`, `lte`,
- `begins_with`, `between` as well as equality:
+`begins_with`, `between` as well as equality:
 
 ```ruby
 Address.where(latitude: 10212)

--- a/lib/dynamoid/criteria.rb
+++ b/lib/dynamoid/criteria.rb
@@ -6,11 +6,11 @@ module Dynamoid
   # Allows classes to be queried by where, all, first, and each and return criteria chains.
   module Criteria
     extend ActiveSupport::Concern
-    
+
     module ClassMethods
-      
-      [:where, :all, :first, :last, :each, :record_limit, :start, :scan_index_forward].each do |meth|
-        # Return a criteria chain in response to a method that will begin or end a chain. For more information, 
+
+      [:where, :all, :first, :last, :each, :record_limit, :scan_limit, :batch, :start, :scan_index_forward].each do |meth|
+        # Return a criteria chain in response to a method that will begin or end a chain. For more information,
         # see Dynamoid::Criteria::Chain.
         #
         # @since 0.2.0
@@ -25,5 +25,5 @@ module Dynamoid
       end
     end
   end
-  
+
 end

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -90,6 +90,15 @@ module Dynamoid #:nodoc:
         self
       end
 
+      # The scan limit which is the limit of records that DynamoDB will
+      # internally query or scan. This is different from the record limit
+      # as with filtering DynamoDB may look at N scanned records but return 0
+      # records if none pass the filter.
+      def scan_limit(limit)
+        @scan_limit = limit
+        self
+      end
+
       def batch(batch_size)
         @batch_size = batch_size
         self
@@ -315,6 +324,7 @@ module Dynamoid #:nodoc:
         opts[:index_name] = @index_name if @index_name
         opts[:select] = 'ALL_ATTRIBUTES'
         opts[:record_limit] = @record_limit if @record_limit
+        opts[:scan_limit] = @scan_limit if @scan_limit
         opts[:next_token] = start_key if @start
         opts[:scan_index_forward] = @scan_index_forward
         opts
@@ -336,6 +346,7 @@ module Dynamoid #:nodoc:
       def scan_opts
         opts = {}
         opts[:record_limit] = @record_limit if @record_limit
+        opts[:scan_limit] = @scan_limit if @scan_limit
         opts[:next_token] = start_key if @start
         opts[:batch_size] = @batch_size if @batch_size
         opts[:consistent_read] = true if @consistent_read


### PR DESCRIPTION
- [Update] Add new method `scan_limit` to allow modifying the number
  of scanned records that DynamoDB looks at. This is different from
  `eval_limit` which is the limit of records returned.

Part 2 of https://github.com/Dynamoid/Dynamoid/pull/180

Will combine the last `batch_size` and fix for bad batching when dealing with limits once part 1 and part 2 are merged.

Reference:
Part 1: https://github.com/Dynamoid/Dynamoid/pull/181

Thanks! I kept the `eval_limit` code somewhat in take and will rebase correctly once Part 1 is merged.