### PR TITLE
Vagrant: Development environment

### DIFF
--- a/.dev/vagrant/minion
+++ b/.dev/vagrant/minion
@@ -1,0 +1,9 @@
+# Masterless Minion Configuration File
+master: localhost
+id: development
+file_client: local
+
+# Where your salt state exists
+file_roots:
+  base:
+    - /vagrant/.dev/vagrant/salt

--- a/.dev/vagrant/salt/apt/init.sls
+++ b/.dev/vagrant/salt/apt/init.sls
@@ -1,0 +1,13 @@
+apt-pkgs:
+  pkg.latest:
+    - pkgs:
+      - daemontools
+      - git-core
+      - openjdk-8-jre-headless
+      - tmux
+      - vim
+
+# JAVA_HOME
+/home/vagrant/.bashrc:
+  file.append:
+    - text: export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"

--- a/.dev/vagrant/salt/dynamodb/init.sls
+++ b/.dev/vagrant/salt/dynamodb/init.sls
@@ -1,0 +1,17 @@
+/opt/install/aws/dynamodb.tar.gz:
+  file.managed:
+    - source: https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_2017-02-16.tar.gz
+    - source_hash: sha256=d79732d7cd6e4b66fbf4bb7a7fc06cb75abbbe1bbbfb3d677a24815a1465a0b2
+    - makedirs: True
+
+/vagrant/spec/DynamoDBLocal-latest:
+  file.directory:
+    - name: /vagrant/spec/DynamoDBLocal-latest
+    - user: vagrant
+    - group: vagrant
+
+dynamodb.install:
+  cmd.wait:
+    - name: cd /vagrant/spec/DynamoDBLocal-latest && tar xfz /opt/install/aws/dynamodb.tar.gz
+    - watch:
+      - file: /opt/install/aws/dynamodb.tar.gz

--- a/.dev/vagrant/salt/rvm/.gemrc
+++ b/.dev/vagrant/salt/rvm/.gemrc
@@ -1,0 +1,1 @@
+gem: --no-ri --no-rdoc

--- a/.dev/vagrant/salt/rvm/init.sls
+++ b/.dev/vagrant/salt/rvm/init.sls
@@ -1,0 +1,67 @@
+# https://docs.saltstack.com/en/latest/ref/states/all/salt.states.rvm.html
+rvm-deps:
+  pkg.installed:
+    - pkgs:
+      - bash
+      - coreutils
+      - gzip
+      - bzip2
+      - gawk
+      - sed
+      - curl
+      - git-core
+      - subversion
+
+mri-deps:
+  pkg.installed:
+    - pkgs:
+      - build-essential
+      - openssl
+      - libreadline6
+      - libreadline6-dev
+      - curl
+      - git-core
+      - zlib1g
+      - zlib1g-dev
+      - libssl-dev
+      - libyaml-dev
+      - libsqlite3-0
+      - libsqlite3-dev
+      - sqlite3
+      - libxml2-dev
+      - libxslt1-dev
+      - autoconf
+      - libc6-dev
+      - libncurses5-dev
+      - automake
+      - libtool
+      - bison
+      - subversion
+      - ruby
+
+ruby-{{ pillar['ruby']['version'] }}:
+  rvm.installed:
+    - name: {{ pillar['ruby']['version'] }}
+    - default: True
+    - user: vagrant
+    - require:
+      - pkg: rvm-deps
+      - pkg: mri-deps
+
+# Disable Documentation Installation
+/home/vagrant/.gemrc:
+  file.managed:
+    - user: vagrant
+    - group: vagrant
+    - name: /home/vagrant/.gemrc
+    - source: salt://rvm/.gemrc
+    - makedirs: True
+
+# Bundler
+bundler.install:
+  gem.installed:
+    - user: vagrant
+    - name: bundler
+    - ruby: ruby-{{ pillar['ruby']['version'] }}
+    - rdoc: false
+    - ri: false

--- a/.dev/vagrant/salt/top.sls
+++ b/.dev/vagrant/salt/top.sls
@@ -1,0 +1,5 @@
+base:
+  'development':
+    - apt
+    - dynamodb
+    - rvm

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ Gemfile.lock
 /tmp/
 /spec/DynamoDBLocal-latest/
 /vendor/
+
+# For vagrant
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,27 @@
+Vagrant.configure('2') do |config|
+  # Choose base box
+  config.vm.box = 'bento/ubuntu-16.04'
+
+  config.vm.provider 'virtualbox' do |vb|
+    # Prevent clock skew when host goes to sleep while VM is running
+    vb.customize ['guestproperty', 'set', :id, '/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold', 10_000]
+
+    vb.cpus = 2
+    vb.memory = 2048
+  end
+
+  # Defaults
+  config.vm.provision :salt do |salt|
+    salt.masterless = true
+    salt.minion_config = '.dev/vagrant/minion'
+
+    # Pillars
+    salt.pillar({
+      'ruby' => {
+        'version' => '2.3.3',
+      }
+    })
+
+    salt.run_highstate = true
+  end
+end

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
       "LICENSE.txt",
       "README.md"
   ]
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(bin|test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(bin|test|spec|features|.dev|Vagrantfile)/}) }
   spec.homepage = "http://github.com/Dynamoid/Dynamoid"
   spec.licenses = ["MIT"]
   spec.bindir = "exe"


### PR DESCRIPTION
- [New] Add Vagrantfile for easy startup for development environment.

Don't know how helpful this is for others but I've been using this `Vagrantfile` in order to have the environment to test Dynamoid separate from my work environment.

So can reject if don't want to have in the repository but just thought I'd open PR up to see.