### PR TITLE
Create multiple objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,12 @@ address.city = 'Chicago'
 address.save
 ```
 
+To create multiple documents at once:
+
+```ruby
+User.create([{name: 'Josh'}, {name: 'Nick'}])
+```
+
 There is an efficient and low-level way to create multiple documents
 (without validation and callbacks running):
 

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -87,7 +87,11 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def create!(attrs = {})
-        build(attrs).tap(&:save!)
+        if attrs.is_a?(Array)
+          attrs.map { |attr| create!(attr) }
+        else
+          build(attrs).tap(&:save!)
+        end
       end
 
       # Initialize a new object.

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -72,7 +72,11 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def create(attrs = {})
-        build(attrs).tap(&:save)
+        if attrs.is_a?(Array)
+          attrs.map { |attr| create(attr) }
+        else
+          build(attrs).tap(&:save)
+        end
       end
 
       # Initialize a new object and immediately save it to the database. Raise an exception if persistence failed.

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -86,6 +86,14 @@ describe Dynamoid::Document do
     expect(address.id).to_not be_nil
   end
 
+  it 'creates multiple documents' do
+    addresses = Address.create([{city: 'Chicago'}, {city: 'New York'}])
+
+    expect(addresses.size).to eq 2
+    expect(addresses.all?(&:persisted?)).to be true
+    expect(addresses[0].city).to eq 'Chicago'
+    expect(addresses[1].city).to eq 'New York'
+  end
   it 'knows if a document exists or not' do
     address = Address.create(:city => 'Chicago')
     expect(Address.exists?(address.id)).to be_truthy

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -94,6 +94,21 @@ describe Dynamoid::Document do
     expect(addresses[0].city).to eq 'Chicago'
     expect(addresses[1].city).to eq 'New York'
   end
+
+  it 'raises error when tries to save multiple invalid objects' do
+    klass = Class.new do
+      include Dynamoid::Document
+      field :city
+      validates :city, presence: true
+
+      def self.name; 'Address'; end
+    end
+
+    expect {
+      klass.create!([{city: 'Chicago'}, {city: nil}])
+    }.to raise_error(Dynamoid::Errors::DocumentNotValid)
+  end
+
   it 'knows if a document exists or not' do
     address = Address.create(:city => 'Chicago')
     expect(Address.exists?(address.id)).to be_truthy


### PR DESCRIPTION
Add support of multiple documents creation with `.create` and `.create!`