### PR TITLE
Change `save`'s return value

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -275,8 +275,6 @@ module Dynamoid
       else
         persist
       end
-
-      self
     end
 
     #

--- a/lib/dynamoid/validations.rb
+++ b/lib/dynamoid/validations.rb
@@ -31,6 +31,7 @@ module Dynamoid
     def save!
       raise Dynamoid::Errors::DocumentNotValid.new(self) unless valid?
       save(:validate => false)
+      self
     end
 
     module ClassMethods

--- a/spec/dynamoid/validations_spec.rb
+++ b/spec/dynamoid/validations_spec.rb
@@ -47,7 +47,7 @@ describe Dynamoid::Validations do
   end
 
   it 'does not validate when saves if `validate` option is false' do
-    model = Class.new do
+    klass = Class.new do
       include Dynamoid::Document
       table name: :documents
 
@@ -55,6 +55,34 @@ describe Dynamoid::Validations do
       validates :name, presence: true
     end
 
-    expect(model.new.save(validate: false)).to be_persisted
+    model = klass.new
+    model.save(validate: false)
+    expect(model).to be_persisted
+  end
+
+  it 'returns true if model is valid' do
+    klass = Class.new do
+      include Dynamoid::Document
+      table name: :documents
+
+      field :name
+      validates :name, presence: true
+    end
+
+    expect(klass.new(name: 'some-name').save).to eq(true)
+  end
+
+  it 'returns false if model is invalid' do
+    klass = Class.new do
+      include Dynamoid::Document
+      table name: :documents
+
+      field :name
+      validates :name, presence: true
+
+      def self.name; 'Document'; end
+    end
+
+    expect(klass.new(name: nil).save).to eq(false)
   end
 end

--- a/spec/dynamoid/validations_spec.rb
+++ b/spec/dynamoid/validations_spec.rb
@@ -85,4 +85,16 @@ describe Dynamoid::Validations do
 
     expect(klass.new(name: nil).save).to eq(false)
   end
+
+  describe 'save!' do
+    it 'returns self' do
+      klass = Class.new do
+        include Dynamoid::Document
+        table name: :documents
+      end
+
+      model = klass.new
+      expect(model.save!).to eq(model)
+    end
+  end
 end


### PR DESCRIPTION
Current behaviour - `save` returns `self` if model is saved successfully
New behaviour - it returns `true`

Both `Mongoid` and `Active Record` supports this behaviour ([here](http://www.rubydoc.info/github/mongoid/mongoid/Mongoid/Persistable/Savable) )