### PR TITLE
Chain: Fix batch_size for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 * Remove support for Dynamoid's (pseudo)indexes, now that DynamoDB offers
   local and global indexes.
 * Rename :float field type to :number.
-* Rename Chain#limit to Chain#record_limit.
+* Rename Chain#limit to Chain#eval_limit.
 
 Housekeeping:
 

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -325,6 +325,7 @@ module Dynamoid #:nodoc:
         opts[:select] = 'ALL_ATTRIBUTES'
         opts[:record_limit] = @record_limit if @record_limit
         opts[:scan_limit] = @scan_limit if @scan_limit
+        opts[:batch_size] = @batch_size if @batch_size
         opts[:next_token] = start_key if @start
         opts[:scan_index_forward] = @scan_index_forward
         opts
@@ -347,8 +348,8 @@ module Dynamoid #:nodoc:
         opts = {}
         opts[:record_limit] = @record_limit if @record_limit
         opts[:scan_limit] = @scan_limit if @scan_limit
-        opts[:next_token] = start_key if @start
         opts[:batch_size] = @batch_size if @batch_size
+        opts[:next_token] = start_key if @start
         opts[:consistent_read] = true if @consistent_read
         opts
       end


### PR DESCRIPTION
- [Update] Queries weren't passing the `batch_size` to the underlying
  adapter. Add and added test to test for this behavior.
- [Update] Modified changelog in previous commit accidentally with
  blanket `eval_limit` replaced with `record_limit`. Changing back
  since that statement is not correct in the changelog.

Related Issue https://github.com/Dynamoid/Dynamoid/issues/85