### PR TITLE
Add efficient creation of multiple documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,13 @@ address.city = 'Chicago'
 address.save
 ```
 
+There is an efficient and low-level way to create multiple documents
+(without validation and callbacks running):
+
+```ruby
+users = User.import([{name: 'Josh'}, {name: 'Nick'}])
+```
+
 ### Querying
 
 Querying can be done in one of three ways:

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -387,7 +387,7 @@ module Dynamoid
     # @since 0.2.0
     def persist(conditions = nil)
       run_callbacks(:save) do
-        self.hash_key = SecureRandom.uuid if self.hash_key.nil? || self.hash_key.blank?
+        self.hash_key = SecureRandom.uuid if self.hash_key.blank?
 
         # Add an exists check to prevent overwriting existing records with new ones
         if(new_record?)


### PR DESCRIPTION
Add `Document.import` method to efficiently create multiple documents

`BatchWriteItem` ([documentation]( http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#batch_write_item-instance_method)) is used so we make fewer HTTP calls

Validation and callbacks are skipped for simplicity. `UnprocessedItems` and `ValidationException` are not handled too.

Example:
```
addresses = Address.import([{city: 'Chicago'}, {city: 'New York'}])
```