### PR TITLE
initialize `client` and `table_cache` when underlying variables are `nil`

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -45,14 +45,13 @@ module Dynamoid
         #   because Amazon, damnit.
         resp.send(lookup).table_status
       }
-      attr_reader :table_cache
 
       # Establish the connection to DynamoDB.
-      #
+
       # @return [Aws::DynamoDB::Client] the DynamoDB connection
       def connect!
-        @client = Aws::DynamoDB::Client.new(connection_config)
-        @table_cache = {}
+        table_cache
+        client
       end
 
       def connection_config
@@ -75,10 +74,18 @@ module Dynamoid
       end
 
       # Return the client object.
+      # Will establish DynamoDB connection when necessary.
       #
       # @since 1.0.0
       def client
-        @client
+        @client ||= Aws::DynamoDB::Client.new(connection_config)
+      end
+
+      # Return table cache.
+      #
+      # @since 1.3.5
+      def table_cache
+        @table_cache ||= {}
       end
 
       # Puts or deletes multiple items in one or more tables


### PR DESCRIPTION
We've had multiple outages in production application running on Sidekiq (never in Rails application).

Both of these variables have been `nil`. I'm wondering if that is the right solution, or whether it should safeguarded with some `concurrent-ruby`?