### PR TITLE
Field Defaults: Allow default primitive w/o Lambda

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -229,6 +229,20 @@ module Dynamoid
           val
         end
       end
+
+      # Evaluates the default value given, this is used by undump
+      # when determining the value of the default given for a field options.
+      #
+      # @param [Object] :value the attribute's default value
+      def undump_default_value(val)
+        if val.respond_to?(:call)
+          val.call
+        elsif val.duplicable?
+          val.dup
+        else
+          val
+        end
+      end
     end
 
     # Set updated_at and any passed in field to current DateTime. Useful for things like last_login_at, etc.
@@ -385,20 +399,6 @@ module Dynamoid
             raise Dynamoid::Errors::StaleObjectError.new(self, 'persist')
           end
         end
-      end
-    end
-
-    # Evaluates the default value given, this is used by undump
-    # when determining the value of the default given for a field options.
-    #
-    # @param [Object] :value the attribute's default value
-    def undump_default_value(value)
-      if value.respond_to?(:call)
-        value.call
-      elsif value.duplicable?
-        value.dup
-      else
-        value
       end
     end
   end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -75,7 +75,13 @@ module Dynamoid
               hash[attribute] = undump_field(incoming[attribute], options)
             elsif options.has_key?(:default)
               default_value = options[:default]
-              value = default_value.respond_to?(:call) ? default_value.call : default_value.dup
+              value = if default_value.respond_to?(:call)
+                        default_value.call
+                      elsif default_value.duplicable?
+                        default_value.dup
+                      else
+                        default_value
+                      end
               hash[attribute] = value
             else
               hash[attribute] = nil

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -74,15 +74,7 @@ module Dynamoid
             if incoming.has_key?(attribute)
               hash[attribute] = undump_field(incoming[attribute], options)
             elsif options.has_key?(:default)
-              default_value = options[:default]
-              value = if default_value.respond_to?(:call)
-                        default_value.call
-                      elsif default_value.duplicable?
-                        default_value.dup
-                      else
-                        default_value
-                      end
-              hash[attribute] = value
+              hash[attribute] = undump_default_value(options[:default])
             else
               hash[attribute] = nil
             end
@@ -393,6 +385,20 @@ module Dynamoid
             raise Dynamoid::Errors::StaleObjectError.new(self, 'persist')
           end
         end
+      end
+    end
+
+    # Evaluates the default value given, this is used by undump
+    # when determining the value of the default given for a field options.
+    #
+    # @param [Object] :value the attribute's default value
+    def undump_default_value(value)
+      if value.respond_to?(:call)
+        value.call
+      elsif value.duplicable?
+        value.dup
+      else
+        value
       end
     end
   end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -207,6 +207,8 @@ describe Dynamoid::Fields do
         field :name, :string, :default => 'x'
         field :uid, :integer, :default => lambda { 42 }
         field :config, :serialized, default: {}
+        field :version, :integer, :default => 1
+        field :hidden, :boolean, :default => false
 
         def self.name
           'Document'
@@ -225,10 +227,12 @@ describe Dynamoid::Fields do
       expect(doc.uid).to eq(42)
     end
 
-    it 'should save default value' do
+    it 'should save default values' do
       doc.save!
       expect(doc.reload.name).to eq('x')
       expect(doc.uid).to eq(42)
+      expect(doc.version).to eq(1)
+      expect(doc.hidden).to be false
     end
 
     it 'does not use default value if nil value assigns' do


### PR DESCRIPTION
- [Update] Persistence was expecting the default value to support
  either `call` or `dup` but certain values like numbers and booleans
  do not support `dup` since they are copy by value. Adding support
  so can write `:default => 1` or `{ default: 1 }` as README
  suggests with `field :actions_taken, :integer, {default: 0}`.

CR @pboling @andrykonchin thanks!