### PR TITLE
Fields: Add options for range method for Document

### DIFF
--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -67,8 +67,8 @@ module Dynamoid #:nodoc:
         end
       end
 
-      def range(name, type = :string)
-        field(name, type)
+      def range(name, type = :string, options = {})
+        field(name, type, options)
         self.range_key = name
       end
 

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -20,6 +20,26 @@ describe Dynamoid::Fields do
     expect{address.id}.to_not raise_error
   end
 
+  it 'allows range key serializers' do
+    date_serializer = Class.new do
+      def self.dump(v)
+        v && v.strftime('%m/%d/%Y')
+      end
+
+      def self.load(v)
+        v && DateTime.strptime(v, '%m/%d/%Y')
+      end
+    end
+
+    expect do
+      model = Class.new do
+        include Dynamoid::Document
+        table name: :special
+        range :special_date, :serialized, serializer: date_serializer
+      end
+    end.to_not raise_error
+  end
+
   it 'automatically declares and fills in created_at and updated_at' do
     address.save
 


### PR DESCRIPTION
- [Update] Allow passing options to `range` when defining attributes
  of the document. Current options mainly for serialized fields and
  passing the `serializer` option.