### PR TITLE
Fix Dynamoid::Criteria::Chain#key_present?

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -267,7 +267,7 @@ module Dynamoid #:nodoc:
         query_keys = query.keys.collect { |k| k.to_s.split('.').first }
 
         # See if querying based on table hash key
-        if query_keys.include?(source.hash_key.to_s)
+        if query.keys.map(&:to_s).include?(source.hash_key.to_s)
           @hash_key = source.hash_key
 
           # Use table's default range key

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -40,6 +40,13 @@ describe Dynamoid::Criteria::Chain do
       expect(chain).to receive(:records_via_scan)
       chain.all
     end
+
+    it 'Scans when there is only not-equal operator for hash key' do
+      chain = Dynamoid::Criteria::Chain.new(Address)
+      chain.query = { :'id.in' => ['test'] }
+      expect(chain).to receive(:records_via_scan)
+      chain.all
+    end
   end
 
   describe 'Limits' do


### PR DESCRIPTION
Fix issue with `Query` request.
Any non-equal condition for partition key leads to making `Query` operation but it should make `Scan` one.

Example

`Document.where(:"id.in" => [])` 