### PR TITLE
Fix query result lazy loading

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -56,9 +56,11 @@ module Dynamoid #:nodoc:
       end
 
       # Returns the last fetched record matched the criteria
+      # Enumerable doesn't implement it, only `first`
+      # So we have to implement it themselves
       #
       def last
-        all.last
+        all.to_a.last
       end
 
       # Destroys all the records matching the criteria.
@@ -133,12 +135,11 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def records
-        results = if key_present?
+        if key_present?
           records_via_query
         else
           records_via_scan
         end
-        @batch_size ? results : Array(results)
       end
 
       def records_via_query

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -56,8 +56,8 @@ module Dynamoid #:nodoc:
       end
 
       # Returns the last fetched record matched the criteria
-      # Enumerable doesn't implement it, only `first`
-      # So we have to implement it themselves
+      # Enumerable doesn't implement `last`, only `first`
+      # So we have to implement it ourselves
       #
       def last
         all.to_a.last

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -123,10 +123,6 @@ module Dynamoid #:nodoc:
         records.each(&block)
       end
 
-      def consistent_opts
-        { :consistent_read => consistent_read }
-      end
-
       private
 
       # The actual records referenced by the association.
@@ -214,6 +210,10 @@ module Dynamoid #:nodoc:
         end
 
         return { name.to_sym => hash }
+      end
+
+      def consistent_opts
+        { :consistent_read => consistent_read }
       end
 
       def range_query

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -106,7 +106,7 @@ module Dynamoid #:nodoc:
       # @since 0.2.0
       def exists?(id_or_conditions = {})
         case id_or_conditions
-          when Hash then ! where(id_or_conditions).all.empty?
+          when Hash then where(id_or_conditions).first.present?
           else !! find(id_or_conditions)
         end
       end

--- a/spec/dynamoid/associations/association_spec.rb
+++ b/spec/dynamoid/associations/association_spec.rb
@@ -141,7 +141,7 @@ describe Dynamoid::Associations::Association do
     magazine.subscriptions.destroy_all
 
     expect(magazine.subscriptions).to be_blank
-    expect(Subscription.all).to be_empty
+    expect(Subscription.all.to_a).to be_empty
   end
 
   it 'deletes all objects and removes them from the association' do
@@ -152,7 +152,7 @@ describe Dynamoid::Associations::Association do
     magazine.subscriptions.delete_all
 
     expect(magazine.subscriptions).to be_blank
-    expect(Subscription.all).to be_empty
+    expect(Subscription.all.to_a).to be_empty
   end
 
   it 'delegates class to the association object' do

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -830,7 +830,7 @@ describe Dynamoid::Criteria::Chain do
 
     it 'finds one specific tweet' do
       chain.query = { :tweet_id => "xx", :group => "two" }
-      expect(chain.all).to eq [tweet3]
+      expect(chain.all.to_a).to eq [tweet3]
     end
 
     it 'finds posts with "where" method with "gt" query' do
@@ -887,17 +887,17 @@ describe Dynamoid::Criteria::Chain do
     describe 'destroy' do
       it 'destroys tweet with a range simple range query' do
         chain.query = { :tweet_id => "x" }
-        expect(chain.all.size).to eq 2
+        expect(chain.all.count).to eq 2
         chain.destroy_all
-        expect(chain.consistent.all.size).to eq 0
+        expect(chain.consistent.all.count).to eq 0
       end
 
       it 'deletes one specific tweet with range' do
         chain = Dynamoid::Criteria::Chain.new(Tweet)
         chain.query = { :tweet_id => "xx", :group => "two" }
-        expect(chain.all.size).to eq 1
+        expect(chain.all.count).to eq 1
         chain.destroy_all
-        expect(chain.consistent.all.size).to eq 0
+        expect(chain.consistent.all.count).to eq 0
       end
     end
 

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -411,6 +411,17 @@ describe Dynamoid::Criteria::Chain do
     end
   end
 
