### PR TITLE
Change behaviour of `find`

### DIFF
--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -107,7 +107,7 @@ module Dynamoid #:nodoc:
       def exists?(id_or_conditions = {})
         case id_or_conditions
           when Hash then where(id_or_conditions).first.present?
-          else !! find(id_or_conditions)
+          else !! find_by_id(id_or_conditions)
         end
       end
 

--- a/lib/dynamoid/errors.rb
+++ b/lib/dynamoid/errors.rb
@@ -61,6 +61,9 @@ module Dynamoid
       end
     end
 
+    class RecordNotFound < Error
+    end
+
     class DocumentNotValid < Error
       attr_reader :document
 

--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -36,9 +36,12 @@ module Dynamoid
         ids = Array(ids.flatten.uniq)
         if ids.count == 1
           result = self.find_by_id(ids.first, options)
+          raise Errors::RecordNotFound if result.nil?
           expects_array ? Array(result) : result
         else
-          find_all(ids)
+          result = find_all(ids)
+          raise Errors::RecordNotFound if result.size != ids.size
+          result
         end
       end
 

--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -36,11 +36,18 @@ module Dynamoid
         ids = Array(ids.flatten.uniq)
         if ids.count == 1
           result = self.find_by_id(ids.first, options)
-          raise Errors::RecordNotFound if result.nil?
+          if result.nil?
+            message = "Couldn't find #{self.name} with '#{self.hash_key}'=#{ids[0]}"
+            raise Errors::RecordNotFound.new(message)
+          end
           expects_array ? Array(result) : result
         else
           result = find_all(ids)
-          raise Errors::RecordNotFound if result.size != ids.size
+          if result.size != ids.size
+            message = "Couldn't find all #{self.name.pluralize} with '#{self.hash_key}': (#{ids.join(', ')}) "
+            message << "(found #{result.size} results, but was looking for #{ids.size})"
+            raise Errors::RecordNotFound.new(message)
+          end
           result
         end
       end

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -16,8 +16,8 @@ describe Dynamoid::Finders do
     expect(found.new_record).to be_falsey
   end
 
-  it 'returns nil when nothing is found' do
-    expect(Address.find('1234')).to be_nil
+  it 'raises error when nothing is found' do
+    expect { expect(Address.find('1234')) }.to raise_error(Dynamoid::Errors::RecordNotFound)
   end
 
   it 'finds multiple ids' do
@@ -34,12 +34,12 @@ describe Dynamoid::Finders do
     expect(Address.find(address.id)).to eq address
   end
 
-  it 'returns nil if non-array id is passed in and no result found' do
-    expect(Address.find("not existing id")).to be_nil
+  it 'raises error if non-array id is passed in and no result found' do
+    expect { Address.find("not existing id") }.to raise_error(Dynamoid::Errors::RecordNotFound)
   end
 
-  it 'returns empty array if array of ids is passed in and no result found' do
-    expect(Address.find(["not existing id"])).to eq []
+  it 'raises error if array of ids is passed in and no result found' do
+    expect { Address.find(["not existing id"]) }.to raise_error(Dynamoid::Errors::RecordNotFound)
   end
 
   # TODO: ATM, adapter sets consistent read to be true for all query. Provide option for setting consistent_read option

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -17,13 +17,23 @@ describe Dynamoid::Finders do
   end
 
   it 'raises error when nothing is found' do
-    expect { expect(Address.find('1234')) }.to raise_error(Dynamoid::Errors::RecordNotFound)
+    expect { Address.find('1234') }.to raise_error(
+      Dynamoid::Errors::RecordNotFound, "Couldn't find Address with 'id'=1234")
   end
 
   it 'finds multiple ids' do
     address2 = Address.create(:city => 'Illinois')
 
     expect(Set.new(Address.find(address.id, address2.id))).to eq Set.new([address, address2])
+  end
+
+  it 'raises error when passed several ids and some models were not found' do
+    a1 = Address.create
+    a2 = Address.create
+    expect { Address.find(a1.id, a2.id, 'fake-id') }.to raise_error(
+      Dynamoid::Errors::RecordNotFound,
+      "Couldn't find all Addresses with 'id': (#{a1.id}, #{a2.id}, fake-id) " +
+      "(found 2 results, but was looking for 3)")
   end
 
   it 'returns array if passed in array' do
@@ -35,11 +45,14 @@ describe Dynamoid::Finders do
   end
 
   it 'raises error if non-array id is passed in and no result found' do
-    expect { Address.find("not existing id") }.to raise_error(Dynamoid::Errors::RecordNotFound)
+    expect { Address.find("not-existing-id") }.to raise_error(
+      Dynamoid::Errors::RecordNotFound,
+      "Couldn't find Address with 'id'=not-existing-id")
   end
 
   it 'raises error if array of ids is passed in and no result found' do
-    expect { Address.find(["not existing id"]) }.to raise_error(Dynamoid::Errors::RecordNotFound)
+    expect { Address.find(["not-existing-id"]) }.to raise_error(
+      Dynamoid::Errors::RecordNotFound, "Couldn't find Address with 'id'=not-existing-id")
   end
 
   # TODO: ATM, adapter sets consistent read to be true for all query. Provide option for setting consistent_read option


### PR DESCRIPTION
It's common to get exception if one or more records can not be found for the requested ids

Both `Mongoid` and `ActiveRecord` support this behaviour ([here](https://mongoid.github.io/old/en/mongoid/docs/querying.html) and [here](http://api.rubyonrails.org/v5.1/classes/ActiveRecord/FinderMethods.html#method-i-find))

Current behaviour - `find` returns `nil` or smaller array.
New behaviour - it raises `RecordNotFound` if one or more records can not be found for the requested ids