### PR TITLE
Fix STI support

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -18,6 +18,11 @@ module Dynamoid #:nodoc:
         @source = source
         @consistent_read = false
         @scan_index_forward = true
+
+        # Honor STI and :type field if it presents
+        if @source.attributes.key?(:type)
+          @query[:type] = @source.name
+        end
       end
 
       # The workhorse method of the criteria chain. Each key in the passed in hash will become another criteria that the

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -21,7 +21,7 @@ module Dynamoid #:nodoc:
 
         # Honor STI and :type field if it presents
         if @source.attributes.key?(:type)
-          @query[:type] = @source.name
+          @query[:'type.in'] = @source.deep_subclasses.map(&:name) << @source.name
         end
       end
 

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -110,6 +110,10 @@ module Dynamoid #:nodoc:
           else !! find(id_or_conditions)
         end
       end
+
+      def deep_subclasses
+        subclasses + subclasses.map(&:deep_subclasses).flatten
+      end
     end
 
     # Initialize a new object.

--- a/spec/app/models/cadillac.rb
+++ b/spec/app/models/cadillac.rb
@@ -1,0 +1,5 @@
+require_relative 'car'
+
+class Cadillac < Car
+end
+

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -780,6 +780,27 @@ describe Dynamoid::Criteria::Chain do
     end
   end
 
+
+  context 'single table inheritance' do
+    describe 'where' do
+      it 'honors STI' do
+        Vehicle.create(description: 'Description')
+        car = Car.create(description: 'Description')
+
+        expect(Car.where(description: 'Description').all).to eq [car]
+      end
+    end
+
+    describe 'all' do
+      it 'honors STI' do
+        Vehicle.create(description: 'Description')
+        car = Car.create
+
+        expect(Car.all).to eq [car]
+      end
+    end
+  end
+
   describe 'User' do
     let(:chain) { described_class.new(User) }
 

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -214,4 +214,14 @@ describe Dynamoid::Document do
       expect(Tweet.count).to eq 2
     end
   end
+
+  describe '.deep_subclasses' do
+    it 'returns direct children' do
+      expect(Car.deep_subclasses).to eq [Cadillac]
+    end
+
+    it 'returns grandchildren too' do
+      expect(Vehicle.deep_subclasses).to include(Cadillac)
+    end
+  end
 end

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -542,6 +542,7 @@ describe Dynamoid::Persistence do
   end
 
   context 'single table inheritance' do
+    let(:vehicle) { Vehicle.create }
     let(:car) { Car.create(power_locks: false) }
     let(:sub) { NuclearSubmarine.create(torpedoes: 5) }
 
@@ -558,6 +559,13 @@ describe Dynamoid::Persistence do
         expect(v).to include(c)
         expect(v).to include(s)
       }
+    end
+
+    it 'does not load parent item when quering the child table' do
+      vehicle && car
+
+      expect(Car.all).to contain_exactly(car)
+      expect(Car.all).not_to include(vehicle)
     end
   end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -248,7 +248,7 @@ describe Dynamoid::Persistence do
     end
   end
 
-  it 'dumps date attributes', :wip do
+  it 'dumps date attributes' do
     address = Address.create(:registered_on => '2017-06-18'.to_date)
     expect(Address.find(address.id).registered_on).to eq '2017-06-18'.to_date
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -567,6 +567,13 @@ describe Dynamoid::Persistence do
       expect(Car.all).to contain_exactly(car)
       expect(Car.all).not_to include(vehicle)
     end
+
+    it 'does not load items of sibling class' do
+      car && sub
+
+      expect(Car.all).to contain_exactly(car)
+      expect(Car.all).not_to include(sub)
+    end
   end
 
   describe ':raw datatype persistence' do


### PR DESCRIPTION
`where`, finders and friends take into account STI (single table inheritence) now

Was implemented STI like it works in Rails' ActiveRecord - query will return items of the model class and all his subclasses