+  describe 'Lazy loading' do
+    describe '.all' do
+      it 'does load result lazily' do
+        Vehicle.create
+
+        expect(Dynamoid.adapter.client).to receive(:scan).exactly(0).times.and_call_original
+        Vehicle.record_limit(1).all
+      end
+    end
+  end
+
   describe 'local secondary indexes used for `where` clauses' do
     let(:model) {
       Class.new do

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -13,20 +13,20 @@ describe Dynamoid::Criteria do
   end
 
   it 'finds all using where' do
-    expect(User.where(:name => 'Josh').all).to eq [user1]
+    expect(User.where(:name => 'Josh').all.to_a).to eq [user1]
   end
 
   context "transforms booleans" do
     it 'accepts native' do
-      expect(User.where(:admin => 't').all).to eq [user1]
+      expect(User.where(:admin => 't').all.to_a).to eq [user1]
     end
 
     it 'accepts string' do
-      expect(User.where(:admin => 'true').all).to eq [user1]
+      expect(User.where(:admin => 'true').all.to_a).to eq [user1]
     end
 
     it 'accepts boolean' do
-      expect(User.where(:admin => true).all).to eq [user1]
+      expect(User.where(:admin => true).all.to_a).to eq [user1]
     end
   end
 
@@ -41,11 +41,11 @@ describe Dynamoid::Criteria do
     end
 
     it 'returns empty attributes for where' do
-      expect(Magazine.where(title: 'Josh').all).to eq []
+      expect(Magazine.where(title: 'Josh').all.to_a).to eq []
     end
 
     it 'returns empty attributes for all' do
-      expect(Magazine.all).to eq []
+      expect(Magazine.all.to_a).to eq []
     end
   end
 
@@ -58,7 +58,7 @@ describe Dynamoid::Criteria do
 
   it 'returns N records' do
     5.times { |i| User.create(:name => 'Josh', :email => 'josh_#{i}@joshsymonds.com') }
-    expect(User.record_limit(2).all.size).to eq(2)
+    expect(User.record_limit(2).all.count).to eq(2)
   end
 
   # TODO This test is broken using the AWS SDK adapter.

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -58,7 +58,7 @@ describe Dynamoid::Finders do
     it 'finds using method_missing for multiple attributes' do
       user = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
 
-      array = User.find_all_by_name_and_email('Josh', 'josh@joshsymonds.com')
+      array = User.find_all_by_name_and_email('Josh', 'josh@joshsymonds.com').to_a
 
       expect(array).to eq [user]
     end
@@ -67,7 +67,7 @@ describe Dynamoid::Finders do
       user1 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
       user2 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
 
-      array = User.find_all_by_name('Josh')
+      array = User.find_all_by_name('Josh').to_a
 
       expect(array.size).to eq 2
       expect(array).to include user1
@@ -78,7 +78,7 @@ describe Dynamoid::Finders do
       user1 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
       user2 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
 
-      array = User.find_all_by_name_and_email('Josh', 'josh@joshsymonds.com')
+      array = User.find_all_by_name_and_email('Josh', 'josh@joshsymonds.com').to_a
 
       expect(array.size).to eq 2
       expect(array).to include user1
@@ -89,7 +89,7 @@ describe Dynamoid::Finders do
       user1 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
       user2 = User.create(:name => 'Justin', :email => 'justin@joshsymonds.com')
 
-      array = User.find_all_by_name_and_email('Gaga','josh@joshsymonds.com')
+      array = User.find_all_by_name_and_email('Gaga','josh@joshsymonds.com').to_a
 
       expect(array).to be_empty
     end
@@ -98,7 +98,7 @@ describe Dynamoid::Finders do
       user1 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
       user2 = User.create(:name => 'Justin', :email => 'justin@joshsymonds.com')
 
-      array = User.find_all_by_name('Gaga')
+      array = User.find_all_by_name('Gaga').to_a
 
       expect(array).to be_empty
     end
@@ -106,7 +106,7 @@ describe Dynamoid::Finders do
     it 'should find on a query that is not indexed' do
       user = User.create(:password => 'Test')
 
-      array = User.find_all_by_password('Test')
+      array = User.find_all_by_password('Test').to_a
 
       expect(array).to eq [user]
     end
@@ -114,14 +114,14 @@ describe Dynamoid::Finders do
     it 'should find on a query on multiple attributes that are not indexed' do
       user = User.create(:password => 'Test', :name => 'Josh')
 
-      array = User.find_all_by_password_and_name('Test', 'Josh')
+      array = User.find_all_by_password_and_name('Test', 'Josh').to_a
 
       expect(array).to eq [user]
     end
 
     it 'should return an empty array when fields exist but nothing is found' do
       User.create_table
-      array = User.find_all_by_password('Test')
+      array = User.find_all_by_password('Test').to_a
 
       expect(array).to be_empty
     end


### PR DESCRIPTION
Old behaviour of `Model.where({}).all`:
- load lazily if user specified batch size
- load all collection into memory otherwise

Proposed behaviour - always return lazy evaluated collection

It means `Model.where({}).all` returns `Enumerator` instead of `Array`. If you need `Array` interface you have to convert collection to `Array` manually with `to_a` method call