### PR TITLE
AWS SDK V2: Add batching to query and fix paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Address.record_limit(10_000).batch(100). each { … } # Batch specified as part 
 ```
 
 The implication of batches is that the underlying requests are done in the batch sizes to make the request and responses
-more manageable.
+more manageable. Note that this batching is for `Query` and `Scans` and not `BatchGetItem` commands.
 
 #### Sort Conditions and Filters
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -506,12 +506,14 @@ module Dynamoid
           record_count = 0
           scan_count = 0
           loop do
-            # Adjust the limit down if the remaining record or scan limit are
+            # Adjust the limit down if the remaining record and/or scan limit are
             # lower to obey limits. We can assume the difference won't be
-            # negative due to break statements below.
+            # negative due to break statements below but choose smaller limit
+            # which is why we have 2 separate if statements.
             if q[:limit] && record_limit && record_limit - record_count < q[:limit]
               q[:limit] = record_limit - record_count
-            elsif q[:limit] && scan_limit && scan_limit - scan_count < q[:limit]
+            end
+            if q[:limit] && scan_limit && scan_limit - scan_count < q[:limit]
               q[:limit] = scan_limit - scan_count
             end
 
@@ -569,12 +571,14 @@ module Dynamoid
           record_count = 0
           scan_count = 0
           loop do
-            # Adjust the limit down if the remaining record or scan limit are
+            # Adjust the limit down if the remaining record and/or scan limit are
             # lower to obey limits. We can assume the difference won't be
-            # negative due to break statements below.
+            # negative due to break statements below but choose smaller limit
+            # which is why we have 2 separate if statements.
             if request[:limit] && record_limit && record_limit - record_count < request[:limit]
               request[:limit] = record_limit - record_count
-            elsif request[:limit] && scan_limit && scan_limit - scan_count < request[:limit]
+            end
+            if request[:limit] && scan_limit && scan_limit - scan_count < request[:limit]
               request[:limit] = scan_limit - scan_count
             end
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -510,6 +510,17 @@ module Dynamoid
             # lower to obey limits. We can assume the difference won't be
             # negative due to break statements below but choose smaller limit
             # which is why we have 2 separate if statements.
+            # NOTE: Adjusting based on record_limit can cause many HTTP requests
+            # being made. We may want to change this behavior, but it affects
+            # filtering on data with potentially large gaps.
+            # Example:
+            #    User.where('created_at.gte' => 1.day.ago).record_limit(1000)
+            #    Records 1-999 User's that fit criteria
+            #    Records 1000-2000 Users's that do not fit criteria
+            #    Record 2001 fits criteria
+            # The underlying implementation will have 1 page for records 1-999
+            # then will request with limit 1 for records 1000-2000 (making 1000
+            # requests of limit 1) until hit record 2001.
             if q[:limit] && record_limit && record_limit - record_count < q[:limit]
               q[:limit] = record_limit - record_count
             end
@@ -575,6 +586,17 @@ module Dynamoid
             # lower to obey limits. We can assume the difference won't be
             # negative due to break statements below but choose smaller limit
             # which is why we have 2 separate if statements.
+            # NOTE: Adjusting based on record_limit can cause many HTTP requests
+            # being made. We may want to change this behavior, but it affects
+            # filtering on data with potentially large gaps.
+            # Example:
+            #    User.where('created_at.gte' => 1.day.ago).record_limit(1000)
+            #    Records 1-999 User's that fit criteria
+            #    Records 1000-2000 Users's that do not fit criteria
+            #    Record 2001 fits criteria
+            # The underlying implementation will have 1 page for records 1-999
+            # then will request with limit 1 for records 1000-2000 (making 1000
+            # requests of limit 1) until hit record 2001.
             if request[:limit] && record_limit && record_limit - record_count < request[:limit]
               request[:limit] = record_limit - record_count
             end

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -62,20 +62,17 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       end
 
       it 'returns correct batch' do
-        pending 'Query does not support batching yet' if request_type == :query
         # Receives 8 times for each item and 1 more for empty page
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(9).times.and_call_original
         expect(dynamo_request(test_table3, request_params, {batch_size: 1}).count).to eq(8)
       end
 
       it 'returns correct batch and paginates in batches' do
-        pending 'Query does not support batching yet' if request_type == :query
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(3).times.and_call_original
         expect(dynamo_request(test_table3, request_params, {batch_size: 3}).count).to eq(8)
       end
 
       it 'returns correct record limit and batch' do
-        pending 'Query does not support batching yet' if request_type == :query
         expect(dynamo_request(test_table3, request_params, {record_limit: 1, batch_size: 1}).count).to eq(1)
       end
 
@@ -105,8 +102,15 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         }).count).to eq(1)
       end
 
+      it 'obeys correct scan limit and batch size with filter with some return' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
+        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Josh'}}), {
+          scan_limit: 3,
+          batch_size: 2, # This would force batching of size 2 for potential of 4 results!
+        }).count).to eq(3)
+      end
+
       it 'obeys correct scan limit with filter and batching for some return' do
-        pending 'Query does not support batching yet' if request_type == :query
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(5).times.and_call_original
         # We should paginate through 5 responses each of size 1 (batch) and
         # only scan through 5 records at most which with our given filter
@@ -119,7 +123,6 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       end
 
       it 'obeys correct record limit with filter, batching, and scan limit' do
-        pending 'Query does not support batching yet' if request_type == :query
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(6).times.and_call_original
         # We should paginate through 6 responses each of size 1 (batch) and
         # only scan through 6 records at most which with our given filter
@@ -150,6 +153,30 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         end
       end
 
+      it 'returns correct for limits and scan limit' do
+        expect(dynamo_request(test_table3, request_params, {
+          scan_limit: 100,
+        }).count).to eq(100)
+      end
+
+      it 'returns correct for scan limit with filtering' do
+        # Not sure why there is difference but :query will do 1 page and see 100 records and filter out 10
+        # while :scan will do 2 pages and see 64 records on first page similar to the 1MB return limit
+        # and then look at 36 records and find 10 on the second page.
+        pages = request_type == :query ? 1 : 2
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(pages).times.and_call_original
+        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 90.0} }), {
+          scan_limit: 100,
+        }).count).to eq(10)
+      end
+
+      it 'returns correct for record limit' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
+        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 5.0} }), {
+          record_limit: 100,
+        }).count).to eq(100)
+      end
+
       it 'returns correct record limit with filtering' do
         expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 133.0} }), {
           record_limit: 100,
@@ -157,7 +184,6 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       end
 
       it 'returns correct with batching' do
-        pending 'Query does not support batching yet' if request_type == :query
         # Since we hit the data size limit 3 times, so we must make 4 requests
         # which is limitation of DynamoDB and therefore batch limit is
         # restricted by this limitation as well!
@@ -165,6 +191,25 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         expect(dynamo_request(test_table3, request_params, {
           batch_size: 100,
         }).count).to eq(200)
+      end
+
+      it 'returns correct with batching and record limit beyond data size limit' do
+        # Since we hit limit once, we need to make sure the second request only
+        # requests for as many as we have left for our record limit.
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
+        expect(dynamo_request(test_table3, request_params, {
+          record_limit: 83,
+          batch_size: 100,
+        }).count).to eq(83)
+      end
+
+      it 'returns correct with batching and record limit' do
+        expect(Dynamoid.adapter.client).to receive(request_type).exactly(11).times.and_call_original
+        # Since we do age >= 5.0 we lose the first 5 results so we make 11 paginated requests
+        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 5.0} }), {
+          record_limit: 100,
+          batch_size: 10,
+        }).count).to eq(100)
       end
     end
   end


### PR DESCRIPTION
- [New] Add batch size to queries as well which should allow
  any Chain querying to use batching correctly
- [Fix] Fix issue where scan could return more
  results than limited. For example having `batch_size` of
  50 and a `record_limit` (was `eval_limit`) of 80 could
  return 100 records since batching would requests in sets
  of 50! Applied similar logic correctly to query.

Part 3 of https://github.com/Dynamoid/Dynamoid/pull/180

Thanks!
