### PR TITLE
Call `eager_load!` to handle Rails models outside of `app/models` directory

### DIFF
--- a/lib/dynamoid/tasks/database.rake
+++ b/lib/dynamoid/tasks/database.rake
@@ -1,11 +1,11 @@
 require 'dynamoid'
 require 'dynamoid/tasks/database'
 
-Rails.application.eager_load!
-
 namespace :dynamoid do
   desc "Creates DynamoDB tables, one for each of your Dynamoid models - does not modify pre-existing tables"
   task :create_tables => :environment do
+    Rails.application.eager_load!
+
     tables = Dynamoid::Tasks::Database.create_tables
     result = tables[:created].map{ |c| "#{c} created" } + tables[:existing].map{ |e| "#{e} already exists" }
     result.sort.each{ |r| puts r }

--- a/lib/dynamoid/tasks/database.rake
+++ b/lib/dynamoid/tasks/database.rake
@@ -1,10 +1,7 @@
 require 'dynamoid'
 require 'dynamoid/tasks/database'
 
-MODELS = File.join(Rails.root, "app/models")
-
-Dir[ File.join(MODELS, "*.rb") ].sort.each { |file| require file }
-
+Rails.application.eager_load!
 
 namespace :dynamoid do
   desc "Creates DynamoDB tables, one for each of your Dynamoid models - does not modify pre-existing tables"


### PR DESCRIPTION
This also fixes some other dependencies issue we've faced.