### PR TITLE
Correct Ruby code style

### DIFF
--- a/lib/dynamoid.rb
+++ b/lib/dynamoid.rb
@@ -1,36 +1,36 @@
-require "delegate"
-require "time"
-require "securerandom"
-require "active_support"
-require "active_support/core_ext"
-require "active_support/json"
-require "active_support/inflector"
-require "active_support/lazy_load_hooks"
-require "active_support/time_with_zone"
-require "active_model"
+require 'delegate'
+require 'time'
+require 'securerandom'
+require 'active_support'
+require 'active_support/core_ext'
+require 'active_support/json'
+require 'active_support/inflector'
+require 'active_support/lazy_load_hooks'
+require 'active_support/time_with_zone'
+require 'active_model'
 
-require "dynamoid/version"
-require "dynamoid/errors"
-require "dynamoid/fields"
-require "dynamoid/indexes"
-require "dynamoid/associations"
-require "dynamoid/persistence"
-require "dynamoid/dirty"
-require "dynamoid/validations"
-require "dynamoid/criteria"
-require "dynamoid/finders"
-require "dynamoid/identity_map"
-require "dynamoid/config"
-require "dynamoid/components"
-require "dynamoid/document"
-require "dynamoid/adapter"
+require 'dynamoid/version'
+require 'dynamoid/errors'
+require 'dynamoid/fields'
+require 'dynamoid/indexes'
+require 'dynamoid/associations'
+require 'dynamoid/persistence'
+require 'dynamoid/dirty'
+require 'dynamoid/validations'
+require 'dynamoid/criteria'
+require 'dynamoid/finders'
+require 'dynamoid/identity_map'
+require 'dynamoid/config'
+require 'dynamoid/components'
+require 'dynamoid/document'
+require 'dynamoid/adapter'
 
-require "dynamoid/tasks/database"
+require 'dynamoid/tasks/database'
 
-require "dynamoid/middleware/identity_map"
+require 'dynamoid/middleware/identity_map'
 
 if defined?(Rails)
-  require "dynamoid/railtie"
+  require 'dynamoid/railtie'
 end
 
 module Dynamoid

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -99,10 +99,10 @@ module Dynamoid
     # @param [Array] range_key of the record to delete, can also be a string of just one range_key
     #
     def delete(table, ids, options = {})
-      range_key = options[:range_key] #array of range keys that matches the ids passed in
+      range_key = options[:range_key] # array of range keys that matches the ids passed in
       if ids.respond_to?(:each)
         if range_key.respond_to?(:each)
-          #turn ids into array of arrays each element being hash_key, range_key
+          # turn ids into array of arrays each element being hash_key, range_key
           ids = ids.each_with_index.map{|id, i| [id, range_key[i]]}
         else
           ids = range_key ? [[ids, range_key]] : ids

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -103,7 +103,7 @@ module Dynamoid
       if ids.respond_to?(:each)
         if range_key.respond_to?(:each)
           #turn ids into array of arrays each element being hash_key, range_key
-          ids = ids.each_with_index.map{|id,i| [id,range_key[i]]}
+          ids = ids.each_with_index.map{|id, i| [id, range_key[i]]}
         else
           ids = range_key ? [[ids, range_key]] : ids
         end

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -89,7 +89,7 @@ module Dynamoid
       # @param [Array]  items to be processed
       # @param [Hash]   additional options
       #
-      #See: http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#batch_write_item-instance_method
+      # See: http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#batch_write_item-instance_method
       def batch_write_item table_name, objects, options = {}
         request_items = []
         options ||= {}
@@ -713,7 +713,7 @@ module Dynamoid
         end
       end
 
-      #Converts from symbol to the API string for the given data type
+      # Converts from symbol to the API string for the given data type
       # E.g. :number -> 'N'
       def api_type(type)
         case(type)

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -880,7 +880,6 @@ module Dynamoid
         attribute_definitions
       end
 
-
       # Builds an attribute definitions based on hash key and range key
       # @params [Hash] hash_key_schema - eg: {:id => :string}
       # @params [Hash] range_key_schema - eg: {:created_at => :datetime}

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -199,12 +199,9 @@ module Dynamoid
         begin
           requests.map do |request_items|
             client.batch_write_item(
-              {
-                request_items: request_items,
-                return_consumed_capacity: 'TOTAL',
-                return_item_collection_metrics: 'SIZE'
-              }
-            )
+              request_items: request_items,
+              return_consumed_capacity: 'TOTAL',
+              return_item_collection_metrics: 'SIZE')
           end
         rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException => e
           raise Dynamoid::Errors::ConditionalCheckFailedException, e
@@ -685,7 +682,7 @@ module Dynamoid
           check = {again: true}
           while check[:again]
             sleep Dynamoid::Config.sync_retry_wait_seconds
-            resp = client.describe_table({ table_name: table_name })
+            resp = client.describe_table(table_name: table_name)
             check = check_table_status?(counter, resp, status)
             Dynamoid.logger.info "Checked table status for #{table_name} (check #{check.inspect})"
             counter += 1

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -234,8 +234,8 @@ module Dynamoid
         gs_indexes = options[:global_secondary_indexes]
 
         key_schema = {
-          :hash_key_schema => { key => (options[:hash_key_type] || :string) },
-          :range_key_schema => options[:range_key]
+          hash_key_schema: { key => (options[:hash_key_type] || :string) },
+          range_key_schema: options[:range_key]
         }
         attribute_definitions = build_all_attribute_definitions(
           key_schema,
@@ -794,10 +794,10 @@ module Dynamoid
         key_schema = aws_key_schema(index.hash_key_schema, index.range_key_schema)
 
         hash = {
-          :index_name => index.name,
-          :key_schema => key_schema,
-          :projection => {
-            :projection_type => index.projection_type.to_s.upcase
+          index_name: index.name,
+          key_schema: key_schema,
+          projection: {
+            projection_type: index.projection_type.to_s.upcase
           }
         }
 
@@ -809,8 +809,8 @@ module Dynamoid
         # Only global secondary indexes have a separate throughput.
         if index.type == :global_secondary
           hash[:provisioned_throughput] = {
-            :read_capacity_units => index.read_capacity,
-            :write_capacity_units => index.write_capacity
+            read_capacity_units: index.read_capacity,
+            write_capacity_units: index.write_capacity
           }
         end
         hash
@@ -910,8 +910,8 @@ module Dynamoid
         aws_type = api_type(dynamoid_type)
 
         {
-          :attribute_name => name.to_s,
-          :attribute_type => aws_type
+          attribute_name: name.to_s,
+          attribute_type: aws_type
         }
       end
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -141,7 +141,7 @@ module Dynamoid
             request_items = Hash.new{|h, k| h[k] = []}
 
             keys = if rng.present?
-              Array(ids).map do |h,r|
+              Array(ids).map do |h, r|
                 { hk => h, rng => r }
               end
             else
@@ -513,7 +513,7 @@ module Dynamoid
         end
 
         query_filter = {}
-        opts.reject {|k,_| k.in? RANGE_MAP.keys}.each do |attr, hash|
+        opts.reject {|k, _| k.in? RANGE_MAP.keys}.each do |attr, hash|
           query_filter[attr] = {
             comparison_operator: FIELD_MAP[hash.keys[0]],
             attribute_value_list: [
@@ -738,13 +738,13 @@ module Dynamoid
       # @return an Expected stanza for the given conditions hash
       #
       def expected_stanza(conditions = nil)
-        expected = Hash.new { |h,k| h[k] = {} }
+        expected = Hash.new { |h, k| h[k] = {} }
         return expected unless conditions
 
         conditions.delete(:unless_exists).try(:each) do |col|
           expected[col.to_s][:exists] = false
         end
-        conditions.delete(:if).try(:each) do |col,val|
+        conditions.delete(:if).try(:each) do |col, val|
           expected[col.to_s][:value] = val
         end
 
@@ -765,7 +765,7 @@ module Dynamoid
       #
       def result_item_to_hash(item)
         {}.tap do |r|
-          item.each { |k,v| r[k.to_sym] = v }
+          item.each { |k, v| r[k.to_sym] = v }
         end
       end
 
@@ -936,7 +936,7 @@ module Dynamoid
         def range_type
           range_type ||= schema[:attribute_definitions].find { |d|
             d[:attribute_name] == range_key
-          }.try(:fetch,:attribute_type, nil)
+          }.try(:fetch, :attribute_type, nil)
         end
 
         def hash_key
@@ -1005,19 +1005,19 @@ module Dynamoid
         def to_h
           ret = {}
 
-          @additions.each do |k,v|
+          @additions.each do |k, v|
             ret[k.to_s] = {
               action: ADD,
               value: v
             }
           end
-          @deletions.each do |k,v|
+          @deletions.each do |k, v|
             ret[k.to_s] = {
               action: DELETE,
               value: v
             }
           end
-          @updates.each do |k,v|
+          @updates.each do |k, v|
             ret[k.to_s] = {
               action: PUT,
               value: v

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -3,7 +3,7 @@ module Dynamoid
 
     # The AwsSdkV2 adapter provides support for the aws-sdk version 2 for ruby.
     class AwsSdkV2
-      EQ = "EQ".freeze
+      EQ = 'EQ'.freeze
       RANGE_MAP = {
           range_greater_than: 'GT',
           range_less_than:    'LT',
@@ -28,16 +28,16 @@ module Dynamoid
           contains:     'CONTAINS',
           not_contains: 'NOT_CONTAINS'
       }
-      HASH_KEY  = "HASH".freeze
-      RANGE_KEY = "RANGE".freeze
-      STRING_TYPE  = "S".freeze
-      NUM_TYPE     = "N".freeze
-      BINARY_TYPE  = "B".freeze
+      HASH_KEY  = 'HASH'.freeze
+      RANGE_KEY = 'RANGE'.freeze
+      STRING_TYPE  = 'S'.freeze
+      NUM_TYPE     = 'N'.freeze
+      BINARY_TYPE  = 'B'.freeze
       TABLE_STATUSES = {
-          creating: "CREATING",
-          updating: "UPDATING",
-          deleting: "DELETING",
-          active: "ACTIVE"
+          creating: 'CREATING',
+          updating: 'UPDATING',
+          deleting: 'DELETING',
+          active: 'ACTIVE'
       }.freeze
       PARSE_TABLE_STATUS = ->(resp, lookup = :table) {
         # lookup is table for describe_table API
@@ -94,7 +94,7 @@ module Dynamoid
         request_items = []
         options ||= {}
         objects.each do |o|
-          request_items << { "put_request" => { item: o } }
+          request_items << { 'put_request' => { item: o } }
         end
 
         begin
@@ -103,8 +103,8 @@ module Dynamoid
               request_items: {
                 table_name => request_items,
               },
-              return_consumed_capacity: "TOTAL",
-              return_item_collection_metrics: "SIZE"
+              return_consumed_capacity: 'TOTAL',
+              return_item_collection_metrics: 'SIZE'
             }.merge!(options)
           )
         rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException => e
@@ -201,8 +201,8 @@ module Dynamoid
             client.batch_write_item(
               {
                 request_items: request_items,
-                return_consumed_capacity: "TOTAL",
-                return_item_collection_metrics: "SIZE"
+                return_consumed_capacity: 'TOTAL',
+                return_item_collection_metrics: 'SIZE'
               }
             )
           end
@@ -391,7 +391,7 @@ module Dynamoid
             key: key_stanza(table, key, range_key),
             attribute_updates: iu.to_h,
             expected: expected_stanza(conditions),
-            return_values: "ALL_NEW"
+            return_values: 'ALL_NEW'
           )
           result_item_to_hash(result[:attributes])
         rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException => e
@@ -1027,9 +1027,9 @@ module Dynamoid
           ret
         end
 
-        ADD    = "ADD".freeze
-        DELETE = "DELETE".freeze
-        PUT    = "PUT".freeze
+        ADD    = 'ADD'.freeze
+        DELETE = 'DELETE'.freeze
+        PUT    = 'PUT'.freeze
       end
     end
   end

--- a/lib/dynamoid/associations.rb
+++ b/lib/dynamoid/associations.rb
@@ -89,7 +89,7 @@ module Dynamoid
       # @since 0.2.0
       def association(type, name, options = {})
         field "#{name}_ids".to_sym, :set
-        self.associations[name] = options.merge(:type => type)
+        self.associations[name] = options.merge(type: type)
         define_method(name) do
           @associations[:"#{name}_ids"] ||= Dynamoid::Associations.const_get(type.to_s.camelcase).new(self, name, options)
         end

--- a/lib/dynamoid/associations.rb
+++ b/lib/dynamoid/associations.rb
@@ -16,16 +16,16 @@ module Dynamoid
   #   * has_one
   module Associations
     extend ActiveSupport::Concern
-    
+
     # Create the association tracking attribute and initialize it to an empty hash.
     included do
       class_attribute :associations, instance_accessor: false
-      
+
       self.associations = {}
     end
 
     module ClassMethods
-      
+
       # create a has_many association for this document.
       #
       # @param [Symbol] name the name of the association
@@ -38,7 +38,7 @@ module Dynamoid
       def has_many(name, options = {})
         association(:has_many, name, options)
       end
-      
+
       # create a has_one association for this document.
       #
       # @param [Symbol] name the name of the association
@@ -51,7 +51,7 @@ module Dynamoid
       def has_one(name, options = {})
         association(:has_one, name, options)
       end
-      
+
       # create a belongs_to association for this document.
       #
       # @param [Symbol] name the name of the association
@@ -64,7 +64,7 @@ module Dynamoid
       def belongs_to(name, options = {})
         association(:belongs_to, name, options)
       end
-      
+
       # create a has_and_belongs_to_many association for this document.
       #
       # @param [Symbol] name the name of the association
@@ -77,7 +77,7 @@ module Dynamoid
       def has_and_belongs_to_many(name, options = {})
         association(:has_and_belongs_to_many, name, options)
       end
-      
+
       private
 
       # create getters and setters for an association.
@@ -86,7 +86,7 @@ module Dynamoid
       # @param [Symbol] name the name of the association
       # @param [Hash] options options to pass to the association constructor; see above for all valid options
       #
-      # @since 0.2.0      
+      # @since 0.2.0
       def association(type, name, options = {})
         field "#{name}_ids".to_sym, :set
         self.associations[name] = options.merge(:type => type)
@@ -102,5 +102,5 @@ module Dynamoid
 
 
   end
-  
+
 end

--- a/lib/dynamoid/associations.rb
+++ b/lib/dynamoid/associations.rb
@@ -100,7 +100,6 @@ module Dynamoid
       end
     end
 
-
   end
 
 end

--- a/lib/dynamoid/associations/belongs_to.rb
+++ b/lib/dynamoid/associations/belongs_to.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 module Dynamoid #:nodoc:
 
-  # The belongs_to association. For belongs_to, we reference only a single target instead of multiple records; that target is the 
+  # The belongs_to association. For belongs_to, we reference only a single target instead of multiple records; that target is the
   # object to which the association object is associated.
   module Associations
     class BelongsTo
@@ -24,7 +24,7 @@ module Dynamoid #:nodoc:
           return has_one_key_name if target_class.associations[has_one_key_name][:type] == :has_one
         end
       end
-      
+
       # Associate a source object to this association.
       #
       # @since 0.2.0
@@ -34,12 +34,12 @@ module Dynamoid #:nodoc:
 
       # Disassociate a source object from this association.
       #
-      # @since 0.2.0      
+      # @since 0.2.0
       def disassociate_target(object)
         ids = object.send(target_attribute) || Set.new
         object.update_attribute(target_attribute, ids - Array(source.hash_key))
       end
     end
   end
-  
+
 end

--- a/lib/dynamoid/associations/has_many.rb
+++ b/lib/dynamoid/associations/has_many.rb
@@ -8,7 +8,7 @@ module Dynamoid #:nodoc:
 
       private
 
-      # Find the target association, always a :belongs_to association. Uses either options[:inverse_of] or the source class name 
+      # Find the target association, always a :belongs_to association. Uses either options[:inverse_of] or the source class name
       # and default parsing to return the most likely name for the target association.
       #
       # @since 0.2.0
@@ -21,19 +21,19 @@ module Dynamoid #:nodoc:
 
       # Associate a source object to this association.
       #
-      # @since 0.2.0                  
+      # @since 0.2.0
       def associate_target(object)
         object.update_attribute(target_attribute, Set[source.hash_key])
       end
-      
+
       # Disassociate a source object from this association.
       #
-      # @since 0.2.0      
+      # @since 0.2.0
       def disassociate_target(object)
         object.update_attribute(target_attribute, nil)
       end
-      
+
     end
   end
-  
+
 end

--- a/lib/dynamoid/associations/many_association.rb
+++ b/lib/dynamoid/associations/many_association.rb
@@ -57,7 +57,6 @@ module Dynamoid #:nodoc:
         object
       end
 
-
       # Add an object or array of objects to an association. This preserves the current records in the association (if any)
       # and adds the object to the target association if it is detected to exist.
       #

--- a/lib/dynamoid/associations/many_association.rb
+++ b/lib/dynamoid/associations/many_association.rb
@@ -14,7 +14,7 @@ module Dynamoid #:nodoc:
 
       include Enumerable
       # Delegate methods to the records the association represents.
-      delegate :first, :last, :empty?, :size, :class, :to => :records
+      delegate :first, :last, :empty?, :size, :class, to: :records
 
       # The records associated to the source.
       #

--- a/lib/dynamoid/associations/single_association.rb
+++ b/lib/dynamoid/associations/single_association.rb
@@ -32,7 +32,6 @@ module Dynamoid #:nodoc:
         setter(target_class.create(attributes))
       end
 
-
       # Is this object equal to the association's target?
       #
       # @return [Boolean] true/false

--- a/lib/dynamoid/associations/single_association.rb
+++ b/lib/dynamoid/associations/single_association.rb
@@ -5,7 +5,7 @@ module Dynamoid #:nodoc:
     module SingleAssociation
       include Association
 
-      delegate :class, :to => :target
+      delegate :class, to: :target
 
       def setter(object)
         delete

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -11,22 +11,22 @@ module Dynamoid
     include ActiveModel::Observing if defined?(ActiveModel::Observing)
 
     # All the default options.
-    option :adapter, :default => 'aws_sdk_v2'
-    option :namespace, :default => defined?(Rails) ? "dynamoid_#{Rails.application.class.parent_name}_#{Rails.env}" : 'dynamoid'
-    option :access_key, :default => nil
-    option :secret_key, :default => nil
-    option :region, :default => nil
-    option :batch_size, :default => 100
-    option :read_capacity, :default => 100
-    option :write_capacity, :default => 20
-    option :warn_on_scan, :default => true
-    option :endpoint, :default => nil
-    option :identity_map, :default => false
-    option :timestamps, :default => true
-    option :sync_retry_max_times, :default => 60 # a bit over 2 minutes
-    option :sync_retry_wait_seconds, :default => 2
-    option :convert_big_decimal, :default => false
-    option :models_dir, :default => 'app/models' # perhaps you keep your dynamoid models in a different directory?
+    option :adapter, default: 'aws_sdk_v2'
+    option :namespace, default: defined?(Rails) ? "dynamoid_#{Rails.application.class.parent_name}_#{Rails.env}" : 'dynamoid'
+    option :access_key, default: nil
+    option :secret_key, default: nil
+    option :region, default: nil
+    option :batch_size, default: 100
+    option :read_capacity, default: 100
+    option :write_capacity, default: 20
+    option :warn_on_scan, default: true
+    option :endpoint, default: nil
+    option :identity_map, default: false
+    option :timestamps, default: true
+    option :sync_retry_max_times, default: 60 # a bit over 2 minutes
+    option :sync_retry_wait_seconds, default: 2
+    option :convert_big_decimal, default: false
+    option :models_dir, default: 'app/models' # perhaps you keep your dynamoid models in a different directory?
     option :application_timezone, default: :local # available values - :utc, :local, time zone names
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
-require "uri"
-require "dynamoid/config/options"
+require 'uri'
+require 'dynamoid/config/options'
 
 module Dynamoid
 
@@ -12,7 +12,7 @@ module Dynamoid
 
     # All the default options.
     option :adapter, :default => 'aws_sdk_v2'
-    option :namespace, :default => defined?(Rails) ? "dynamoid_#{Rails.application.class.parent_name}_#{Rails.env}" : "dynamoid"
+    option :namespace, :default => defined?(Rails) ? "dynamoid_#{Rails.application.class.parent_name}_#{Rails.env}" : 'dynamoid'
     option :access_key, :default => nil
     option :secret_key, :default => nil
     option :region, :default => nil
@@ -26,7 +26,7 @@ module Dynamoid
     option :sync_retry_max_times, :default => 60 # a bit over 2 minutes
     option :sync_retry_wait_seconds, :default => 2
     option :convert_big_decimal, :default => false
-    option :models_dir, :default => "app/models" # perhaps you keep your dynamoid models in a different directory?
+    option :models_dir, :default => 'app/models' # perhaps you keep your dynamoid models in a different directory?
     option :application_timezone, default: :local # available values - :utc, :local, time zone names
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.

--- a/lib/dynamoid/config/options.rb
+++ b/lib/dynamoid/config/options.rb
@@ -43,7 +43,7 @@ module Dynamoid #:nodoc
           def #{name}?
             #{name}
           end
-          
+
           def reset_#{name}
             settings[#{name.inspect}] = defaults[#{name.inspect}]
           end

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -177,17 +177,17 @@ module Dynamoid #:nodoc:
 
         case operation
         when 'gt'
-          { :range_greater_than => val }
+          { range_greater_than: val }
         when 'lt'
-          { :range_less_than  => val }
+          { range_less_than: val }
         when 'gte'
-          { :range_gte  => val }
+          { range_gte: val }
         when 'lte'
-          { :range_lte => val }
+          { range_lte: val }
         when 'between'
-          { :range_between => val }
+          { range_between: val }
         when 'begins_with'
-          { :range_begins_with => val }
+          { range_begins_with: val }
         end
       end
 
@@ -220,7 +220,7 @@ module Dynamoid #:nodoc:
       end
 
       def consistent_opts
-        { :consistent_read => consistent_read }
+        { consistent_read: consistent_read }
       end
 
       def range_query
@@ -235,7 +235,7 @@ module Dynamoid #:nodoc:
           opts[:range_key] = @range_key
           if query[@range_key].present?
             value = type_cast_condition_parameter(@range_key, query[@range_key])
-            opts.update(:range_eq => value)
+            opts.update(range_eq: value)
           end
 
           query.keys.select { |k| k.to_s =~ /^#{@range_key}\./ }.each do |key|

--- a/lib/dynamoid/dirty.rb
+++ b/lib/dynamoid/dirty.rb
@@ -15,7 +15,7 @@ module Dynamoid
 
     def update!(*)
       ret = super
-      clear_changes #update! completely reloads all fields on the class, so any extant changes are wiped out
+      clear_changes # update! completely reloads all fields on the class, so any extant changes are wiped out
       ret
     end
 
@@ -26,7 +26,7 @@ module Dynamoid
     def clear_changes
       previous = changes
       (block_given? ? yield : true).tap do |result|
-        unless result == false #failed validation; nil is OK.
+        unless result == false # failed validation; nil is OK.
           @previously_changed = previous
           changed_attributes.clear
         end

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -179,7 +179,7 @@ module Dynamoid #:nodoc:
     # @since 0.2.0
     def reload
       range_key_value = range_value ? dumped_range_value : nil
-      self.attributes = self.class.find(hash_key, :range_key => range_key_value, :consistent_read => true).attributes
+      self.attributes = self.class.find(hash_key, range_key: range_key_value, consistent_read: true).attributes
       @associations.values.each(&:reset)
       self
     end

--- a/lib/dynamoid/errors.rb
+++ b/lib/dynamoid/errors.rb
@@ -27,7 +27,7 @@ module Dynamoid
       attr_reader :record
 
       def initialize(record)
-        super("Failed to destroy item")
+        super('Failed to destroy item')
         @record = record
       end
     end

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -82,7 +82,7 @@ module Dynamoid #:nodoc:
 
       def remove_field(field)
         field = field.to_sym
-        attributes.delete(field) or raise "No such field"
+        attributes.delete(field) or raise 'No such field'
 
         generated_methods.module_eval do
           remove_method field

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -50,7 +50,7 @@ module Dynamoid #:nodoc:
           Dynamoid.logger.warn("Field type :float, which you declared for '#{name}', is deprecated in favor of :number.")
           type = :number
         end
-        self.attributes = attributes.merge(name => {:type => type}.merge(options))
+        self.attributes = attributes.merge(name => {type: type}.merge(options))
 
         generated_methods.module_eval do
           define_method(named) { read_attribute(named) }

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -23,7 +23,7 @@ module Dynamoid #:nodoc:
       field :created_at, :datetime
       field :updated_at, :datetime
 
-      field :id #Default primary key
+      field :id # Default primary key
     end
 
     module ClassMethods
@@ -73,7 +73,7 @@ module Dynamoid #:nodoc:
       end
 
       def table(options)
-        #a default 'id' column is created when Dynamoid::Document is included
+        # a default 'id' column is created when Dynamoid::Document is included
         unless(attributes.has_key? hash_key)
           remove_field :id
           field(hash_key)

--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -148,9 +148,9 @@ module Dynamoid
 
         if range_key_field
           range_key_field = range_key_field.to_s
-          range_key_op = "eq"
-          if range_key_field.include?(".")
-            range_key_field, range_key_op = range_key_field.split(".", 2)
+          range_key_op = 'eq'
+          if range_key_field.include?('.')
+            range_key_field, range_key_op = range_key_field.split('.', 2)
           end
           range_op_mapped = RANGE_MAP.fetch(range_key_op)
         end

--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -90,7 +90,7 @@ module Dynamoid
       # @param [String/Number] range_key of the object to find
       #
       def find_by_composite_key(hash_key, range_key, options = {})
-        find_by_id(hash_key, options.merge({:range_key => range_key}))
+        find_by_id(hash_key, options.merge({range_key: range_key}))
       end
 
       # Find all objects by hash and range keys.
@@ -161,9 +161,9 @@ module Dynamoid
 
         # query
         opts = {
-          :hash_key => hash_key_field.to_s,
-          :hash_value => hash_key_value,
-          :index_name => index.name,
+          hash_key: hash_key_field.to_s,
+          hash_value: hash_key_value,
+          index_name: index.name,
         }
         if range_key_field
           opts[:range_key] = range_key_field

--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -90,7 +90,7 @@ module Dynamoid
       # @param [String/Number] range_key of the object to find
       #
       def find_by_composite_key(hash_key, range_key, options = {})
-        find_by_id(hash_key, options.merge({range_key: range_key}))
+        find_by_id(hash_key, options.merge(range_key: range_key))
       end
 
       # Find all objects by hash and range keys.
@@ -115,7 +115,7 @@ module Dynamoid
       # @return [Array] an array of all matching items
       #
       def find_all_by_composite_key(hash_key, options = {})
-        Dynamoid.adapter.query(self.table_name, options.merge({hash_value: hash_key})).collect do |item|
+        Dynamoid.adapter.query(self.table_name, options.merge(hash_value: hash_key)).collect do |item|
           from_database(item)
         end
       end

--- a/lib/dynamoid/identity_map.rb
+++ b/lib/dynamoid/identity_map.rb
@@ -80,7 +80,6 @@ module Dynamoid
       super
     end
 
-
     def identity_map_key
       key = hash_key.to_s
       if self.class.range_key

--- a/lib/dynamoid/indexes.rb
+++ b/lib/dynamoid/indexes.rb
@@ -39,8 +39,8 @@ module Dynamoid
         end
 
         index_opts = {
-            :read_capacity => Dynamoid::Config.read_capacity,
-            :write_capacity => Dynamoid::Config.write_capacity
+            read_capacity: Dynamoid::Config.read_capacity,
+            write_capacity: Dynamoid::Config.write_capacity
         }.merge(options)
 
         index_opts[:dynamoid_class] = self
@@ -83,9 +83,9 @@ module Dynamoid
         end
 
         index_opts = options.merge({
-          :dynamoid_class => self,
-          :type => :local_secondary,
-          :hash_key => primary_hash_key
+          dynamoid_class: self,
+          type: :local_secondary,
+          hash_key: primary_hash_key
         })
 
         index = Dynamoid::Indexes::Index.new(index_opts)

--- a/lib/dynamoid/indexes.rb
+++ b/lib/dynamoid/indexes.rb
@@ -52,7 +52,6 @@ module Dynamoid
         self
       end
 
-
       # Defines a local secondary index on a table. Will use the same primary
       # hash key as the table.
       #
@@ -95,12 +94,10 @@ module Dynamoid
         self
       end
 
-
       def find_index(hash, range=nil)
         index = self.indexes[index_key(hash, range)]
         index
       end
-
 
       # Returns true iff the provided hash[,range] key combo is a local
       # secondary index.
@@ -113,7 +110,6 @@ module Dynamoid
         self.local_secondary_indexes[index_key(hash, range)].present?
       end
 
-
       # Returns true iff the provided hash[,range] key combo is a global
       # secondary index.
       #
@@ -124,7 +120,6 @@ module Dynamoid
       def is_global_secondary_index?(hash, range=nil)
         self.global_secondary_indexes[index_key(hash, range)].present?
       end
-
 
       # Generates a convenient lookup key name for a hash/range index.
       # Should normally not be used directly.
@@ -140,7 +135,6 @@ module Dynamoid
         name
       end
 
-
       # Generates a default index name.
       #
       # @param [Symbol] hash hash key name.
@@ -149,7 +143,6 @@ module Dynamoid
       def index_name(hash, range=nil)
         "#{self.table_name}_index_#{self.index_key(hash, range)}"
       end
-
 
       # Convenience method to return all indexes on the table.
       #
@@ -166,7 +159,6 @@ module Dynamoid
       end
     end
 
-
     # Represents the attributes of a DynamoDB index.
     class Index
       include ActiveModel::Validations
@@ -178,14 +170,12 @@ module Dynamoid
           :hash_key_schema, :range_key_schema, :projected_attributes,
           :read_capacity, :write_capacity
 
-
       validate do
         validate_index_type
         validate_hash_key
         validate_range_key
         validate_projected_attributes
       end
-
 
       def initialize(attrs={})
         unless attrs[:dynamoid_class].present?
@@ -205,7 +195,6 @@ module Dynamoid
         raise Dynamoid::Errors::InvalidIndex.new(self) unless self.valid?
       end
 
-
       # Convenience method to determine the projection type for an index.
       # Projection types are: :keys_only, :all, :include.
       #
@@ -217,7 +206,6 @@ module Dynamoid
           @projected_attributes
         end
       end
-
 
       private
 

--- a/lib/dynamoid/indexes.rb
+++ b/lib/dynamoid/indexes.rb
@@ -209,53 +209,53 @@ module Dynamoid
 
       private
 
-        def validate_projected_attributes
-          unless (@projected_attributes.is_a?(Array) ||
-                  PROJECTION_TYPES.include?(@projected_attributes))
-            errors.add(:projected_attributes, 'Invalid projected attributes specified.')
-          end
+      def validate_projected_attributes
+        unless (@projected_attributes.is_a?(Array) ||
+                PROJECTION_TYPES.include?(@projected_attributes))
+          errors.add(:projected_attributes, 'Invalid projected attributes specified.')
         end
+      end
 
-        def validate_index_type
-          unless (@type.present? &&
-            [:local_secondary, :global_secondary].include?(@type))
-              errors.add(:type, 'Invalid index :type specified')
-          end
+      def validate_index_type
+        unless (@type.present? &&
+          [:local_secondary, :global_secondary].include?(@type))
+            errors.add(:type, 'Invalid index :type specified')
         end
+      end
 
-        def validate_range_key
-          if @range_key.present?
-            range_field_attributes = @dynamoid_class.attributes[@range_key]
-            if range_field_attributes.present?
-              range_key_type = range_field_attributes[:type]
-              if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(range_key_type)
-                @range_key_schema = {
-                  @range_key => @dynamoid_class.dynamo_type(range_key_type)
-                }
-              else
-                errors.add(:range_key, 'Index :range_key is not a valid key type')
-              end
-            else
-              errors.add(:range_key, "No such field #{@range_key} defined on table")
-            end
-          end
-        end
-
-        def validate_hash_key
-          hash_field_attributes = @dynamoid_class.attributes[@hash_key]
-          if hash_field_attributes.present?
-            hash_field_type = hash_field_attributes[:type]
-            if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(hash_field_type)
-              @hash_key_schema = {
-                @hash_key => @dynamoid_class.dynamo_type(hash_field_type)
+      def validate_range_key
+        if @range_key.present?
+          range_field_attributes = @dynamoid_class.attributes[@range_key]
+          if range_field_attributes.present?
+            range_key_type = range_field_attributes[:type]
+            if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(range_key_type)
+              @range_key_schema = {
+                @range_key => @dynamoid_class.dynamo_type(range_key_type)
               }
             else
-              errors.add(:hash_key, 'Index :hash_key is not a valid key type')
+              errors.add(:range_key, 'Index :range_key is not a valid key type')
             end
           else
-            errors.add(:hash_key, "No such field #{@hash_key} defined on table")
+            errors.add(:range_key, "No such field #{@range_key} defined on table")
           end
         end
+      end
+
+      def validate_hash_key
+        hash_field_attributes = @dynamoid_class.attributes[@hash_key]
+        if hash_field_attributes.present?
+          hash_field_type = hash_field_attributes[:type]
+          if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(hash_field_type)
+            @hash_key_schema = {
+              @hash_key => @dynamoid_class.dynamo_type(hash_field_type)
+            }
+          else
+            errors.add(:hash_key, 'Index :hash_key is not a valid key type')
+          end
+        else
+          errors.add(:hash_key, "No such field #{@hash_key} defined on table")
+        end
+      end
     end
   end
 end

--- a/lib/dynamoid/indexes.rb
+++ b/lib/dynamoid/indexes.rb
@@ -82,11 +82,10 @@ module Dynamoid
             ' must use a different :range_key than the primary key')
         end
 
-        index_opts = options.merge({
+        index_opts = options.merge(
           dynamoid_class: self,
           type: :local_secondary,
-          hash_key: primary_hash_key
-        })
+          hash_key: primary_hash_key)
 
         index = Dynamoid::Indexes::Index.new(index_opts)
         key = index_key(primary_hash_key, index_range_key)

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -41,14 +41,14 @@ module Dynamoid
           range_key_hash = nil
         end
         options = {
-          :id => self.hash_key,
-          :table_name => self.table_name,
-          :write_capacity => self.write_capacity,
-          :read_capacity => self.read_capacity,
-          :range_key => range_key_hash,
-          :hash_key_type => dynamo_type(attributes[self.hash_key][:type]),
-          :local_secondary_indexes => self.local_secondary_indexes.values,
-          :global_secondary_indexes => self.global_secondary_indexes.values
+          id: self.hash_key,
+          table_name: self.table_name,
+          write_capacity: self.write_capacity,
+          read_capacity: self.read_capacity,
+          range_key: range_key_hash,
+          hash_key_type: dynamo_type(attributes[self.hash_key][:type]),
+          local_secondary_indexes: self.local_secondary_indexes.values,
+          global_secondary_indexes: self.global_secondary_indexes.values
         }.merge(options)
 
         Dynamoid.adapter.create_table(options[:table_name], options[:id], options)
@@ -283,7 +283,7 @@ module Dynamoid
       self.class.create_table
 
       if new_record?
-        conditions = { :unless_exists => [self.class.hash_key]}
+        conditions = { unless_exists: [self.class.hash_key]}
         conditions[:unless_exists] << range_key if(range_key)
 
         run_callbacks(:create) { persist(conditions) }
@@ -299,10 +299,10 @@ module Dynamoid
     #
     def update!(conditions = {}, &block)
       run_callbacks(:update) do
-        options = range_key ? {:range_key => dump_field(self.read_attribute(range_key), self.class.attributes[range_key])} : {}
+        options = range_key ? {range_key: dump_field(self.read_attribute(range_key), self.class.attributes[range_key])} : {}
 
         begin
-          new_attrs = Dynamoid.adapter.update_item(self.class.table_name, self.hash_key, options.merge(:conditions => conditions)) do |t|
+          new_attrs = Dynamoid.adapter.update_item(self.class.table_name, self.hash_key, options.merge(conditions: conditions)) do |t|
             if(self.class.attributes[:lock_version])
               t.add(lock_version: 1)
             end
@@ -341,11 +341,11 @@ module Dynamoid
     #
     # @since 0.2.0
     def delete
-      options = range_key ? {:range_key => dump_field(self.read_attribute(range_key), self.class.attributes[range_key])} : {}
+      options = range_key ? {range_key: dump_field(self.read_attribute(range_key), self.class.attributes[range_key])} : {}
 
       # Add an optimistic locking check if the lock_version column exists
       if(self.class.attributes[:lock_version])
-        conditions = {:if => {}}
+        conditions = {if: {}}
         conditions[:if][:lock_version] =
           if changes[:lock_version].nil?
             self.lock_version

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -21,7 +21,7 @@ module Dynamoid
         table_base_name = options[:name] || base_class.name.split('::').last
           .downcase.pluralize
 
-        @table_name ||= [Dynamoid::Config.namespace.to_s,table_base_name].reject(&:empty?).join("_")
+        @table_name ||= [Dynamoid::Config.namespace.to_s, table_base_name].reject(&:empty?).join("_")
       end
 
       # Creates a table.

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -21,7 +21,7 @@ module Dynamoid
         table_base_name = options[:name] || base_class.name.split('::').last
           .downcase.pluralize
 
-        @table_name ||= [Dynamoid::Config.namespace.to_s, table_base_name].reject(&:empty?).join("_")
+        @table_name ||= [Dynamoid::Config.namespace.to_s, table_base_name].reject(&:empty?).join('_')
       end
 
       # Creates a table.
@@ -144,7 +144,7 @@ module Dynamoid
                 elsif value == 'f' || value == false
                   false
                 else
-                  raise ArgumentError, "Boolean column neither true nor false"
+                  raise ArgumentError, 'Boolean column neither true nor false'
                 end
               else
                 raise ArgumentError, "Unknown type #{options[:type]}"

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -397,7 +397,7 @@ module Dynamoid
         if(self.class.attributes[:lock_version])
           conditions ||= {}
           self.lock_version = (lock_version || 0) + 1
-          #Uses the original lock_version value from ActiveModel::Dirty in case user changed lock_version manually
+          # Uses the original lock_version value from ActiveModel::Dirty in case user changed lock_version manually
           (conditions[:if] ||= {})[:lock_version] = changes[:lock_version][0] if(changes[:lock_version][0])
         end
 

--- a/lib/dynamoid/railtie.rb
+++ b/lib/dynamoid/railtie.rb
@@ -3,7 +3,7 @@ if defined? (Rails)
   module Dynamoid
     class Railtie < Rails::Railtie
       rake_tasks do
-        Dir[File.join(File.dirname(__FILE__),'tasks/*.rake')].each { |f| load f }
+        Dir[File.join(File.dirname(__FILE__), 'tasks/*.rake')].each { |f| load f }
       end
     end
   end

--- a/lib/dynamoid/validations.rb
+++ b/lib/dynamoid/validations.rb
@@ -12,7 +12,7 @@ module Dynamoid
     #
     # @since 0.2.0
     def save(options = {})
-      options.reverse_merge!(:validate => true)
+      options.reverse_merge!(validate: true)
       return false if options[:validate] and (not valid?)
       super
     end
@@ -30,7 +30,7 @@ module Dynamoid
     # @since 0.2.0
     def save!
       raise Dynamoid::Errors::DocumentNotValid.new(self) unless valid?
-      save(:validate => false)
+      save(validate: false)
       self
     end
 

--- a/lib/dynamoid/validations.rb
+++ b/lib/dynamoid/validations.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 module Dynamoid
-  
+
   # Provide ActiveModel validations to Dynamoid documents.
   module Validations
     extend ActiveSupport::Concern

--- a/lib/dynamoid/version.rb
+++ b/lib/dynamoid/version.rb
@@ -1,3 +1,3 @@
 module Dynamoid
-  VERSION = "1.3.4"
+  VERSION = '1.3.4'
 end

--- a/spec/app/models/address.rb
+++ b/spec/app/models/address.rb
@@ -8,7 +8,7 @@ class Address
   field :config, :raw
   field :registered_on, :date
 
-  field :lock_version, :integer #Provides Optimistic Locking
+  field :lock_version, :integer # Provides Optimistic Locking
 
   def zip_code=(zip_code)
     self.city = "Chicago"

--- a/spec/app/models/address.rb
+++ b/spec/app/models/address.rb
@@ -11,6 +11,6 @@ class Address
   field :lock_version, :integer # Provides Optimistic Locking
 
   def zip_code=(zip_code)
-    self.city = "Chicago"
+    self.city = 'Chicago'
   end
 end

--- a/spec/app/models/bar.rb
+++ b/spec/app/models/bar.rb
@@ -12,5 +12,5 @@ class Bar
 
   validates_presence_of :name, :visited_at
 
-  global_secondary_index :hash_key => :name, :range_key => :visited_at
+  global_secondary_index hash_key: :name, range_key: :visited_at
 end

--- a/spec/app/models/camel_case.rb
+++ b/spec/app/models/camel_case.rb
@@ -7,18 +7,18 @@ class CamelCase
   has_many :users
   has_one :sponsor
   has_and_belongs_to_many :subscriptions
-  
+
   before_create :doing_before_create
   after_create :doing_after_create
   before_update :doing_before_update
   after_update :doing_after_update
-  
+
   private
-  
+
   def doing_before_create
     true
   end
-  
+
   def doing_after_create
     true
   end

--- a/spec/app/models/car.rb
+++ b/spec/app/models/car.rb
@@ -1,6 +1,6 @@
 require_relative 'vehicle'
 
 class Car < Vehicle
-  
+
   field :power_locks, :boolean
 end

--- a/spec/app/models/magazine.rb
+++ b/spec/app/models/magazine.rb
@@ -1,10 +1,10 @@
 class Magazine
   include Dynamoid::Document
   table :key => :title
-  
+
   field :title
   field :size, :number
-  
+
   has_many :subscriptions
   has_many :camel_cases
   has_one :sponsor

--- a/spec/app/models/magazine.rb
+++ b/spec/app/models/magazine.rb
@@ -1,6 +1,6 @@
 class Magazine
   include Dynamoid::Document
-  table :key => :title
+  table key: :title
 
   field :title
   field :size, :number
@@ -9,5 +9,5 @@ class Magazine
   has_many :camel_cases
   has_one :sponsor
 
-  belongs_to :owner, :class_name => 'User', :inverse_of => :books
+  belongs_to :owner, class_name: 'User', inverse_of: :books
 end

--- a/spec/app/models/nuclear_submarine.rb
+++ b/spec/app/models/nuclear_submarine.rb
@@ -1,5 +1,5 @@
 require_relative 'vehicle'
 class NuclearSubmarine < Vehicle
-  
+
   field :torpedoes, :integer
 end

--- a/spec/app/models/post.rb
+++ b/spec/app/models/post.rb
@@ -9,7 +9,7 @@ class Post
   field :length
   field :name
 
-  local_secondary_index :range_key => :name
-  global_secondary_index :hash_key => :name, :range_key => :posted_at
-  global_secondary_index :hash_key => :length
+  local_secondary_index range_key: :name
+  global_secondary_index hash_key: :name, range_key: :posted_at
+  global_secondary_index hash_key: :length
 end

--- a/spec/app/models/sponsor.rb
+++ b/spec/app/models/sponsor.rb
@@ -1,6 +1,6 @@
 class Sponsor
   include Dynamoid::Document
-  
+
   belongs_to :magazine
   has_many :subscriptions
 

--- a/spec/app/models/subscription.rb
+++ b/spec/app/models/subscription.rb
@@ -6,7 +6,7 @@ class Subscription
   belongs_to :magazine
   has_and_belongs_to_many :users
 
-  belongs_to :customer, :class_name => 'User', :inverse_of => :monthly
+  belongs_to :customer, class_name: 'User', inverse_of: :monthly
 
   has_and_belongs_to_many :camel_cases
 end

--- a/spec/app/models/user.rb
+++ b/spec/app/models/user.rb
@@ -12,11 +12,11 @@ class User
 
   has_and_belongs_to_many :subscriptions
 
-  has_many :books, :class_name => 'Magazine', :inverse_of => :owner
-  has_one :monthly, :class_name => 'Subscription', :inverse_of => :customer
+  has_many :books, class_name: 'Magazine', inverse_of: :owner
+  has_one :monthly, class_name: 'Subscription', inverse_of: :customer
 
-  has_and_belongs_to_many :followers, :class_name => 'User', :inverse_of => :following
-  has_and_belongs_to_many :following, :class_name => 'User', :inverse_of => :followers
+  has_and_belongs_to_many :followers, class_name: 'User', inverse_of: :following
+  has_and_belongs_to_many :following, class_name: 'User', inverse_of: :followers
 
   belongs_to :camel_case
 

--- a/spec/app/models/vehicle.rb
+++ b/spec/app/models/vehicle.rb
@@ -1,7 +1,7 @@
 class Vehicle
   include Dynamoid::Document
-  
+
   field :type
-  
+
   field :description
 end

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -10,8 +10,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
   {
     1 => [:id],
     2 => [:id],
-    3 => [:id, {:range_key => {:range => :number}}],
-    4 => [:id, {:range_key => {:range => :number}}]
+    3 => [:id, {range_key: {range: :number}}],
+    4 => [:id, {range_key: {range: :number}}]
   }.each do |n, args|
     name = "dynamoid_tests_TestTable#{n}"
     let(:"test_table#{n}") do
@@ -35,7 +35,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     def request_params
-      return {:hash_value => '1'} if @request_type == :query
+      return {hash_value: '1'} if @request_type == :query
       {}
     end
 
@@ -47,8 +47,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     context 'multiple name entities' do
       before(:each) do
         (1..4).each do |i|
-          Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => i.to_f})
-          Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Pascal', :range => (i + 4).to_f})
+          Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: i.to_f})
+          Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Pascal', range: (i + 4).to_f})
         end
       end
 
@@ -77,19 +77,19 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       end
 
       it 'returns correct record limit with filter' do
-        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Josh'}}), {record_limit: 1}).count)
+        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Josh'}}), {record_limit: 1}).count)
           .to eq(1)
       end
 
       it 'obeys correct scan limit with filter' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(1).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Josh'}}), {scan_limit: 2}).count)
+        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Josh'}}), {scan_limit: 2}).count)
           .to eq(2)
       end
 
       it 'obeys correct scan limit over record limit with filter' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(1).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Josh'}}), {
+        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Josh'}}), {
           scan_limit: 2,
           record_limit: 10, # Won't be able to return more than 2 due to scan limit
         }).count).to eq(2)
@@ -97,14 +97,14 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
       it 'obeys correct scan limit with filter with some return' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(1).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Pascal'}}), {
+        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Pascal'}}), {
           scan_limit: 5,
         }).count).to eq(1)
       end
 
       it 'obeys correct scan limit and batch size with filter with some return' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Josh'}}), {
+        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Josh'}}), {
           scan_limit: 3,
           batch_size: 2, # This would force batching of size 2 for potential of 4 results!
         }).count).to eq(3)
@@ -115,7 +115,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         # We should paginate through 5 responses each of size 1 (batch) and
         # only scan through 5 records at most which with our given filter
         # should return 1 result since first 4 are Josh and last is Pascal.
-        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Pascal'}}), {
+        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Pascal'}}), {
           batch_size: 1,
           scan_limit: 5,
           record_limit: 3,
@@ -127,7 +127,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         # We should paginate through 6 responses each of size 1 (batch) and
         # only scan through 6 records at most which with our given filter
         # should return 2 results, and hit record limit before scan limit.
-        expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Pascal'}}), {
+        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Pascal'}}), {
           batch_size: 1,
           scan_limit: 10,
           record_limit: 2,
@@ -145,10 +145,10 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         # We use :age since :range won't work for filtering in queries
         200.times do |i|
           Dynamoid.adapter.put_item(test_table3, {
-            :id => '1',
-            :range => i.to_f,
-            :age => i.to_f,
-            :data => 'A'*1024*16,
+            id: '1',
+            range: i.to_f,
+            age: i.to_f,
+            data: 'A'*1024*16,
           })
         end
       end
@@ -165,20 +165,20 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         # and then look at 36 records and find 10 on the second page.
         pages = request_type == :query ? 1 : 2
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(pages).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 90.0} }), {
+        expect(dynamo_request(test_table3, request_params.merge({ age: {gte: 90.0} }), {
           scan_limit: 100,
         }).count).to eq(10)
       end
 
       it 'returns correct for record limit' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 5.0} }), {
+        expect(dynamo_request(test_table3, request_params.merge({ age: {gte: 5.0} }), {
           record_limit: 100,
         }).count).to eq(100)
       end
 
       it 'returns correct record limit with filtering' do
-        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 133.0} }), {
+        expect(dynamo_request(test_table3, request_params.merge({ age: {gte: 133.0} }), {
           record_limit: 100,
         }).count).to eq(67)
       end
@@ -206,7 +206,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       it 'returns correct with batching and record limit' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(11).times.and_call_original
         # Since we do age >= 5.0 we lose the first 5 results so we make 11 paginated requests
-        expect(dynamo_request(test_table3, request_params.merge({ :age => {:gte => 5.0} }), {
+        expect(dynamo_request(test_table3, request_params.merge({ age: {gte: 5.0} }), {
           record_limit: 100,
           batch_size: 10,
         }).count).to eq(100)
@@ -215,11 +215,11 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
     it 'correctly limits edge case of record and scan counts approaching limits' do
       (1..4).each do |i|
-        Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => i.to_f})
+        Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: i.to_f})
       end
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Pascal', :range => 5.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Pascal', range: 5.0})
       (6..10).each do |i|
-        Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => i.to_f})
+        Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: i.to_f})
       end
 
       expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
@@ -227,7 +227,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       # we would get the 5th Josh (range value 6.0) whereas correct implementation would
       # adjust limit to 1 since can only scan 1 more record therefore would see Pascal
       # and not go to next valid record.
-      expect(dynamo_request(test_table3, request_params.merge({:name => {:eq => 'Josh'}}), {
+      expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Josh'}}), {
         batch_size: 4,
         scan_limit: 5,    # Scan limit would adjust requested limit to 1
         record_limit: 6,  # Record limit would adjust requested limit to 2
@@ -240,42 +240,42 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
   #
   shared_examples 'range queries' do
     before do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :range => 3.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '1', range: 1.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '1', range: 3.0})
     end
 
     it 'performs query on a table with a range and selects items in a range' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_between => [0.0, 3.0]).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+      expect(Dynamoid.adapter.query(test_table3, hash_value: '1', range_between: [0.0, 3.0]).to_a).to eq [{id: '1', range: BigDecimal.new(1)}, {id: '1', range: BigDecimal.new(3)}]
     end
 
     it 'performs query on a table with a range and selects items in a range with :select option' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_between => [0.0, 3.0], :select =>  'ALL_ATTRIBUTES').to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+      expect(Dynamoid.adapter.query(test_table3, hash_value: '1', range_between: [0.0, 3.0], select: 'ALL_ATTRIBUTES').to_a).to eq [{id: '1', range: BigDecimal.new(1)}, {id: '1', range: BigDecimal.new(3)}]
     end
 
     it 'performs query on a table with a range and selects items greater than' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_greater_than => 1.0).to_a).to eq [{:id => '1', :range => BigDecimal.new(3)}]
+      expect(Dynamoid.adapter.query(test_table3, hash_value: '1', range_greater_than: 1.0).to_a).to eq [{id: '1', range: BigDecimal.new(3)}]
     end
 
     it 'performs query on a table with a range and selects items less than' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_less_than => 2.0).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}]
+      expect(Dynamoid.adapter.query(test_table3, hash_value: '1', range_less_than: 2.0).to_a).to eq [{id: '1', range: BigDecimal.new(1)}]
     end
 
     it 'performs query on a table with a range and selects items gte' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_gte => 1.0).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+      expect(Dynamoid.adapter.query(test_table3, hash_value: '1', range_gte: 1.0).to_a).to eq [{id: '1', range: BigDecimal.new(1)}, {id: '1', range: BigDecimal.new(3)}]
     end
 
     it 'performs query on a table with a range and selects items lte' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_lte => 3.0).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+      expect(Dynamoid.adapter.query(test_table3, hash_value: '1', range_lte: 3.0).to_a).to eq [{id: '1', range: BigDecimal.new(1)}, {id: '1', range: BigDecimal.new(3)}]
     end
 
     it 'performs query on a table and returns items based on returns correct limit' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_greater_than => 0.0, :record_limit => 1).count).to eq(1)
+      expect(Dynamoid.adapter.query(test_table3, hash_value: '1', range_greater_than: 0.0, record_limit: 1).count).to eq(1)
     end
 
     it 'performs query on a table with a range and selects all items' do
-      200.times { |i| Dynamoid.adapter.put_item(test_table3, {:id => '1', :range => i.to_f, :data => 'A'*1024*16}) }
+      200.times { |i| Dynamoid.adapter.put_item(test_table3, {id: '1', range: i.to_f, data: 'A'*1024*16}) }
       # 64 of these items will exceed the 1MB result limit thus query won't return all results on first loop
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_gte => 0.0).count).to eq(200)
+      expect(Dynamoid.adapter.query(test_table3, hash_value: '1', range_gte: 0.0).count).to eq(200)
     end
   end
 
@@ -284,39 +284,39 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
   #
   shared_examples 'correct ordering' do
     before(:each) do
-      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 1, :range => 1.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 2, :range => 2.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 3, :range => 3.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 4, :range => 4.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 5, :range => 5.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 6, :range => 6.0})
+      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 1, range: 1.0})
+      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 2, range: 2.0})
+      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 3, range: 3.0})
+      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 4, range: 4.0})
+      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 5, range: 5.0})
+      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 6, range: 6.0})
     end
 
     it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward true' do
-      query = Dynamoid.adapter.query(test_table4, :hash_value => '1', :range_greater_than => 0, :scan_index_forward => true).to_a
-      expect(query[0]).to eq({:id => '1', :order => 1, :range => BigDecimal.new(1)})
-      expect(query[1]).to eq({:id => '1', :order => 2, :range => BigDecimal.new(2)})
-      expect(query[2]).to eq({:id => '1', :order => 3, :range => BigDecimal.new(3)})
-      expect(query[3]).to eq({:id => '1', :order => 4, :range => BigDecimal.new(4)})
-      expect(query[4]).to eq({:id => '1', :order => 5, :range => BigDecimal.new(5)})
-      expect(query[5]).to eq({:id => '1', :order => 6, :range => BigDecimal.new(6)})
+      query = Dynamoid.adapter.query(test_table4, hash_value: '1', range_greater_than: 0, scan_index_forward: true).to_a
+      expect(query[0]).to eq({id: '1', order: 1, range: BigDecimal.new(1)})
+      expect(query[1]).to eq({id: '1', order: 2, range: BigDecimal.new(2)})
+      expect(query[2]).to eq({id: '1', order: 3, range: BigDecimal.new(3)})
+      expect(query[3]).to eq({id: '1', order: 4, range: BigDecimal.new(4)})
+      expect(query[4]).to eq({id: '1', order: 5, range: BigDecimal.new(5)})
+      expect(query[5]).to eq({id: '1', order: 6, range: BigDecimal.new(6)})
     end
 
     it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward false' do
-      query = Dynamoid.adapter.query(test_table4, :hash_value => '1', :range_greater_than => 0, :scan_index_forward => false).to_a
-      expect(query[5]).to eq({:id => '1', :order => 1, :range => BigDecimal.new(1)})
-      expect(query[4]).to eq({:id => '1', :order => 2, :range => BigDecimal.new(2)})
-      expect(query[3]).to eq({:id => '1', :order => 3, :range => BigDecimal.new(3)})
-      expect(query[2]).to eq({:id => '1', :order => 4, :range => BigDecimal.new(4)})
-      expect(query[1]).to eq({:id => '1', :order => 5, :range => BigDecimal.new(5)})
-      expect(query[0]).to eq({:id => '1', :order => 6, :range => BigDecimal.new(6)})
+      query = Dynamoid.adapter.query(test_table4, hash_value: '1', range_greater_than: 0, scan_index_forward: false).to_a
+      expect(query[5]).to eq({id: '1', order: 1, range: BigDecimal.new(1)})
+      expect(query[4]).to eq({id: '1', order: 2, range: BigDecimal.new(2)})
+      expect(query[3]).to eq({id: '1', order: 3, range: BigDecimal.new(3)})
+      expect(query[2]).to eq({id: '1', order: 4, range: BigDecimal.new(4)})
+      expect(query[1]).to eq({id: '1', order: 5, range: BigDecimal.new(5)})
+      expect(query[0]).to eq({id: '1', order: 6, range: BigDecimal.new(6)})
     end
   end
 
   context 'without a preexisting table' do
     # CreateTable and DeleteTable
     it 'performs CreateTable and DeleteTable' do
-      table = Dynamoid.adapter.create_table('CreateTable', :id, :range_key =>  { :created_at => :number })
+      table = Dynamoid.adapter.create_table('CreateTable', :id, range_key: { created_at: :number })
 
       expect(Dynamoid.adapter.list_tables).to include 'CreateTable'
 
@@ -327,7 +327,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       let(:doc_class) do
         Class.new do
           include Dynamoid::Document
-          range :range => :number
+          range range: :number
           field :range2
           field :hash2
         end
@@ -335,14 +335,14 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
       it 'creates table with local_secondary_index' do
         # setup
-        doc_class.table({:name => 'table_lsi', :key => :id})
+        doc_class.table({name: 'table_lsi', key: :id})
         doc_class.local_secondary_index ({
-          :range_key => :range2,
+          range_key: :range2,
         })
 
         Dynamoid.adapter.create_table('table_lsi', :id, {
-          :local_secondary_indexes => doc_class.local_secondary_indexes.values,
-          :range_key => { :range => :number }
+          local_secondary_indexes: doc_class.local_secondary_indexes.values,
+          range_key: { range: :number }
         })
 
         # execute
@@ -354,25 +354,25 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         expect(Dynamoid::AdapterPlugin::AwsSdkV2::PARSE_TABLE_STATUS.call(resp)).to eq(Dynamoid::AdapterPlugin::AwsSdkV2::TABLE_STATUSES[:active])
         expect(lsi.index_name).to eql 'dynamoid_tests_table_lsi_index_id_range2'
         expect(lsi.key_schema.map(&:to_hash)).to eql [
-          {:attribute_name=>'id', :key_type=>'HASH'},
-          {:attribute_name=>'range2', :key_type=>'RANGE'}
+          {attribute_name: 'id', key_type: 'HASH'},
+          {attribute_name: 'range2', key_type: 'RANGE'}
         ]
-        expect(lsi.projection.to_hash).to eql ({:projection_type=>'KEYS_ONLY'})
+        expect(lsi.projection.to_hash).to eql ({projection_type: 'KEYS_ONLY'})
       end
 
       it 'creates table with global_secondary_index' do
         # setup
-        doc_class.table({:name => 'table_gsi', :key => :id})
+        doc_class.table({name: 'table_gsi', key: :id})
         doc_class.global_secondary_index ({
-          :hash_key => :hash2,
-          :range_key => :range2,
-          :write_capacity => 10,
-          :read_capacity => 20
+          hash_key: :hash2,
+          range_key: :range2,
+          write_capacity: 10,
+          read_capacity: 20
 
         })
         Dynamoid.adapter.create_table('table_gsi', :id, {
-          :global_secondary_indexes => doc_class.global_secondary_indexes.values,
-          :range_key => { :range => :number }
+          global_secondary_indexes: doc_class.global_secondary_indexes.values,
+          range_key: { range: :number }
         })
 
         # execute
@@ -384,10 +384,10 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         expect(Dynamoid::AdapterPlugin::AwsSdkV2::PARSE_TABLE_STATUS.call(resp)).to eq(Dynamoid::AdapterPlugin::AwsSdkV2::TABLE_STATUSES[:active])
         expect(gsi.index_name).to eql 'dynamoid_tests_table_gsi_index_hash2_range2'
         expect(gsi.key_schema.map(&:to_hash)).to eql [
-          {:attribute_name=>'hash2', :key_type=>'HASH'},
-          {:attribute_name=>'range2', :key_type=>'RANGE'}
+          {attribute_name: 'hash2', key_type: 'HASH'},
+          {attribute_name: 'range2', key_type: 'RANGE'}
         ]
-        expect(gsi.projection.to_hash).to eql ({:projection_type=>'KEYS_ONLY'})
+        expect(gsi.projection.to_hash).to eql ({projection_type: 'KEYS_ONLY'})
         expect(gsi.provisioned_throughput.write_capacity_units).to eql 10
         expect(gsi.provisioned_throughput.read_capacity_units).to eql 20
       end
@@ -401,9 +401,9 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs GetItem for an item that does exist' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
 
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({:name => 'Josh', :id => '1'})
+      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({name: 'Josh', id: '1'})
 
       Dynamoid.adapter.delete_item(test_table1, '1')
 
@@ -411,13 +411,13 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs GetItem for an item that does exist with a range key' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 2.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 2.0})
 
-      expect(Dynamoid.adapter.get_item(test_table3, '1', :range_key => 2.0)).to eq({:name => 'Josh', :id => '1', :range => 2.0})
+      expect(Dynamoid.adapter.get_item(test_table3, '1', range_key: 2.0)).to eq({name: 'Josh', id: '1', range: 2.0})
 
-      Dynamoid.adapter.delete_item(test_table3, '1', :range_key => 2.0)
+      Dynamoid.adapter.delete_item(test_table3, '1', range_key: 2.0)
 
-      expect(Dynamoid.adapter.get_item(test_table3, '1', :range_key => 2.0)).to be_nil
+      expect(Dynamoid.adapter.get_item(test_table3, '1', range_key: 2.0)).to be_nil
     end
 
     it 'performs DeleteItem for an item that does not exist' do
@@ -427,56 +427,56 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs PutItem for an item that does not exist' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
 
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({:id => '1', :name => 'Josh'})
+      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({id: '1', name: 'Josh'})
     end
 
     # BatchGetItem
     it 'passes options to underlying BatchGet call' do
       pending 'at the moment passing the options to underlying batch get is not supported'
-      expect_any_instance_of(Aws::DynamoDB::Client).to receive(:batch_get_item).with(:request_items => {test_table1 => {:keys => [{'id' => '1'}, {'id' => '2'}], :consistent_read => true}}).and_call_original
-      described_class.batch_get_item({test_table1 => ['1', '2']}, :consistent_read => true)
+      expect_any_instance_of(Aws::DynamoDB::Client).to receive(:batch_get_item).with(request_items: {test_table1 => {keys: [{'id' => '1'}, {'id' => '2'}], consistent_read: true}}).and_call_original
+      described_class.batch_get_item({test_table1 => ['1', '2']}, consistent_read: true)
     end
 
     it 'performs BatchGetItem with singular keys' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table2, {:id => '1', :name => 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table2, {id: '1', name: 'Justin'})
 
       results = Dynamoid.adapter.batch_get_item(test_table1 => '1', test_table2 => '1')
       expect(results.size).to eq 2
-      expect(results[test_table1]).to include({:name => 'Josh', :id => '1'})
-      expect(results[test_table2]).to include({:name => 'Justin', :id => '1'})
+      expect(results[test_table1]).to include({name: 'Josh', id: '1'})
+      expect(results[test_table2]).to include({name: 'Justin', id: '1'})
     end
 
     it 'performs BatchGetItem with multiple keys' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Justin'})
 
       results = Dynamoid.adapter.batch_get_item(test_table1 => ['1', '2'])
       expect(results.size).to eq 1
-      expect(results[test_table1]).to include({:name => 'Josh', :id => '1'})
-      expect(results[test_table1]).to include({:name => 'Justin', :id => '2'})
+      expect(results[test_table1]).to include({name: 'Josh', id: '1'})
+      expect(results[test_table1]).to include({name: 'Justin', id: '2'})
     end
 
     it 'performs BatchGetItem with one ranged key' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 1.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '2', name: 'Justin', range: 2.0})
 
       results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0]])
       expect(results.size).to eq 1
-      expect(results[test_table3]).to include({:name => 'Josh', :id => '1', :range => 1.0})
+      expect(results[test_table3]).to include({name: 'Josh', id: '1', range: 1.0})
     end
 
     it 'performs BatchGetItem with multiple ranged keys' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 1.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '2', name: 'Justin', range: 2.0})
 
       results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0], ['2', 2.0]])
       expect(results.size).to eq 1
 
-      expect(results[test_table3]).to include({:name => 'Josh', :id => '1', :range => 1.0})
-      expect(results[test_table3]).to include({:name => 'Justin', :id => '2', :range => 2.0})
+      expect(results[test_table3]).to include({name: 'Josh', id: '1', range: 1.0})
+      expect(results[test_table3]).to include({name: 'Justin', id: '2', range: 2.0})
     end
 
     it 'performs BatchGetItem with ranges of 100 keys' do
@@ -484,7 +484,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
       (1..101).each do |i|
         id, range = i.to_s, i.to_f
-        Dynamoid.adapter.put_item(test_table3, {:id => id, :name => "Josh_#{i}", :range => range})
+        Dynamoid.adapter.put_item(test_table3, {id: id, name: "Josh_#{i}", range: range})
         table_ids << [id, range]
       end
 
@@ -492,13 +492,13 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
       expect(results.size).to eq 1
 
-      expect(results[test_table3]).to include({:name => 'Josh_101', :id => '101', :range => 101.0})
+      expect(results[test_table3]).to include({name: 'Josh_101', id: '101', range: 101.0})
     end
 
     # BatchDeleteItem
     it 'performs BatchDeleteItem with singular keys' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table2, {:id => '1', :name => 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table2, {id: '1', name: 'Justin'})
 
       Dynamoid.adapter.batch_delete_item(test_table1 => ['1'], test_table2 => ['1'])
 
@@ -510,8 +510,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs BatchDeleteItem with multiple keys' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Justin'})
 
       Dynamoid.adapter.batch_delete_item(test_table1 => ['1', '2'])
 
@@ -522,8 +522,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs BatchDeleteItem with one ranged key' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 1.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '2', name: 'Justin', range: 2.0})
 
       Dynamoid.adapter.batch_delete_item(test_table3 => [['1', 1.0]])
       results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0]])
@@ -533,8 +533,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs BatchDeleteItem with multiple ranged keys' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 1.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '2', name: 'Justin', range: 2.0})
 
       Dynamoid.adapter.batch_delete_item(test_table3 => [['1', 1.0], ['2', 2.0]])
       results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0], ['2', 2.0]])
@@ -586,16 +586,16 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
     # Query
     it 'performs query on a table and returns items' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
 
-      expect(Dynamoid.adapter.query(test_table1, :hash_value => '1').first).to eq({ :id=> '1', :name=>'Josh' })
+      expect(Dynamoid.adapter.query(test_table1, hash_value: '1').first).to eq({ id: '1', name: 'Josh' })
     end
 
     it 'performs query on a table and returns items if there are multiple items' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Justin'})
 
-      expect(Dynamoid.adapter.query(test_table1, :hash_value => '1').first).to eq({ :id=> '1', :name=>'Josh' })
+      expect(Dynamoid.adapter.query(test_table1, hash_value: '1').first).to eq({ id: '1', name: 'Josh' })
     end
 
     it_behaves_like 'range queries'
@@ -606,55 +606,55 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
     # Scan
     it 'performs scan on a table and returns items' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
 
-      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ :id=> '1', :name=>'Josh' }]
+      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ id: '1', name: 'Josh' }]
     end
 
     it 'performs scan on a table and returns items if there are multiple items but only one match' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Justin'})
 
-      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ :id=> '1', :name=>'Josh' }]
+      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ id: '1', name: 'Josh' }]
     end
 
     it 'performs scan on a table and returns multiple items if there are multiple matches' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Josh'})
 
-      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'})).to include({:name=>'Josh', :id=>'2'}, {:name=>'Josh', :id=>'1'})
+      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'})).to include({name: 'Josh', id: '2'}, {name: 'Josh', id: '1'})
     end
 
     it 'performs scan on a table and returns all items if no criteria are specified' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Josh'})
 
-      expect(Dynamoid.adapter.scan(test_table1, {})).to include({:name=>'Josh', :id=>'2'}, {:name=>'Josh', :id=>'1'})
+      expect(Dynamoid.adapter.scan(test_table1, {})).to include({name: 'Josh', id: '2'}, {name: 'Josh', id: '1'})
     end
 
     it 'performs scan on a table and returns correct limit' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '3', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '4', :name => 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '3', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '4', name: 'Josh'})
 
       expect(Dynamoid.adapter.scan(test_table1, {}, {record_limit: 1}).count).to eq(1)
     end
 
     it 'performs scan on a table and returns correct batch' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '3', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '4', :name => 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '3', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '4', name: 'Josh'})
 
       expect(Dynamoid.adapter.scan(test_table1, {}, {batch_size: 1}).count).to eq(4)
     end
 
     it 'performs scan on a table and returns correct limit and batch' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '3', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '4', :name => 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '3', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '4', name: 'Josh'})
 
       expect(Dynamoid.adapter.scan(test_table1, {}, {record_limit: 1, batch_size: 1}).count).to eq(1)
     end
@@ -665,11 +665,11 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
     # Truncate
     it 'performs truncate on an existing table' do
-      Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Pascal'})
+      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Pascal'})
 
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({:name => 'Josh', :id => '1'})
-      expect(Dynamoid.adapter.get_item(test_table1, '2')).to eq({:name => 'Pascal', :id => '2'})
+      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({name: 'Josh', id: '1'})
+      expect(Dynamoid.adapter.get_item(test_table1, '2')).to eq({name: 'Pascal', id: '2'})
 
       Dynamoid.adapter.truncate(test_table1)
 
@@ -678,13 +678,13 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs truncate on an existing table with a range key' do
-      Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 1.0})
+      Dynamoid.adapter.put_item(test_table3, {id: '2', name: 'Justin', range: 2.0})
 
       Dynamoid.adapter.truncate(test_table3)
 
-      expect(Dynamoid.adapter.get_item(test_table3, '1', :range_key => 1.0)).to be_nil
-      expect(Dynamoid.adapter.get_item(test_table3, '2', :range_key => 2.0)).to be_nil
+      expect(Dynamoid.adapter.get_item(test_table3, '1', range_key: 1.0)).to be_nil
+      expect(Dynamoid.adapter.get_item(test_table3, '2', range_key: 2.0)).to be_nil
     end
 
     it_behaves_like 'correct ordering'

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -240,8 +240,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
   #
   shared_examples 'range queries' do
     before do
-      Dynamoid.adapter.put_item(test_table3, {:id => "1", :range => 1.0})
-      Dynamoid.adapter.put_item(test_table3, {:id => "1", :range => 3.0})
+      Dynamoid.adapter.put_item(test_table3, {:id => '1', :range => 1.0})
+      Dynamoid.adapter.put_item(test_table3, {:id => '1', :range => 3.0})
     end
 
     it 'performs query on a table with a range and selects items in a range' do
@@ -273,7 +273,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs query on a table with a range and selects all items' do
-      200.times { |i| Dynamoid.adapter.put_item(test_table3, {:id => "1", :range => i.to_f, :data => "A"*1024*16}) }
+      200.times { |i| Dynamoid.adapter.put_item(test_table3, {:id => '1', :range => i.to_f, :data => 'A'*1024*16}) }
       # 64 of these items will exceed the 1MB result limit thus query won't return all results on first loop
       expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_gte => 0.0).count).to eq(200)
     end
@@ -284,12 +284,12 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
   #
   shared_examples 'correct ordering' do
     before(:each) do
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 1, :range => 1.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 2, :range => 2.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 3, :range => 3.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 4, :range => 4.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 5, :range => 5.0})
-      Dynamoid.adapter.put_item(test_table4, {:id => "1", :order => 6, :range => 6.0})
+      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 1, :range => 1.0})
+      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 2, :range => 2.0})
+      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 3, :range => 3.0})
+      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 4, :range => 4.0})
+      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 5, :range => 5.0})
+      Dynamoid.adapter.put_item(test_table4, {:id => '1', :order => 6, :range => 6.0})
     end
 
     it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward true' do
@@ -352,12 +352,12 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
         # test
         expect(Dynamoid::AdapterPlugin::AwsSdkV2::PARSE_TABLE_STATUS.call(resp)).to eq(Dynamoid::AdapterPlugin::AwsSdkV2::TABLE_STATUSES[:active])
-        expect(lsi.index_name).to eql "dynamoid_tests_table_lsi_index_id_range2"
+        expect(lsi.index_name).to eql 'dynamoid_tests_table_lsi_index_id_range2'
         expect(lsi.key_schema.map(&:to_hash)).to eql [
-          {:attribute_name=>"id", :key_type=>"HASH"},
-          {:attribute_name=>"range2", :key_type=>"RANGE"}
+          {:attribute_name=>'id', :key_type=>'HASH'},
+          {:attribute_name=>'range2', :key_type=>'RANGE'}
         ]
-        expect(lsi.projection.to_hash).to eql ({:projection_type=>"KEYS_ONLY"})
+        expect(lsi.projection.to_hash).to eql ({:projection_type=>'KEYS_ONLY'})
       end
 
       it 'creates table with global_secondary_index' do
@@ -382,12 +382,12 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
         # test
         expect(Dynamoid::AdapterPlugin::AwsSdkV2::PARSE_TABLE_STATUS.call(resp)).to eq(Dynamoid::AdapterPlugin::AwsSdkV2::TABLE_STATUSES[:active])
-        expect(gsi.index_name).to eql "dynamoid_tests_table_gsi_index_hash2_range2"
+        expect(gsi.index_name).to eql 'dynamoid_tests_table_gsi_index_hash2_range2'
         expect(gsi.key_schema.map(&:to_hash)).to eql [
-          {:attribute_name=>"hash2", :key_type=>"HASH"},
-          {:attribute_name=>"range2", :key_type=>"RANGE"}
+          {:attribute_name=>'hash2', :key_type=>'HASH'},
+          {:attribute_name=>'range2', :key_type=>'RANGE'}
         ]
-        expect(gsi.projection.to_hash).to eql ({:projection_type=>"KEYS_ONLY"})
+        expect(gsi.projection.to_hash).to eql ({:projection_type=>'KEYS_ONLY'})
         expect(gsi.provisioned_throughput.write_capacity_units).to eql 10
         expect(gsi.provisioned_throughput.read_capacity_units).to eql 20
       end
@@ -396,11 +396,11 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
   context 'with a preexisting table' do
     # GetItem, PutItem and DeleteItem
-    it "performs GetItem for an item that does not exist" do
+    it 'performs GetItem for an item that does not exist' do
       expect(Dynamoid.adapter.get_item(test_table1, '1')).to be_nil
     end
 
-    it "performs GetItem for an item that does exist" do
+    it 'performs GetItem for an item that does exist' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
 
       expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({:name => 'Josh', :id => '1'})
@@ -434,12 +434,12 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
     # BatchGetItem
     it 'passes options to underlying BatchGet call' do
-      pending "at the moment passing the options to underlying batch get is not supported"
+      pending 'at the moment passing the options to underlying batch get is not supported'
       expect_any_instance_of(Aws::DynamoDB::Client).to receive(:batch_get_item).with(:request_items => {test_table1 => {:keys => [{'id' => '1'}, {'id' => '2'}], :consistent_read => true}}).and_call_original
       described_class.batch_get_item({test_table1 => ['1', '2']}, :consistent_read => true)
     end
 
-    it "performs BatchGetItem with singular keys" do
+    it 'performs BatchGetItem with singular keys' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table2, {:id => '1', :name => 'Justin'})
 
@@ -449,7 +449,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       expect(results[test_table2]).to include({:name => 'Justin', :id => '1'})
     end
 
-    it "performs BatchGetItem with multiple keys" do
+    it 'performs BatchGetItem with multiple keys' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
 
@@ -496,7 +496,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     # BatchDeleteItem
-    it "performs BatchDeleteItem with singular keys" do
+    it 'performs BatchDeleteItem with singular keys' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table2, {:id => '1', :name => 'Justin'})
 
@@ -509,7 +509,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       expect(results[test_table2]).to be_blank
     end
 
-    it "performs BatchDeleteItem with multiple keys" do
+    it 'performs BatchDeleteItem with multiple keys' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
 
@@ -588,14 +588,14 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     it 'performs query on a table and returns items' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.query(test_table1, :hash_value => '1').first).to eq({ :id=> '1', :name=>"Josh" })
+      expect(Dynamoid.adapter.query(test_table1, :hash_value => '1').first).to eq({ :id=> '1', :name=>'Josh' })
     end
 
     it 'performs query on a table and returns items if there are multiple items' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
 
-      expect(Dynamoid.adapter.query(test_table1, :hash_value => '1').first).to eq({ :id=> '1', :name=>"Josh" })
+      expect(Dynamoid.adapter.query(test_table1, :hash_value => '1').first).to eq({ :id=> '1', :name=>'Josh' })
     end
 
     it_behaves_like 'range queries'
@@ -608,28 +608,28 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     it 'performs scan on a table and returns items' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ :id=> '1', :name=>"Josh" }]
+      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ :id=> '1', :name=>'Josh' }]
     end
 
     it 'performs scan on a table and returns items if there are multiple items but only one match' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Justin'})
 
-      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ :id=> '1', :name=>"Josh" }]
+      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ :id=> '1', :name=>'Josh' }]
     end
 
     it 'performs scan on a table and returns multiple items if there are multiple matches' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'})).to include({:name=>"Josh", :id=>"2"}, {:name=>"Josh", :id=>"1"})
+      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'})).to include({:name=>'Josh', :id=>'2'}, {:name=>'Josh', :id=>'1'})
     end
 
     it 'performs scan on a table and returns all items if no criteria are specified' do
       Dynamoid.adapter.put_item(test_table1, {:id => '1', :name => 'Josh'})
       Dynamoid.adapter.put_item(test_table1, {:id => '2', :name => 'Josh'})
 
-      expect(Dynamoid.adapter.scan(test_table1, {})).to include({:name=>"Josh", :id=>"2"}, {:name=>"Josh", :id=>"1"})
+      expect(Dynamoid.adapter.scan(test_table1, {})).to include({:name=>'Josh', :id=>'2'}, {:name=>'Josh', :id=>'1'})
     end
 
     it 'performs scan on a table and returns correct limit' do

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -245,11 +245,11 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs query on a table with a range and selects items in a range' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_between => [0.0,3.0]).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_between => [0.0, 3.0]).to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
     end
 
     it 'performs query on a table with a range and selects items in a range with :select option' do
-      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_between => [0.0,3.0], :select =>  'ALL_ATTRIBUTES').to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
+      expect(Dynamoid.adapter.query(test_table3, :hash_value => '1', :range_between => [0.0, 3.0], :select =>  'ALL_ATTRIBUTES').to_a).to eq [{:id => '1', :range => BigDecimal.new(1)}, {:id => '1', :range => BigDecimal.new(3)}]
     end
 
     it 'performs query on a table with a range and selects items greater than' do
@@ -472,7 +472,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
       Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
 
-      results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0],['2', 2.0]])
+      results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0], ['2', 2.0]])
       expect(results.size).to eq 1
 
       expect(results[test_table3]).to include({:name => 'Josh', :id => '1', :range => 1.0})
@@ -536,8 +536,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       Dynamoid.adapter.put_item(test_table3, {:id => '1', :name => 'Josh', :range => 1.0})
       Dynamoid.adapter.put_item(test_table3, {:id => '2', :name => 'Justin', :range => 2.0})
 
-      Dynamoid.adapter.batch_delete_item(test_table3 => [['1', 1.0],['2', 2.0]])
-      results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0],['2', 2.0]])
+      Dynamoid.adapter.batch_delete_item(test_table3 => [['1', 1.0], ['2', 2.0]])
+      results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0], ['2', 2.0]])
 
       expect(results.size).to eq 1
       expect(results[test_table3]).to be_blank

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -47,8 +47,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     context 'multiple name entities' do
       before(:each) do
         (1..4).each do |i|
-          Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: i.to_f})
-          Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Pascal', range: (i + 4).to_f})
+          Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Josh', range: i.to_f)
+          Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Pascal', range: (i + 4).to_f)
         end
       end
 
@@ -57,57 +57,57 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       end
 
       it 'returns correct record limit' do
-        expect(dynamo_request(test_table3, request_params, {record_limit: 1}).count).to eq(1)
-        expect(dynamo_request(test_table3, request_params, {record_limit: 3}).count).to eq(3)
+        expect(dynamo_request(test_table3, request_params, record_limit: 1).count).to eq(1)
+        expect(dynamo_request(test_table3, request_params, record_limit: 3).count).to eq(3)
       end
 
       it 'returns correct batch' do
         # Receives 8 times for each item and 1 more for empty page
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(9).times.and_call_original
-        expect(dynamo_request(test_table3, request_params, {batch_size: 1}).count).to eq(8)
+        expect(dynamo_request(test_table3, request_params, batch_size: 1).count).to eq(8)
       end
 
       it 'returns correct batch and paginates in batches' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(3).times.and_call_original
-        expect(dynamo_request(test_table3, request_params, {batch_size: 3}).count).to eq(8)
+        expect(dynamo_request(test_table3, request_params, batch_size: 3).count).to eq(8)
       end
 
       it 'returns correct record limit and batch' do
-        expect(dynamo_request(test_table3, request_params, {record_limit: 1, batch_size: 1}).count).to eq(1)
+        expect(dynamo_request(test_table3, request_params, record_limit: 1, batch_size: 1).count).to eq(1)
       end
 
       it 'returns correct record limit with filter' do
-        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Josh'}}), {record_limit: 1}).count)
+        expect(dynamo_request(test_table3, request_params.merge(name: {eq: 'Josh'}), record_limit: 1).count)
           .to eq(1)
       end
 
       it 'obeys correct scan limit with filter' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(1).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Josh'}}), {scan_limit: 2}).count)
+        expect(dynamo_request(test_table3, request_params.merge(name: {eq: 'Josh'}), scan_limit: 2).count)
           .to eq(2)
       end
 
       it 'obeys correct scan limit over record limit with filter' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(1).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Josh'}}), {
+        expect(dynamo_request(test_table3, request_params.merge(name: {eq: 'Josh'}),
           scan_limit: 2,
           record_limit: 10, # Won't be able to return more than 2 due to scan limit
-        }).count).to eq(2)
+        ).count).to eq(2)
       end
 
       it 'obeys correct scan limit with filter with some return' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(1).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Pascal'}}), {
-          scan_limit: 5,
-        }).count).to eq(1)
+        expect(dynamo_request(test_table3, request_params.merge(name: {eq: 'Pascal'}),
+          scan_limit: 5
+        ).count).to eq(1)
       end
 
       it 'obeys correct scan limit and batch size with filter with some return' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Josh'}}), {
+        expect(dynamo_request(test_table3, request_params.merge(name: {eq: 'Josh'}),
           scan_limit: 3,
           batch_size: 2, # This would force batching of size 2 for potential of 4 results!
-        }).count).to eq(3)
+        ).count).to eq(3)
       end
 
       it 'obeys correct scan limit with filter and batching for some return' do
@@ -115,11 +115,11 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         # We should paginate through 5 responses each of size 1 (batch) and
         # only scan through 5 records at most which with our given filter
         # should return 1 result since first 4 are Josh and last is Pascal.
-        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Pascal'}}), {
+        expect(dynamo_request(test_table3, request_params.merge(name: {eq: 'Pascal'}),
           batch_size: 1,
           scan_limit: 5,
-          record_limit: 3,
-        }).count).to eq(1)
+          record_limit: 3
+        ).count).to eq(1)
       end
 
       it 'obeys correct record limit with filter, batching, and scan limit' do
@@ -127,11 +127,11 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         # We should paginate through 6 responses each of size 1 (batch) and
         # only scan through 6 records at most which with our given filter
         # should return 2 results, and hit record limit before scan limit.
-        expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Pascal'}}), {
+        expect(dynamo_request(test_table3, request_params.merge(name: {eq: 'Pascal'}),
           batch_size: 1,
           scan_limit: 10,
-          record_limit: 2,
-        }).count).to eq(2)
+          record_limit: 2
+        ).count).to eq(2)
       end
     end
 
@@ -144,19 +144,18 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         # 64 of these items will exceed the 1MB result record_limit thus query won't return all results on first loop
         # We use :age since :range won't work for filtering in queries
         200.times do |i|
-          Dynamoid.adapter.put_item(test_table3, {
+          Dynamoid.adapter.put_item(test_table3,
             id: '1',
             range: i.to_f,
             age: i.to_f,
-            data: 'A'*1024*16,
-          })
+            data: 'A'*1024*16)
         end
       end
 
       it 'returns correct for limits and scan limit' do
-        expect(dynamo_request(test_table3, request_params, {
-          scan_limit: 100,
-        }).count).to eq(100)
+        expect(dynamo_request(test_table3, request_params,
+          scan_limit: 100
+        ).count).to eq(100)
       end
 
       it 'returns correct for scan limit with filtering' do
@@ -165,22 +164,22 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         # and then look at 36 records and find 10 on the second page.
         pages = request_type == :query ? 1 : 2
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(pages).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({ age: {gte: 90.0} }), {
-          scan_limit: 100,
-        }).count).to eq(10)
+        expect(dynamo_request(test_table3, request_params.merge(age: {gte: 90.0}),
+          scan_limit: 100
+        ).count).to eq(10)
       end
 
       it 'returns correct for record limit' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
-        expect(dynamo_request(test_table3, request_params.merge({ age: {gte: 5.0} }), {
-          record_limit: 100,
-        }).count).to eq(100)
+        expect(dynamo_request(test_table3, request_params.merge(age: {gte: 5.0}),
+          record_limit: 100
+        ).count).to eq(100)
       end
 
       it 'returns correct record limit with filtering' do
-        expect(dynamo_request(test_table3, request_params.merge({ age: {gte: 133.0} }), {
-          record_limit: 100,
-        }).count).to eq(67)
+        expect(dynamo_request(test_table3, request_params.merge(age: {gte: 133.0}),
+          record_limit: 100
+        ).count).to eq(67)
       end
 
       it 'returns correct with batching' do
@@ -188,38 +187,38 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         # which is limitation of DynamoDB and therefore batch limit is
         # restricted by this limitation as well!
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(4).times.and_call_original
-        expect(dynamo_request(test_table3, request_params, {
-          batch_size: 100,
-        }).count).to eq(200)
+        expect(dynamo_request(test_table3, request_params,
+          batch_size: 100
+        ).count).to eq(200)
       end
 
       it 'returns correct with batching and record limit beyond data size limit' do
         # Since we hit limit once, we need to make sure the second request only
         # requests for as many as we have left for our record limit.
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
-        expect(dynamo_request(test_table3, request_params, {
+        expect(dynamo_request(test_table3, request_params,
           record_limit: 83,
-          batch_size: 100,
-        }).count).to eq(83)
+          batch_size: 100
+        ).count).to eq(83)
       end
 
       it 'returns correct with batching and record limit' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(11).times.and_call_original
         # Since we do age >= 5.0 we lose the first 5 results so we make 11 paginated requests
-        expect(dynamo_request(test_table3, request_params.merge({ age: {gte: 5.0} }), {
+        expect(dynamo_request(test_table3, request_params.merge(age: {gte: 5.0}),
           record_limit: 100,
-          batch_size: 10,
-        }).count).to eq(100)
+          batch_size: 10
+        ).count).to eq(100)
       end
     end
 
     it 'correctly limits edge case of record and scan counts approaching limits' do
       (1..4).each do |i|
-        Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: i.to_f})
+        Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Josh', range: i.to_f)
       end
-      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Pascal', range: 5.0})
+      Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Pascal', range: 5.0)
       (6..10).each do |i|
-        Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: i.to_f})
+        Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Josh', range: i.to_f)
       end
 
       expect(Dynamoid.adapter.client).to receive(request_type).exactly(2).times.and_call_original
@@ -227,11 +226,11 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       # we would get the 5th Josh (range value 6.0) whereas correct implementation would
       # adjust limit to 1 since can only scan 1 more record therefore would see Pascal
       # and not go to next valid record.
-      expect(dynamo_request(test_table3, request_params.merge({name: {eq: 'Josh'}}), {
+      expect(dynamo_request(test_table3, request_params.merge(name: {eq: 'Josh'}),
         batch_size: 4,
         scan_limit: 5,    # Scan limit would adjust requested limit to 1
         record_limit: 6,  # Record limit would adjust requested limit to 2
-      }).count).to eq(4)
+      ).count).to eq(4)
     end
   end
 
@@ -240,8 +239,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
   #
   shared_examples 'range queries' do
     before do
-      Dynamoid.adapter.put_item(test_table3, {id: '1', range: 1.0})
-      Dynamoid.adapter.put_item(test_table3, {id: '1', range: 3.0})
+      Dynamoid.adapter.put_item(test_table3, id: '1', range: 1.0)
+      Dynamoid.adapter.put_item(test_table3, id: '1', range: 3.0)
     end
 
     it 'performs query on a table with a range and selects items in a range' do
@@ -273,7 +272,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs query on a table with a range and selects all items' do
-      200.times { |i| Dynamoid.adapter.put_item(test_table3, {id: '1', range: i.to_f, data: 'A'*1024*16}) }
+      200.times { |i| Dynamoid.adapter.put_item(test_table3, id: '1', range: i.to_f, data: 'A'*1024*16) }
       # 64 of these items will exceed the 1MB result limit thus query won't return all results on first loop
       expect(Dynamoid.adapter.query(test_table3, hash_value: '1', range_gte: 0.0).count).to eq(200)
     end
@@ -284,32 +283,32 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
   #
   shared_examples 'correct ordering' do
     before(:each) do
-      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 1, range: 1.0})
-      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 2, range: 2.0})
-      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 3, range: 3.0})
-      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 4, range: 4.0})
-      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 5, range: 5.0})
-      Dynamoid.adapter.put_item(test_table4, {id: '1', order: 6, range: 6.0})
+      Dynamoid.adapter.put_item(test_table4, id: '1', order: 1, range: 1.0)
+      Dynamoid.adapter.put_item(test_table4, id: '1', order: 2, range: 2.0)
+      Dynamoid.adapter.put_item(test_table4, id: '1', order: 3, range: 3.0)
+      Dynamoid.adapter.put_item(test_table4, id: '1', order: 4, range: 4.0)
+      Dynamoid.adapter.put_item(test_table4, id: '1', order: 5, range: 5.0)
+      Dynamoid.adapter.put_item(test_table4, id: '1', order: 6, range: 6.0)
     end
 
     it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward true' do
       query = Dynamoid.adapter.query(test_table4, hash_value: '1', range_greater_than: 0, scan_index_forward: true).to_a
-      expect(query[0]).to eq({id: '1', order: 1, range: BigDecimal.new(1)})
-      expect(query[1]).to eq({id: '1', order: 2, range: BigDecimal.new(2)})
-      expect(query[2]).to eq({id: '1', order: 3, range: BigDecimal.new(3)})
-      expect(query[3]).to eq({id: '1', order: 4, range: BigDecimal.new(4)})
-      expect(query[4]).to eq({id: '1', order: 5, range: BigDecimal.new(5)})
-      expect(query[5]).to eq({id: '1', order: 6, range: BigDecimal.new(6)})
+      expect(query[0]).to eq(id: '1', order: 1, range: BigDecimal.new(1))
+      expect(query[1]).to eq(id: '1', order: 2, range: BigDecimal.new(2))
+      expect(query[2]).to eq(id: '1', order: 3, range: BigDecimal.new(3))
+      expect(query[3]).to eq(id: '1', order: 4, range: BigDecimal.new(4))
+      expect(query[4]).to eq(id: '1', order: 5, range: BigDecimal.new(5))
+      expect(query[5]).to eq(id: '1', order: 6, range: BigDecimal.new(6))
     end
 
     it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward false' do
       query = Dynamoid.adapter.query(test_table4, hash_value: '1', range_greater_than: 0, scan_index_forward: false).to_a
-      expect(query[5]).to eq({id: '1', order: 1, range: BigDecimal.new(1)})
-      expect(query[4]).to eq({id: '1', order: 2, range: BigDecimal.new(2)})
-      expect(query[3]).to eq({id: '1', order: 3, range: BigDecimal.new(3)})
-      expect(query[2]).to eq({id: '1', order: 4, range: BigDecimal.new(4)})
-      expect(query[1]).to eq({id: '1', order: 5, range: BigDecimal.new(5)})
-      expect(query[0]).to eq({id: '1', order: 6, range: BigDecimal.new(6)})
+      expect(query[5]).to eq(id: '1', order: 1, range: BigDecimal.new(1))
+      expect(query[4]).to eq(id: '1', order: 2, range: BigDecimal.new(2))
+      expect(query[3]).to eq(id: '1', order: 3, range: BigDecimal.new(3))
+      expect(query[2]).to eq(id: '1', order: 4, range: BigDecimal.new(4))
+      expect(query[1]).to eq(id: '1', order: 5, range: BigDecimal.new(5))
+      expect(query[0]).to eq(id: '1', order: 6, range: BigDecimal.new(6))
     end
   end
 
@@ -335,15 +334,14 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
       it 'creates table with local_secondary_index' do
         # setup
-        doc_class.table({name: 'table_lsi', key: :id})
+        doc_class.table(name: 'table_lsi', key: :id)
         doc_class.local_secondary_index ({
           range_key: :range2,
         })
 
-        Dynamoid.adapter.create_table('table_lsi', :id, {
+        Dynamoid.adapter.create_table('table_lsi', :id,
           local_secondary_indexes: doc_class.local_secondary_indexes.values,
-          range_key: { range: :number }
-        })
+          range_key: { range: :number })
 
         # execute
         resp = Dynamoid.adapter.client.describe_table(table_name: 'table_lsi')
@@ -362,7 +360,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
       it 'creates table with global_secondary_index' do
         # setup
-        doc_class.table({name: 'table_gsi', key: :id})
+        doc_class.table(name: 'table_gsi', key: :id)
         doc_class.global_secondary_index ({
           hash_key: :hash2,
           range_key: :range2,
@@ -370,10 +368,9 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
           read_capacity: 20
 
         })
-        Dynamoid.adapter.create_table('table_gsi', :id, {
+        Dynamoid.adapter.create_table('table_gsi', :id,
           global_secondary_indexes: doc_class.global_secondary_indexes.values,
-          range_key: { range: :number }
-        })
+          range_key: { range: :number })
 
         # execute
         resp = Dynamoid.adapter.client.describe_table(table_name: 'table_gsi')
@@ -401,9 +398,9 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs GetItem for an item that does exist' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
 
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({name: 'Josh', id: '1'})
+      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq(name: 'Josh', id: '1')
 
       Dynamoid.adapter.delete_item(test_table1, '1')
 
@@ -411,9 +408,9 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs GetItem for an item that does exist with a range key' do
-      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 2.0})
+      Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Josh', range: 2.0)
 
-      expect(Dynamoid.adapter.get_item(test_table3, '1', range_key: 2.0)).to eq({name: 'Josh', id: '1', range: 2.0})
+      expect(Dynamoid.adapter.get_item(test_table3, '1', range_key: 2.0)).to eq(name: 'Josh', id: '1', range: 2.0)
 
       Dynamoid.adapter.delete_item(test_table3, '1', range_key: 2.0)
 
@@ -427,9 +424,9 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs PutItem for an item that does not exist' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
 
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({id: '1', name: 'Josh'})
+      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq(id: '1', name: 'Josh')
     end
 
     # BatchGetItem
@@ -440,43 +437,43 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs BatchGetItem with singular keys' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table2, {id: '1', name: 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table2, id: '1', name: 'Justin')
 
       results = Dynamoid.adapter.batch_get_item(test_table1 => '1', test_table2 => '1')
       expect(results.size).to eq 2
-      expect(results[test_table1]).to include({name: 'Josh', id: '1'})
-      expect(results[test_table2]).to include({name: 'Justin', id: '1'})
+      expect(results[test_table1]).to include(name: 'Josh', id: '1')
+      expect(results[test_table2]).to include(name: 'Justin', id: '1')
     end
 
     it 'performs BatchGetItem with multiple keys' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Justin')
 
       results = Dynamoid.adapter.batch_get_item(test_table1 => ['1', '2'])
       expect(results.size).to eq 1
-      expect(results[test_table1]).to include({name: 'Josh', id: '1'})
-      expect(results[test_table1]).to include({name: 'Justin', id: '2'})
+      expect(results[test_table1]).to include(name: 'Josh', id: '1')
+      expect(results[test_table1]).to include(name: 'Justin', id: '2')
     end
 
     it 'performs BatchGetItem with one ranged key' do
-      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 1.0})
-      Dynamoid.adapter.put_item(test_table3, {id: '2', name: 'Justin', range: 2.0})
+      Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Josh', range: 1.0)
+      Dynamoid.adapter.put_item(test_table3, id: '2', name: 'Justin', range: 2.0)
 
       results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0]])
       expect(results.size).to eq 1
-      expect(results[test_table3]).to include({name: 'Josh', id: '1', range: 1.0})
+      expect(results[test_table3]).to include(name: 'Josh', id: '1', range: 1.0)
     end
 
     it 'performs BatchGetItem with multiple ranged keys' do
-      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 1.0})
-      Dynamoid.adapter.put_item(test_table3, {id: '2', name: 'Justin', range: 2.0})
+      Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Josh', range: 1.0)
+      Dynamoid.adapter.put_item(test_table3, id: '2', name: 'Justin', range: 2.0)
 
       results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0], ['2', 2.0]])
       expect(results.size).to eq 1
 
-      expect(results[test_table3]).to include({name: 'Josh', id: '1', range: 1.0})
-      expect(results[test_table3]).to include({name: 'Justin', id: '2', range: 2.0})
+      expect(results[test_table3]).to include(name: 'Josh', id: '1', range: 1.0)
+      expect(results[test_table3]).to include(name: 'Justin', id: '2', range: 2.0)
     end
 
     it 'performs BatchGetItem with ranges of 100 keys' do
@@ -484,7 +481,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
       (1..101).each do |i|
         id, range = i.to_s, i.to_f
-        Dynamoid.adapter.put_item(test_table3, {id: id, name: "Josh_#{i}", range: range})
+        Dynamoid.adapter.put_item(test_table3, id: id, name: "Josh_#{i}", range: range)
         table_ids << [id, range]
       end
 
@@ -492,13 +489,13 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
       expect(results.size).to eq 1
 
-      expect(results[test_table3]).to include({name: 'Josh_101', id: '101', range: 101.0})
+      expect(results[test_table3]).to include(name: 'Josh_101', id: '101', range: 101.0)
     end
 
     # BatchDeleteItem
     it 'performs BatchDeleteItem with singular keys' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table2, {id: '1', name: 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table2, id: '1', name: 'Justin')
 
       Dynamoid.adapter.batch_delete_item(test_table1 => ['1'], test_table2 => ['1'])
 
@@ -510,8 +507,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs BatchDeleteItem with multiple keys' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Justin')
 
       Dynamoid.adapter.batch_delete_item(test_table1 => ['1', '2'])
 
@@ -522,8 +519,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs BatchDeleteItem with one ranged key' do
-      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 1.0})
-      Dynamoid.adapter.put_item(test_table3, {id: '2', name: 'Justin', range: 2.0})
+      Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Josh', range: 1.0)
+      Dynamoid.adapter.put_item(test_table3, id: '2', name: 'Justin', range: 2.0)
 
       Dynamoid.adapter.batch_delete_item(test_table3 => [['1', 1.0]])
       results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0]])
@@ -533,8 +530,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs BatchDeleteItem with multiple ranged keys' do
-      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 1.0})
-      Dynamoid.adapter.put_item(test_table3, {id: '2', name: 'Justin', range: 2.0})
+      Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Josh', range: 1.0)
+      Dynamoid.adapter.put_item(test_table3, id: '2', name: 'Justin', range: 2.0)
 
       Dynamoid.adapter.batch_delete_item(test_table3 => [['1', 1.0], ['2', 2.0]])
       results = Dynamoid.adapter.batch_get_item(test_table3 => [['1', 1.0], ['2', 2.0]])
@@ -586,16 +583,16 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
     # Query
     it 'performs query on a table and returns items' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
 
-      expect(Dynamoid.adapter.query(test_table1, hash_value: '1').first).to eq({ id: '1', name: 'Josh' })
+      expect(Dynamoid.adapter.query(test_table1, hash_value: '1').first).to eq(id: '1', name: 'Josh')
     end
 
     it 'performs query on a table and returns items if there are multiple items' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Justin')
 
-      expect(Dynamoid.adapter.query(test_table1, hash_value: '1').first).to eq({ id: '1', name: 'Josh' })
+      expect(Dynamoid.adapter.query(test_table1, hash_value: '1').first).to eq(id: '1', name: 'Josh')
     end
 
     it_behaves_like 'range queries'
@@ -606,57 +603,57 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
     # Scan
     it 'performs scan on a table and returns items' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
 
       expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ id: '1', name: 'Josh' }]
     end
 
     it 'performs scan on a table and returns items if there are multiple items but only one match' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Justin'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Justin')
 
       expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'}).to_a).to eq [{ id: '1', name: 'Josh' }]
     end
 
     it 'performs scan on a table and returns multiple items if there are multiple matches' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Josh')
 
-      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'})).to include({name: 'Josh', id: '2'}, {name: 'Josh', id: '1'})
+      expect(Dynamoid.adapter.scan(test_table1, name: {eq: 'Josh'})).to include({name: 'Josh', id: '2'}, name: 'Josh', id: '1')
     end
 
     it 'performs scan on a table and returns all items if no criteria are specified' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Josh')
 
-      expect(Dynamoid.adapter.scan(test_table1, {})).to include({name: 'Josh', id: '2'}, {name: 'Josh', id: '1'})
+      expect(Dynamoid.adapter.scan(test_table1, {})).to include({name: 'Josh', id: '2'}, name: 'Josh', id: '1')
     end
 
     it 'performs scan on a table and returns correct limit' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '3', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '4', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '3', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '4', name: 'Josh')
 
-      expect(Dynamoid.adapter.scan(test_table1, {}, {record_limit: 1}).count).to eq(1)
+      expect(Dynamoid.adapter.scan(test_table1, {}, record_limit: 1).count).to eq(1)
     end
 
     it 'performs scan on a table and returns correct batch' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '3', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '4', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '3', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '4', name: 'Josh')
 
-      expect(Dynamoid.adapter.scan(test_table1, {}, {batch_size: 1}).count).to eq(4)
+      expect(Dynamoid.adapter.scan(test_table1, {}, batch_size: 1).count).to eq(4)
     end
 
     it 'performs scan on a table and returns correct limit and batch' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '3', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '4', name: 'Josh'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '3', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '4', name: 'Josh')
 
-      expect(Dynamoid.adapter.scan(test_table1, {}, {record_limit: 1, batch_size: 1}).count).to eq(1)
+      expect(Dynamoid.adapter.scan(test_table1, {}, record_limit: 1, batch_size: 1).count).to eq(1)
     end
 
     describe 'scans' do
@@ -665,11 +662,11 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
     # Truncate
     it 'performs truncate on an existing table' do
-      Dynamoid.adapter.put_item(test_table1, {id: '1', name: 'Josh'})
-      Dynamoid.adapter.put_item(test_table1, {id: '2', name: 'Pascal'})
+      Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
+      Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Pascal')
 
-      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq({name: 'Josh', id: '1'})
-      expect(Dynamoid.adapter.get_item(test_table1, '2')).to eq({name: 'Pascal', id: '2'})
+      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq(name: 'Josh', id: '1')
+      expect(Dynamoid.adapter.get_item(test_table1, '2')).to eq(name: 'Pascal', id: '2')
 
       Dynamoid.adapter.truncate(test_table1)
 
@@ -678,8 +675,8 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
 
     it 'performs truncate on an existing table with a range key' do
-      Dynamoid.adapter.put_item(test_table3, {id: '1', name: 'Josh', range: 1.0})
-      Dynamoid.adapter.put_item(test_table3, {id: '2', name: 'Justin', range: 2.0})
+      Dynamoid.adapter.put_item(test_table3, id: '1', name: 'Josh', range: 1.0)
+      Dynamoid.adapter.put_item(test_table3, id: '2', name: 'Justin', range: 2.0)
 
       Dynamoid.adapter.truncate(test_table3)
 

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -577,7 +577,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
 
     # ListTables
     it 'performs ListTables' do
-      #Force creation of the tables
+      # Force creation of the tables
       test_table1; test_table2; test_table3; test_table4
 
       expect(Dynamoid.adapter.list_tables).to include test_table1

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v2_spec.rb
@@ -313,7 +313,6 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
     end
   end
 
-
   context 'without a preexisting table' do
     # CreateTable and DeleteTable
     it 'performs CreateTable and DeleteTable' do
@@ -394,7 +393,6 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
       end
     end
   end
-
 
   context 'with a preexisting table' do
     # GetItem, PutItem and DeleteItem

--- a/spec/dynamoid/adapter_spec.rb
+++ b/spec/dynamoid/adapter_spec.rb
@@ -55,8 +55,8 @@ describe Dynamoid::Adapter do
   end
 
   it 'writes through the adapter' do
-    expect(subject).to receive(:put_item).with(test_table, {:id => single_id}, nil).and_return(true)
-    subject.write(test_table, {:id => single_id})
+    expect(subject).to receive(:put_item).with(test_table, {id: single_id}, nil).and_return(true)
+    subject.write(test_table, {id: single_id})
   end
 
   it 'reads through the adapter for one ID' do
@@ -80,22 +80,22 @@ describe Dynamoid::Adapter do
   end
 
   it 'reads through the adapter for one ID and a range key' do
-    expect(subject).to receive(:get_item).with(test_table, single_id, :range_key => 2.0).and_return(true)
-    subject.read(test_table, single_id, :range_key => 2.0)
+    expect(subject).to receive(:get_item).with(test_table, single_id, range_key: 2.0).and_return(true)
+    subject.read(test_table, single_id, range_key: 2.0)
   end
 
   it 'reads through the adapter for many IDs and a range key' do
     expect(subject).to receive(:batch_get_item).with({test_table => [['1', 2.0], ['2', 2.0]]}, {}).and_return(true)
-    subject.read(test_table, many_ids, :range_key => 2.0)
+    subject.read(test_table, many_ids, range_key: 2.0)
   end
 
   it 'deletes through the adapter for one ID and a range key' do
-    expect(subject).to receive(:delete_item).with(test_table, single_id, :range_key => 2.0).and_return(nil)
-    subject.delete(test_table, single_id, :range_key => 2.0)
+    expect(subject).to receive(:delete_item).with(test_table, single_id, range_key: 2.0).and_return(nil)
+    subject.delete(test_table, single_id, range_key: 2.0)
   end
 
   it 'deletes through the adapter for many IDs and a range key' do
     expect(subject).to receive(:batch_delete_item).with({test_table => [['1', 2.0], ['2', 2.0]]}).and_return(nil)
-    subject.delete(test_table, many_ids, :range_key => [2.0, 2.0])
+    subject.delete(test_table, many_ids, range_key: [2.0, 2.0])
   end
 end

--- a/spec/dynamoid/adapter_spec.rb
+++ b/spec/dynamoid/adapter_spec.rb
@@ -56,7 +56,7 @@ describe Dynamoid::Adapter do
 
   it 'writes through the adapter' do
     expect(subject).to receive(:put_item).with(test_table, {id: single_id}, nil).and_return(true)
-    subject.write(test_table, {id: single_id})
+    subject.write(test_table, id: single_id)
   end
 
   it 'reads through the adapter for one ID' do
@@ -75,7 +75,7 @@ describe Dynamoid::Adapter do
   end
 
   it 'deletes through the adapter for many IDs' do
-    expect(subject).to receive(:batch_delete_item).with({test_table => many_ids}).and_return(nil)
+    expect(subject).to receive(:batch_delete_item).with(test_table => many_ids).and_return(nil)
     subject.delete(test_table, many_ids)
   end
 
@@ -95,7 +95,7 @@ describe Dynamoid::Adapter do
   end
 
   it 'deletes through the adapter for many IDs and a range key' do
-    expect(subject).to receive(:batch_delete_item).with({test_table => [['1', 2.0], ['2', 2.0]]}).and_return(nil)
+    expect(subject).to receive(:batch_delete_item).with(test_table => [['1', 2.0], ['2', 2.0]]).and_return(nil)
     subject.delete(test_table, many_ids, range_key: [2.0, 2.0])
   end
 end

--- a/spec/dynamoid/adapter_spec.rb
+++ b/spec/dynamoid/adapter_spec.rb
@@ -96,6 +96,6 @@ describe Dynamoid::Adapter do
 
   it 'deletes through the adapter for many IDs and a range key' do
     expect(subject).to receive(:batch_delete_item).with({test_table => [['1', 2.0], ['2', 2.0]]}).and_return(nil)
-    subject.delete(test_table, many_ids, :range_key => [2.0,2.0])
+    subject.delete(test_table, many_ids, :range_key => [2.0, 2.0])
   end
 end

--- a/spec/dynamoid/associations/has_and_belongs_to_many_spec.rb
+++ b/spec/dynamoid/associations/has_and_belongs_to_many_spec.rb
@@ -6,7 +6,7 @@ describe Dynamoid::Associations::HasAndBelongsToMany do
 
   it 'determines equality from its records' do
     user = subscription.users.create
-    
+
     expect(subscription.users.size).to eq 1
     expect(subscription.users).to include user
   end
@@ -15,14 +15,14 @@ describe Dynamoid::Associations::HasAndBelongsToMany do
     expect(subscription.users.send(:target_association)).to eq :subscriptions
     expect(camel_case.subscriptions.send(:target_association)).to eq :camel_cases
   end
-  
+
   it 'determines target attribute' do
     expect(subscription.users.send(:target_attribute)).to eq :subscriptions_ids
   end
-  
+
   it 'associates has_and_belongs_to_many automatically' do
     user = subscription.users.create
-    
+
     expect(user.subscriptions.size).to eq 1
     expect(user.subscriptions).to include subscription
     expect(subscription.users.size).to eq 1
@@ -33,10 +33,10 @@ describe Dynamoid::Associations::HasAndBelongsToMany do
     expect(follower.following).to include user
     expect(user.followers).to include follower
   end
-  
+
   it 'disassociates has_and_belongs_to_many automatically' do
     user = subscription.users.create
-    
+
     subscription.users.delete(user)
     expect(subscription.users.size).to eq 0
     expect(user.subscriptions.size).to eq 0

--- a/spec/dynamoid/associations_spec.rb
+++ b/spec/dynamoid/associations_spec.rb
@@ -2,11 +2,11 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Dynamoid::Associations do
   let(:magazine) { Magazine.create }
-  
+
   it 'defines a getter' do
     expect(magazine).to respond_to :subscriptions
   end
-  
+
   it 'defines a setter' do
     expect(magazine).to respond_to :subscriptions=
   end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -798,7 +798,6 @@ describe Dynamoid::Criteria::Chain do
     end
   end
 
-
   context 'single table inheritance' do
     describe 'where' do
       it 'honors STI' do

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -74,18 +74,18 @@ describe Dynamoid::Criteria::Chain do
       end
 
       it 'supports record_limit' do
-        expect(model.where(request_params.merge({ name: 'Josh' })).record_limit(1).count).to eq(1)
-        expect(model.where(request_params.merge({ name: 'Josh' })).record_limit(3).count).to eq(3)
+        expect(model.where(request_params.merge(name: 'Josh')).record_limit(1).count).to eq(1)
+        expect(model.where(request_params.merge(name: 'Josh')).record_limit(3).count).to eq(3)
       end
 
       it 'supports scan_limit' do
-        expect(model.where(request_params.merge({ name: 'Pascal' })).scan_limit(1).count).to eq(0)
-        expect(model.where(request_params.merge({ name: 'Pascal' })).scan_limit(11).count).to eq(1)
+        expect(model.where(request_params.merge(name: 'Pascal')).scan_limit(1).count).to eq(0)
+        expect(model.where(request_params.merge(name: 'Pascal')).scan_limit(11).count).to eq(1)
       end
 
       it 'supports batch' do
-        expect(model.where(request_params.merge({ name: 'Josh' })).batch(1).count).to eq(10)
-        expect(model.where(request_params.merge({ name: 'Josh' })).batch(3).count).to eq(10)
+        expect(model.where(request_params.merge(name: 'Josh')).batch(1).count).to eq(10)
+        expect(model.where(request_params.merge(name: 'Josh')).batch(3).count).to eq(10)
       end
 
       it 'supports combined limits with batch size 1' do
@@ -93,7 +93,7 @@ describe Dynamoid::Criteria::Chain do
         # 3 Pascal objects but it'll hit record_limit first with 2 objects
         # so we'd only see 12 requests due to batching.
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(12).times.and_call_original
-        expect(model.where(request_params.merge({ name: 'Pascal' }))
+        expect(model.where(request_params.merge(name: 'Pascal'))
                     .record_limit(2)
                     .scan_limit(13)
                     .batch(1).count).to eq(2)
@@ -104,7 +104,7 @@ describe Dynamoid::Criteria::Chain do
         # 3 Josh, 3 Josh, 3 Josh, 1 Josh + 2 Pascal, 3 Pascal, 3 Pascal, 2 Pascal
         # So total of 7 requests
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(7).times.and_call_original
-        expect(model.where(request_params.merge({ name: 'Pascal' }))
+        expect(model.where(request_params.merge(name: 'Pascal'))
                     .record_limit(10)
                     .batch(3).count).to eq(10)
       end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Dynamoid::Criteria::Chain do
   let(:time) { DateTime.now }
-  let!(:user) { User.create(:name => 'Josh', :email => 'josh@joshsymonds.com', :password => 'Test123') }
+  let!(:user) { User.create(name: 'Josh', email: 'josh@joshsymonds.com', password: 'Test123') }
   let(:chain) { Dynamoid::Criteria::Chain.new(User) }
 
   describe 'Query vs Scan' do
@@ -15,35 +15,35 @@ describe Dynamoid::Criteria::Chain do
 
     it 'Queries when query is only ID' do
       chain = Dynamoid::Criteria::Chain.new(Address)
-      chain.query = { :id => 'test' }
+      chain.query = { id: 'test' }
       expect(chain).to receive(:records_via_query)
       chain.all
     end
 
     it 'Queries when query contains ID' do
       chain = Dynamoid::Criteria::Chain.new(Address)
-      chain.query = { :id => 'test', city: 'Bucharest' }
+      chain.query = { id: 'test', city: 'Bucharest' }
       expect(chain).to receive(:records_via_query)
       chain.all
     end
 
     it 'Scans when query includes keys that are neither a hash nor a range' do
       chain = Dynamoid::Criteria::Chain.new(Address)
-      chain.query = { :city => 'Bucharest' }
+      chain.query = { city: 'Bucharest' }
       expect(chain).to receive(:records_via_scan)
       chain.all
     end
 
     it 'Scans when query is only a range' do
       chain = Dynamoid::Criteria::Chain.new(Tweet)
-      chain.query = { :group => 'xx' }
+      chain.query = { group: 'xx' }
       expect(chain).to receive(:records_via_scan)
       chain.all
     end
 
     it 'Scans when there is only not-equal operator for hash key' do
       chain = Dynamoid::Criteria::Chain.new(Address)
-      chain.query = { :'id.in' => ['test'] }
+      chain.query = { 'id.in': ['test'] }
       expect(chain).to receive(:records_via_scan)
       chain.all
     end
@@ -509,7 +509,7 @@ describe Dynamoid::Criteria::Chain do
 
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:records_via_scan).and_call_original
-      expect(chain.where(:city => 'San Francisco').count).to eq(2)
+      expect(chain.where(city: 'San Francisco').count).to eq(2)
       # Does not use GSI since not projecting all attributes
       expect(chain.hash_key).to be_nil
       expect(chain.range_key).to be_nil
@@ -546,7 +546,7 @@ describe Dynamoid::Criteria::Chain do
       it 'supports query on global secondary index but always defaults to table hash key' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(:name => 'Bob').count).to eq(1)
+        expect(chain.where(name: 'Bob').count).to eq(1)
         expect(chain.hash_key).to eq(:name)
         expect(chain.range_key).to be_nil
         expect(chain.index_name).to be_nil
@@ -555,7 +555,7 @@ describe Dynamoid::Criteria::Chain do
       it 'supports query on global secondary index' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(:city => 'San Francisco').count).to eq(3)
+        expect(chain.where(city: 'San Francisco').count).to eq(3)
         expect(chain.hash_key).to eq(:city)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:cityage)
@@ -569,7 +569,7 @@ describe Dynamoid::Criteria::Chain do
 
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(:email => 'greg@test.com').count).to eq(1)
+        expect(chain.where(email: 'greg@test.com').count).to eq(1)
         expect(chain.hash_key).to eq(:email)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:emailage)
@@ -585,7 +585,7 @@ describe Dynamoid::Criteria::Chain do
       it 'supports scan when no global secondary index available' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_scan).and_call_original
-        expect(chain.where(:gender => 'male').count).to eq(4)
+        expect(chain.where(gender: 'male').count).to eq(4)
         expect(chain.hash_key).to be_nil
         expect(chain.range_key).to be_nil
         expect(chain.index_name).to be_nil
@@ -594,7 +594,7 @@ describe Dynamoid::Criteria::Chain do
       it 'supports query on global secondary index with start' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(:city => 'San Francisco').count).to eq(3)
+        expect(chain.where(city: 'San Francisco').count).to eq(3)
         expect(chain.hash_key).to eq(:city)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:cityage)
@@ -602,7 +602,7 @@ describe Dynamoid::Criteria::Chain do
         # Now query with start at customer2 and we should only see customer3
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(:city => 'San Francisco').start(@customer2).all).to contain_exactly(@customer3)
+        expect(chain.where(city: 'San Francisco').start(@customer2).all).to contain_exactly(@customer3)
       end
     end
 
@@ -621,7 +621,7 @@ describe Dynamoid::Criteria::Chain do
 
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:records_via_query).and_call_original
-      expect(chain.where(:city => 'San Francisco').start(customer1).all).to contain_exactly(customer2)
+      expect(chain.where(city: 'San Francisco').start(customer1).all).to contain_exactly(customer2)
     end
   end
 
@@ -973,23 +973,23 @@ describe Dynamoid::Criteria::Chain do
     let(:chain) { described_class.new(User) }
 
     it 'defines each' do
-      chain.query = {:name => 'Josh'}
+      chain.query = {name: 'Josh'}
       chain.each {|u| u.update_attribute(:name, 'Justin')}
 
       expect(User.find(user.id).name).to eq 'Justin'
     end
 
     it 'includes Enumerable' do
-      chain.query = {:name => 'Josh'}
+      chain.query = {name: 'Josh'}
 
       expect(chain.collect {|u| u.name}).to eq ['Josh']
     end
   end
 
   describe 'Tweet' do
-    let!(:tweet1) { Tweet.create(:tweet_id => 'x', :group => 'one') }
-    let!(:tweet2) { Tweet.create(:tweet_id => 'x', :group => 'two') }
-    let!(:tweet3) { Tweet.create(:tweet_id => 'xx', :group => 'two') }
+    let!(:tweet1) { Tweet.create(tweet_id: 'x', group: 'one') }
+    let!(:tweet2) { Tweet.create(tweet_id: 'x', group: 'two') }
+    let!(:tweet3) { Tweet.create(tweet_id: 'xx', group: 'two') }
     let(:tweets) { [tweet1, tweet2, tweet3] }
     let(:chain) { Dynamoid::Criteria::Chain.new(Tweet) }
 
@@ -1000,22 +1000,22 @@ describe Dynamoid::Criteria::Chain do
     end
 
     it 'finds tweets with a start' do
-      chain.query = { :tweet_id => 'x' }
+      chain.query = { tweet_id: 'x' }
       chain.start(tweet1)
       expect(chain.count).to eq 1
       expect(chain.first).to eq tweet2
     end
 
     it 'finds one specific tweet' do
-      chain.query = { :tweet_id => 'xx', :group => 'two' }
+      chain.query = { tweet_id: 'xx', group: 'two' }
       expect(chain.all.to_a).to eq [tweet3]
     end
 
     it 'finds posts with "where" method with "gt" query' do
       ts_epsilon = 0.001 # 1 ms
       time = DateTime.now
-      post1 = Post.create(:post_id => 'x', :posted_at => time)
-      post2 = Post.create(:post_id => 'x', :posted_at => (time + 1.hour))
+      post1 = Post.create(post_id: 'x', posted_at: time)
+      post2 = Post.create(post_id: 'x', posted_at: (time + 1.hour))
       chain = Dynamoid::Criteria::Chain.new(Post)
       query = { :post_id => 'x', 'posted_at.gt' => (time + ts_epsilon) }
       resultset = chain.send(:where, query)
@@ -1031,8 +1031,8 @@ describe Dynamoid::Criteria::Chain do
     it 'finds posts with "where" method with "lt" query' do
       ts_epsilon = 0.001 # 1 ms
       time = DateTime.now
-      post1 = Post.create(:post_id => 'x', :posted_at => time)
-      post2 = Post.create(:post_id => 'x', :posted_at => (time + 1.hour))
+      post1 = Post.create(post_id: 'x', posted_at: time)
+      post2 = Post.create(post_id: 'x', posted_at: (time + 1.hour))
       chain = Dynamoid::Criteria::Chain.new(Post)
       query = { :post_id => 'x', 'posted_at.lt' => (time + 1.hour - ts_epsilon) }
       resultset = chain.send(:where, query)
@@ -1048,8 +1048,8 @@ describe Dynamoid::Criteria::Chain do
     it 'finds posts with "where" method with "between" query' do
       ts_epsilon = 0.001 # 1 ms
       time = DateTime.now
-      post1 = Post.create(:post_id => 'x', :posted_at => time)
-      post2 = Post.create(:post_id => 'x', :posted_at => (time + 1.hour))
+      post1 = Post.create(post_id: 'x', posted_at: time)
+      post2 = Post.create(post_id: 'x', posted_at: (time + 1.hour))
       chain = Dynamoid::Criteria::Chain.new(Post)
       query = { :post_id => 'x', 'posted_at.between' => [time - ts_epsilon, time + ts_epsilon]}
       resultset = chain.send(:where, query)

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -89,7 +89,6 @@ describe Dynamoid::Criteria do
     end.not_to raise_error(Dynamoid::Errors::InvalidQuery)
   end
 
-
   context 'when scans and warn_on_scan config option is true' do
     before do
       @warn_on_scan = Dynamoid::Config.warn_on_scan

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -1,11 +1,11 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Dynamoid::Criteria do
-  let!(:user1) {User.create(:name => 'Josh', :email => 'josh@joshsymonds.com', admin: true)}
-  let!(:user2) {User.create(:name => 'Justin', :email => 'justin@joshsymonds.com', admin: false)}
+  let!(:user1) {User.create(name: 'Josh', email: 'josh@joshsymonds.com', admin: true)}
+  let!(:user2) {User.create(name: 'Justin', email: 'justin@joshsymonds.com', admin: false)}
 
   it 'finds first using where' do
-    expect(User.where(:name => 'Josh').first).to eq user1
+    expect(User.where(name: 'Josh').first).to eq user1
   end
 
   it 'finds last using where' do
@@ -13,20 +13,20 @@ describe Dynamoid::Criteria do
   end
 
   it 'finds all using where' do
-    expect(User.where(:name => 'Josh').all.to_a).to eq [user1]
+    expect(User.where(name: 'Josh').all.to_a).to eq [user1]
   end
 
   context 'transforms booleans' do
     it 'accepts native' do
-      expect(User.where(:admin => 't').all.to_a).to eq [user1]
+      expect(User.where(admin: 't').all.to_a).to eq [user1]
     end
 
     it 'accepts string' do
-      expect(User.where(:admin => 'true').all.to_a).to eq [user1]
+      expect(User.where(admin: 'true').all.to_a).to eq [user1]
     end
 
     it 'accepts boolean' do
-      expect(User.where(:admin => true).all.to_a).to eq [user1]
+      expect(User.where(admin: true).all.to_a).to eq [user1]
     end
   end
 
@@ -57,7 +57,7 @@ describe Dynamoid::Criteria do
   end
 
   it 'returns N records' do
-    5.times { |i| User.create(:name => 'Josh', :email => 'josh_#{i}@joshsymonds.com') }
+    5.times { |i| User.create(name: 'Josh', email: 'josh_#{i}@joshsymonds.com') }
     expect(User.record_limit(2).all.count).to eq(2)
   end
 
@@ -74,18 +74,18 @@ describe Dynamoid::Criteria do
   it 'send consistent option to adapter' do
     pending 'This test is broken as we are overriding the consistent_read option to true inside the adapter'
     expect(Dynamoid::Adapter).to receive(:get_item) { |table_name, key, options| options[:consistent_read] == true }
-    User.where(:name => 'x').consistent.first
+    User.where(name: 'x').consistent.first
 
     expect(Dynamoid::Adapter).to receive(:query) { |table_name, options| options[:consistent_read] == true }.returns([])
-    Tweet.where(:tweet_id => 'xx', :group => 'two').consistent.all
+    Tweet.where(tweet_id: 'xx', group: 'two').consistent.all
 
     expect(Dynamoid::Adapter).to receive(:query) { |table_name, options| options[:consistent_read] == false }.returns([])
-    Tweet.where(:tweet_id => 'xx', :group => 'two').all
+    Tweet.where(tweet_id: 'xx', group: 'two').all
   end
 
   it 'does not raise exception when consistent_read is used with scan' do
     expect do
-      User.where(:password => 'password').consistent.first
+      User.where(password: 'password').consistent.first
     end.not_to raise_error(Dynamoid::Errors::InvalidQuery)
   end
 

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -16,7 +16,7 @@ describe Dynamoid::Criteria do
     expect(User.where(:name => 'Josh').all.to_a).to eq [user1]
   end
 
-  context "transforms booleans" do
+  context 'transforms booleans' do
     it 'accepts native' do
       expect(User.where(:admin => 't').all.to_a).to eq [user1]
     end
@@ -72,7 +72,7 @@ describe Dynamoid::Criteria do
   #end
 
   it 'send consistent option to adapter' do
-    pending "This test is broken as we are overriding the consistent_read option to true inside the adapter"
+    pending 'This test is broken as we are overriding the consistent_read option to true inside the adapter'
     expect(Dynamoid::Adapter).to receive(:get_item) { |table_name, key, options| options[:consistent_read] == true }
     User.where(:name => 'x').consistent.first
 

--- a/spec/dynamoid/dirty_spec.rb
+++ b/spec/dynamoid/dirty_spec.rb
@@ -9,14 +9,14 @@ describe Dynamoid::Dirty do
     end
 
     it 'is not empty' do
-      tweet = Tweet.new(:tweet_id => "1", :group => 'abc')
+      tweet = Tweet.new(:tweet_id => '1', :group => 'abc')
       expect(tweet).to be_changed
       expect(tweet.group_was).to be_nil
     end
 
     it 'is empty when loaded from database' do
-      Tweet.create!(:tweet_id => "1", :group => 'abc')
-      tweet = Tweet.where(:tweet_id => "1", :group => 'abc').first
+      Tweet.create!(:tweet_id => '1', :group => 'abc')
+      tweet = Tweet.where(:tweet_id => '1', :group => 'abc').first
       expect(tweet).to_not be_changed
       tweet.group = 'abc'
       tweet.reload
@@ -24,15 +24,15 @@ describe Dynamoid::Dirty do
     end
 
     it 'is empty after an update' do
-      tweet = Tweet.create!(:tweet_id => "1", :group => 'abc')
+      tweet = Tweet.create!(:tweet_id => '1', :group => 'abc')
       tweet.update! do |t|
-        t.set(msg: "foo")
+        t.set(msg: 'foo')
       end
       expect(tweet).to_not be_changed
     end
 
     it 'tracks changes after saves' do
-      tweet = Tweet.new(:tweet_id => "1", :group => 'abc')
+      tweet = Tweet.new(:tweet_id => '1', :group => 'abc')
       tweet.save!
       expect(tweet).to_not be_changed
 
@@ -47,7 +47,7 @@ describe Dynamoid::Dirty do
     end
 
     it 'clears changes on save' do
-      tweet = Tweet.new(:tweet_id => "1", :group => 'abc')
+      tweet = Tweet.new(:tweet_id => '1', :group => 'abc')
       tweet.group = 'xyz'
       expect(tweet.group_changed?).to be_truthy
       tweet.save!

--- a/spec/dynamoid/dirty_spec.rb
+++ b/spec/dynamoid/dirty_spec.rb
@@ -9,14 +9,14 @@ describe Dynamoid::Dirty do
     end
 
     it 'is not empty' do
-      tweet = Tweet.new(:tweet_id => '1', :group => 'abc')
+      tweet = Tweet.new(tweet_id: '1', group: 'abc')
       expect(tweet).to be_changed
       expect(tweet.group_was).to be_nil
     end
 
     it 'is empty when loaded from database' do
-      Tweet.create!(:tweet_id => '1', :group => 'abc')
-      tweet = Tweet.where(:tweet_id => '1', :group => 'abc').first
+      Tweet.create!(tweet_id: '1', group: 'abc')
+      tweet = Tweet.where(tweet_id: '1', group: 'abc').first
       expect(tweet).to_not be_changed
       tweet.group = 'abc'
       tweet.reload
@@ -24,7 +24,7 @@ describe Dynamoid::Dirty do
     end
 
     it 'is empty after an update' do
-      tweet = Tweet.create!(:tweet_id => '1', :group => 'abc')
+      tweet = Tweet.create!(tweet_id: '1', group: 'abc')
       tweet.update! do |t|
         t.set(msg: 'foo')
       end
@@ -32,7 +32,7 @@ describe Dynamoid::Dirty do
     end
 
     it 'tracks changes after saves' do
-      tweet = Tweet.new(:tweet_id => '1', :group => 'abc')
+      tweet = Tweet.new(tweet_id: '1', group: 'abc')
       tweet.save!
       expect(tweet).to_not be_changed
 
@@ -47,7 +47,7 @@ describe Dynamoid::Dirty do
     end
 
     it 'clears changes on save' do
-      tweet = Tweet.new(:tweet_id => '1', :group => 'abc')
+      tweet = Tweet.new(tweet_id: '1', group: 'abc')
       tweet.group = 'xyz'
       expect(tweet.group_changed?).to be_truthy
       tweet.save!

--- a/spec/dynamoid/dirty_spec.rb
+++ b/spec/dynamoid/dirty_spec.rb
@@ -22,7 +22,7 @@ describe Dynamoid::Dirty do
       tweet.reload
       expect(tweet).to_not be_changed
     end
-    
+
     it 'is empty after an update' do
       tweet = Tweet.create!(:tweet_id => "1", :group => 'abc')
       tweet.update! do |t|

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -66,7 +66,7 @@ describe Dynamoid::Document do
       field :city
       def city=(value); self[:city] = value.downcase; end
     end
-    expect(klass.new(:city => "Chicago").city).to eq "chicago"
+    expect(klass.new(:city => 'Chicago').city).to eq 'chicago'
   end
 
   it 'ignores unknown fields (does not raise error)' do
@@ -75,8 +75,8 @@ describe Dynamoid::Document do
       field :city
     end
 
-    model = klass.new(:unknown_field => "test", :city => "Chicago")
-    expect(model.city).to eql "Chicago"
+    model = klass.new(:unknown_field => 'test', :city => 'Chicago')
+    expect(model.city).to eql 'Chicago'
   end
 
   it 'creates a new document' do
@@ -112,9 +112,9 @@ describe Dynamoid::Document do
   it 'knows if a document exists or not' do
     address = Address.create(:city => 'Chicago')
     expect(Address.exists?(address.id)).to be_truthy
-    expect(Address.exists?("does-not-exist")).to be_falsey
+    expect(Address.exists?('does-not-exist')).to be_falsey
     expect(Address.exists?(:city => address.city)).to be_truthy
-    expect(Address.exists?(:city => "does-not-exist")).to be_falsey
+    expect(Address.exists?(:city => 'does-not-exist')).to be_falsey
   end
 
   it 'gets errors courtesy of ActiveModel' do
@@ -219,11 +219,11 @@ describe Dynamoid::Document do
   end
 
   context 'single table inheritance' do
-    it "should have a type" do
-      expect(Vehicle.new.type).to eq "Vehicle"
+    it 'should have a type' do
+      expect(Vehicle.new.type).to eq 'Vehicle'
     end
 
-    it "reports the same table name for both base and derived classes" do
+    it 'reports the same table name for both base and derived classes' do
       expect(Vehicle.table_name).to eq Car.table_name
       expect(Vehicle.table_name).to eq NuclearSubmarine.table_name
     end

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -27,7 +27,7 @@ describe Dynamoid::Document do
   end
 
   it 'initializes a new document with attributes' do
-    address = Address.new(:city => 'Chicago')
+    address = Address.new(city: 'Chicago')
 
     expect(address.new_record).to be_truthy
 
@@ -44,7 +44,7 @@ describe Dynamoid::Document do
   end
 
   it 'initializes a new document with a virtual attribute' do
-    address = Address.new(:zip_code => '12345')
+    address = Address.new(zip_code: '12345')
 
     expect(address.new_record).to be_truthy
 
@@ -66,7 +66,7 @@ describe Dynamoid::Document do
       field :city
       def city=(value); self[:city] = value.downcase; end
     end
-    expect(klass.new(:city => 'Chicago').city).to eq 'chicago'
+    expect(klass.new(city: 'Chicago').city).to eq 'chicago'
   end
 
   it 'ignores unknown fields (does not raise error)' do
@@ -75,12 +75,12 @@ describe Dynamoid::Document do
       field :city
     end
 
-    model = klass.new(:unknown_field => 'test', :city => 'Chicago')
+    model = klass.new(unknown_field: 'test', city: 'Chicago')
     expect(model.city).to eql 'Chicago'
   end
 
   it 'creates a new document' do
-    address = Address.create(:city => 'Chicago')
+    address = Address.create(city: 'Chicago')
 
     expect(address.new_record).to be_falsey
     expect(address.id).to_not be_nil
@@ -110,15 +110,15 @@ describe Dynamoid::Document do
   end
 
   it 'knows if a document exists or not' do
-    address = Address.create(:city => 'Chicago')
+    address = Address.create(city: 'Chicago')
     expect(Address.exists?(address.id)).to be_truthy
     expect(Address.exists?('does-not-exist')).to be_falsey
-    expect(Address.exists?(:city => address.city)).to be_truthy
-    expect(Address.exists?(:city => 'does-not-exist')).to be_falsey
+    expect(Address.exists?(city: address.city)).to be_truthy
+    expect(Address.exists?(city: 'does-not-exist')).to be_falsey
   end
 
   it 'gets errors courtesy of ActiveModel' do
-    address = Address.create(:city => 'Chicago')
+    address = Address.create(city: 'Chicago')
 
     expect(address.errors).to be_empty
     expect(address.errors.full_messages).to be_empty
@@ -126,16 +126,16 @@ describe Dynamoid::Document do
 
   context '.reload' do
     let(:address){ Address.create }
-    let(:message){ Message.create({:text => 'Nice, supporting datetime range!', :time => Time.now.to_datetime}) }
-    let(:tweet){ tweet = Tweet.create(:tweet_id => 'x', :group => 'abc') }
+    let(:message){ Message.create({text: 'Nice, supporting datetime range!', time: Time.now.to_datetime}) }
+    let(:tweet){ tweet = Tweet.create(tweet_id: 'x', group: 'abc') }
 
     it 'reflects persisted changes' do
-      address.update_attributes(:city => 'Chicago')
+      address.update_attributes(city: 'Chicago')
       expect(address.reload.city).to eq 'Chicago'
     end
 
     it 'uses a :consistent_read' do
-      expect(Tweet).to receive(:find).with(tweet.hash_key, {:range_key => tweet.range_value, :consistent_read => true}).and_return(tweet)
+      expect(Tweet).to receive(:find).with(tweet.hash_key, {range_key: tweet.range_value, consistent_read: true}).and_return(tweet)
       tweet.reload
     end
 
@@ -159,7 +159,7 @@ describe Dynamoid::Document do
   end
 
   it 'follows any table options provided to it' do
-    tweet = Tweet.create(:group => 12345)
+    tweet = Tweet.create(group: 12345)
 
     expect{tweet.id}.to raise_error(NoMethodError)
     expect(tweet.tweet_id).to_not be_nil
@@ -205,14 +205,14 @@ describe Dynamoid::Document do
 
   context 'with a range key' do
     it_behaves_like 'it has equality testing and hashing' do
-      let(:document){ Tweet.create(:tweet_id => 'x', :group => 'abc', :msg => 'foo') }
-      let(:different) { Tweet.create(:tweet_id => 'y', :group => 'abc', :msg => 'foo') }
-      let(:same) { Tweet.new(:tweet_id => 'x', :group => 'abc', :msg => 'bar') }
+      let(:document){ Tweet.create(tweet_id: 'x', group: 'abc', msg: 'foo') }
+      let(:different) { Tweet.create(tweet_id: 'y', group: 'abc', msg: 'foo') }
+      let(:same) { Tweet.new(tweet_id: 'x', group: 'abc', msg: 'bar') }
     end
 
     it 'is not equal to another document with the same hash key but a different range value' do
-      document = Tweet.create(:tweet_id => 'x', :group => 'abc')
-      different = Tweet.create(:tweet_id => 'x', :group => 'xyz')
+      document = Tweet.create(tweet_id: 'x', group: 'abc')
+      different = Tweet.create(tweet_id: 'x', group: 'xyz')
 
       expect(document).to_not eq different
     end
@@ -231,8 +231,8 @@ describe Dynamoid::Document do
 
   context '#count' do
     it 'returns the number of documents in the table' do
-      document = Tweet.create(:tweet_id => 'x', :group => 'abc')
-      different = Tweet.create(:tweet_id => 'x', :group => 'xyz')
+      document = Tweet.create(tweet_id: 'x', group: 'abc')
+      different = Tweet.create(tweet_id: 'x', group: 'xyz')
 
       expect(Tweet.count).to eq 2
     end

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -6,16 +6,16 @@ describe Dynamoid::Document do
     address = Address.new
 
     expect(address.new_record).to be_truthy
-    expect(address.attributes).to eq({id: nil,
-                                      created_at: nil,
-                                      updated_at: nil,
-                                      city: nil,
-                                      options: nil,
-                                      deliverable: nil,
-                                      latitude: nil,
-                                      config: nil,
-                                      registered_on: nil,
-                                      lock_version: nil})
+    expect(address.attributes).to eq(id: nil,
+                                     created_at: nil,
+                                     updated_at: nil,
+                                     city: nil,
+                                     options: nil,
+                                     deliverable: nil,
+                                     latitude: nil,
+                                     config: nil,
+                                     registered_on: nil,
+                                     lock_version: nil)
   end
 
   it 'responds to will_change! methods for all fields' do
@@ -31,16 +31,16 @@ describe Dynamoid::Document do
 
     expect(address.new_record).to be_truthy
 
-    expect(address.attributes).to eq({id: nil,
-                                      created_at: nil,
-                                      updated_at: nil,
-                                      city: 'Chicago',
-                                      options: nil,
-                                      deliverable: nil,
-                                      latitude: nil,
-                                      config: nil,
-                                      registered_on: nil,
-                                      lock_version: nil})
+    expect(address.attributes).to eq(id: nil,
+                                     created_at: nil,
+                                     updated_at: nil,
+                                     city: 'Chicago',
+                                     options: nil,
+                                     deliverable: nil,
+                                     latitude: nil,
+                                     config: nil,
+                                     registered_on: nil,
+                                     lock_version: nil)
   end
 
   it 'initializes a new document with a virtual attribute' do
@@ -48,16 +48,16 @@ describe Dynamoid::Document do
 
     expect(address.new_record).to be_truthy
 
-    expect(address.attributes).to eq({id: nil,
-                                      created_at: nil,
-                                      updated_at: nil,
-                                      city: 'Chicago',
-                                      options: nil,
-                                      deliverable: nil,
-                                      latitude: nil,
-                                      config: nil,
-                                      registered_on: nil,
-                                      lock_version: nil})
+    expect(address.attributes).to eq(id: nil,
+                                     created_at: nil,
+                                     updated_at: nil,
+                                     city: 'Chicago',
+                                     options: nil,
+                                     deliverable: nil,
+                                     latitude: nil,
+                                     config: nil,
+                                     registered_on: nil,
+                                     lock_version: nil)
   end
 
   it 'allows interception of write_attribute on load' do
@@ -126,7 +126,7 @@ describe Dynamoid::Document do
 
   context '.reload' do
     let(:address){ Address.create }
-    let(:message){ Message.create({text: 'Nice, supporting datetime range!', time: Time.now.to_datetime}) }
+    let(:message){ Message.create(text: 'Nice, supporting datetime range!', time: Time.now.to_datetime) }
     let(:tweet){ tweet = Tweet.create(tweet_id: 'x', group: 'abc') }
 
     it 'reflects persisted changes' do
@@ -135,7 +135,7 @@ describe Dynamoid::Document do
     end
 
     it 'uses a :consistent_read' do
-      expect(Tweet).to receive(:find).with(tweet.hash_key, {range_key: tweet.range_value, consistent_read: true}).and_return(tweet)
+      expect(Tweet).to receive(:find).with(tweet.hash_key, range_key: tweet.range_value, consistent_read: true).and_return(tweet)
       tweet.reload
     end
 
@@ -191,7 +191,7 @@ describe Dynamoid::Document do
     end
 
     it 'hashes documents with the keys to the same value' do
-      expect({document => 1}).to have_key(same)
+      expect(document => 1).to have_key(same)
     end
   end
 

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -169,9 +169,9 @@ describe Dynamoid::Fields do
     end
   end
 
-  it "raises an exception when items size exceeds 400kb" do
+  it 'raises an exception when items size exceeds 400kb' do
     expect {
-      Address.create(city: "Ten chars " * 500_000)
+      Address.create(city: 'Ten chars ' * 500_000)
     }.to raise_error(Aws::DynamoDB::Errors::ValidationException, 'Item size has exceeded the maximum allowed size')
   end
 
@@ -285,11 +285,11 @@ describe Dynamoid::Fields do
   end
 
   context 'single table inheritance' do
-    it "has only base class fields on the base class" do
+    it 'has only base class fields on the base class' do
       expect(Vehicle.attributes.keys.to_set).to eq Set.new([:type, :description, :created_at, :updated_at, :id])
     end
 
-    it "has only the base and derived fields on a sub-class" do
+    it 'has only the base and derived fields on a sub-class' do
       # Only NuclearSubmarines have torpedoes
       expect(Car.attributes).to_not have_key(:torpedoes)
     end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -156,16 +156,16 @@ describe Dynamoid::Fields do
     end
 
     it 'returns all attributes' do
-      expect(Address.attributes).to eq({id: {type: :string},
-                                        created_at: {type: :datetime},
-                                        updated_at: {type: :datetime},
-                                        city: {type: :string},
-                                        options: {type: :serialized},
-                                        deliverable: {type: :boolean},
-                                        latitude: {type: :number},
-                                        config: {type: :raw},
-                                        registered_on: {type: :date},
-                                        lock_version: {type: :integer}})
+      expect(Address.attributes).to eq(id: {type: :string},
+                                       created_at: {type: :datetime},
+                                       updated_at: {type: :datetime},
+                                       city: {type: :string},
+                                       options: {type: :serialized},
+                                       deliverable: {type: :boolean},
+                                       latitude: {type: :number},
+                                       config: {type: :raw},
+                                       registered_on: {type: :date},
+                                       lock_version: {type: :integer})
     end
   end
 

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -290,7 +290,7 @@ describe Dynamoid::Fields do
     end
 
     it "has only the base and derived fields on a sub-class" do
-      #Only NuclearSubmarines have torpedoes
+      # Only NuclearSubmarines have torpedoes
       expect(Car.attributes).to_not have_key(:torpedoes)
     end
   end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -95,7 +95,7 @@ describe Dynamoid::Fields do
 
     it 'should update all attributes' do
       expect(address).to receive(:save).once.and_return(true)
-      address.update_attributes(:city => 'Chicago')
+      address.update_attributes(city: 'Chicago')
       expect(address[:city]).to eq 'Chicago'
       expect(address.id).to eq original_id
     end
@@ -204,11 +204,11 @@ describe Dynamoid::Fields do
       Class.new do
         include Dynamoid::Document
 
-        field :name, :string, :default => 'x'
-        field :uid, :integer, :default => lambda { 42 }
+        field :name, :string, default: 'x'
+        field :uid, :integer, default: lambda { 42 }
         field :config, :serialized, default: {}
-        field :version, :integer, :default => 1
-        field :hidden, :boolean, :default => false
+        field :version, :integer, default: 1
+        field :hidden, :boolean, default: false
 
         def self.name
           'Document'

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Dynamoid::Finders do
-  let!(:address) { Address.create(:city => 'Chicago') }
+  let!(:address) { Address.create(city: 'Chicago') }
 
   it 'finds an existing address' do
     found = Address.find(address.id)
@@ -22,7 +22,7 @@ describe Dynamoid::Finders do
   end
 
   it 'finds multiple ids' do
-    address2 = Address.create(:city => 'Illinois')
+    address2 = Address.create(city: 'Illinois')
 
     expect(Set.new(Address.find(address.id, address2.id))).to eq Set.new([address, address2])
   end
@@ -69,7 +69,7 @@ describe Dynamoid::Finders do
     end
 
     it 'finds using method_missing for multiple attributes' do
-      user = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
+      user = User.create(name: 'Josh', email: 'josh@joshsymonds.com')
 
       array = User.find_all_by_name_and_email('Josh', 'josh@joshsymonds.com').to_a
 
@@ -77,8 +77,8 @@ describe Dynamoid::Finders do
     end
 
     it 'finds using method_missing for single attributes and multiple results' do
-      user1 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
-      user2 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
+      user1 = User.create(name: 'Josh', email: 'josh@joshsymonds.com')
+      user2 = User.create(name: 'Josh', email: 'josh@joshsymonds.com')
 
       array = User.find_all_by_name('Josh').to_a
 
@@ -88,8 +88,8 @@ describe Dynamoid::Finders do
     end
 
     it 'finds using method_missing for multiple attributes and multiple results' do
-      user1 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
-      user2 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
+      user1 = User.create(name: 'Josh', email: 'josh@joshsymonds.com')
+      user2 = User.create(name: 'Josh', email: 'josh@joshsymonds.com')
 
       array = User.find_all_by_name_and_email('Josh', 'josh@joshsymonds.com').to_a
 
@@ -99,8 +99,8 @@ describe Dynamoid::Finders do
     end
 
     it 'finds using method_missing for multiple attributes and no results' do
-      user1 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
-      user2 = User.create(:name => 'Justin', :email => 'justin@joshsymonds.com')
+      user1 = User.create(name: 'Josh', email: 'josh@joshsymonds.com')
+      user2 = User.create(name: 'Justin', email: 'justin@joshsymonds.com')
 
       array = User.find_all_by_name_and_email('Gaga', 'josh@joshsymonds.com').to_a
 
@@ -108,8 +108,8 @@ describe Dynamoid::Finders do
     end
 
     it 'finds using method_missing for a single attribute and no results' do
-      user1 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
-      user2 = User.create(:name => 'Justin', :email => 'justin@joshsymonds.com')
+      user1 = User.create(name: 'Josh', email: 'josh@joshsymonds.com')
+      user2 = User.create(name: 'Justin', email: 'justin@joshsymonds.com')
 
       array = User.find_all_by_name('Gaga').to_a
 
@@ -117,7 +117,7 @@ describe Dynamoid::Finders do
     end
 
     it 'should find on a query that is not indexed' do
-      user = User.create(:password => 'Test')
+      user = User.create(password: 'Test')
 
       array = User.find_all_by_password('Test').to_a
 
@@ -125,7 +125,7 @@ describe Dynamoid::Finders do
     end
 
     it 'should find on a query on multiple attributes that are not indexed' do
-      user = User.create(:password => 'Test', :name => 'Josh')
+      user = User.create(password: 'Test', name: 'Josh')
 
       array = User.find_all_by_password_and_name('Test', 'Josh').to_a
 
@@ -149,7 +149,7 @@ describe Dynamoid::Finders do
     end
 
     it 'should return a array of tweets' do
-      tweets = (1..10).map { |i| Tweet.create(:tweet_id => "#{i}", :group => "group_#{i}") }
+      tweets = (1..10).map { |i| Tweet.create(tweet_id: "#{i}", group: "group_#{i}") }
       expect(Tweet.find_all(tweets.map { |t| [t.tweet_id, t.group] })).to match_array(tweets)
     end
 
@@ -164,8 +164,8 @@ describe Dynamoid::Finders do
     it 'passes options to the adapter' do
       pending 'This test is broken as we are overriding the consistent_read option to true inside the adapter'
       user_ids = [%w(1 red), %w(1 green)]
-      Dynamoid.adapter.expects(:read).with(anything, user_ids, :consistent_read => true)
-      User.find_all(user_ids, :consistent_read => true)
+      Dynamoid.adapter.expects(:read).with(anything, user_ids, consistent_read: true)
+      User.find_all(user_ids, consistent_read: true)
     end
 
   end
@@ -176,22 +176,22 @@ describe Dynamoid::Finders do
     end
 
     it 'returns exception if index could not be found' do
-      Post.create(:post_id => 1, :posted_at => Time.now)
+      Post.create(post_id: 1, posted_at: Time.now)
       expect do
-        Post.find_all_by_secondary_index(:posted_at => Time.now.to_i)
+        Post.find_all_by_secondary_index(posted_at: Time.now.to_i)
       end.to raise_exception(Dynamoid::Errors::MissingIndex)
     end
 
     context 'local secondary index' do
       it 'queries the local secondary index' do
         time = DateTime.now
-        p1 = Post.create(:name => 'p1', :post_id => 1, :posted_at => time)
-        p2 = Post.create(:name => 'p2', :post_id => 1, :posted_at => time + 1.day)
-        p3 = Post.create(:name => 'p3', :post_id => 2, :posted_at => time)
+        p1 = Post.create(name: 'p1', post_id: 1, posted_at: time)
+        p2 = Post.create(name: 'p2', post_id: 1, posted_at: time + 1.day)
+        p3 = Post.create(name: 'p3', post_id: 2, posted_at: time)
 
         posts = Post.find_all_by_secondary_index(
-          {:post_id => p1.post_id},
-          :range => {:name => 'p1'}
+          {post_id: p1.post_id},
+          range: {name: 'p1'}
         )
         post = posts.first
 
@@ -204,12 +204,12 @@ describe Dynamoid::Finders do
     context 'global secondary index' do
       it 'can sort' do
         time = DateTime.now
-        first_visit = Bar.create(:name => 'Drank', :visited_at => (time - 1.day).to_i)
-        Bar.create(:name => 'Drank', :visited_at => time.to_i)
-        last_visit = Bar.create(:name => 'Drank', :visited_at => (time + 1.day).to_i)
+        first_visit = Bar.create(name: 'Drank', visited_at: (time - 1.day).to_i)
+        Bar.create(name: 'Drank', visited_at: time.to_i)
+        last_visit = Bar.create(name: 'Drank', visited_at: (time + 1.day).to_i)
 
         bars = Bar.find_all_by_secondary_index(
-            {:name => 'Drank'}, :range => {'visited_at.lte' => (time + 10.days).to_i}
+            {name: 'Drank'}, range: {'visited_at.lte' => (time + 10.days).to_i}
         )
         first_bar = bars.first
         last_bar = bars.last
@@ -221,13 +221,13 @@ describe Dynamoid::Finders do
       end
       it 'honors :scan_index_forward => false' do
         time = DateTime.now
-        first_visit = Bar.create(:name => 'Drank', :visited_at => time - 1.day)
-        Bar.create(:name => 'Drank', :visited_at => time)
-        last_visit = Bar.create(:name => 'Drank', :visited_at => time + 1.day)
-        different_bar = Bar.create(:name => 'Junk', :visited_at => time + 7.days)
+        first_visit = Bar.create(name: 'Drank', visited_at: time - 1.day)
+        Bar.create(name: 'Drank', visited_at: time)
+        last_visit = Bar.create(name: 'Drank', visited_at: time + 1.day)
+        different_bar = Bar.create(name: 'Junk', visited_at: time + 7.days)
         bars = Bar.find_all_by_secondary_index(
-            {:name => 'Drank'}, :range => {'visited_at.lte' => (time + 10.days).to_i},
-            :scan_index_forward => false
+            {name: 'Drank'}, range: {'visited_at.lte' => (time + 10.days).to_i},
+            scan_index_forward: false
         )
         first_bar = bars.first
         last_bar = bars.last
@@ -239,23 +239,23 @@ describe Dynamoid::Finders do
       end
       it 'queries gsi with hash key' do
         time = DateTime.now
-        p1 = Post.create(:post_id => 1, :posted_at => time, :length => '10')
-        p2 = Post.create(:post_id => 2, :posted_at => time, :length => '30')
-        p3 = Post.create(:post_id => 3, :posted_at => time, :length => '10')
+        p1 = Post.create(post_id: 1, posted_at: time, length: '10')
+        p2 = Post.create(post_id: 2, posted_at: time, length: '30')
+        p3 = Post.create(post_id: 3, posted_at: time, length: '10')
 
-        posts = Post.find_all_by_secondary_index(:length => '10')
+        posts = Post.find_all_by_secondary_index(length: '10')
         expect(posts.map(&:post_id).sort).to eql ['1', '3']
       end
 
       it 'queries gsi with hash and range key' do
         time = DateTime.now
-        p1 = Post.create(:post_id => 1, :posted_at => time, :name => 'post1')
-        p2 = Post.create(:post_id => 2, :posted_at => time + 1.day, :name => 'post1')
-        p3 = Post.create(:post_id => 3, :posted_at => time, :name => 'post3')
+        p1 = Post.create(post_id: 1, posted_at: time, name: 'post1')
+        p2 = Post.create(post_id: 2, posted_at: time + 1.day, name: 'post1')
+        p3 = Post.create(post_id: 3, posted_at: time, name: 'post3')
 
         posts = Post.find_all_by_secondary_index(
-          {:name => 'post1'},
-          :range =>  {:posted_at => time_to_f(time)}
+          {name: 'post1'},
+          range: {posted_at: time_to_f(time)}
         )
         expect(posts.map(&:post_id).sort).to eql ['1']
       end
@@ -265,11 +265,11 @@ describe Dynamoid::Finders do
       describe 'string comparisons' do
         it 'filters based on begins_with operator' do
           time = DateTime.now
-          Post.create(:post_id => 1, :posted_at => time, :name => 'fb_post')
-          Post.create(:post_id => 1, :posted_at => time + 1.day, :name => 'blog_post')
+          Post.create(post_id: 1, posted_at: time, name: 'fb_post')
+          Post.create(post_id: 1, posted_at: time + 1.day, name: 'blog_post')
 
           posts = Post.find_all_by_secondary_index(
-            {:post_id => '1'}, :range => {'name.begins_with' => 'blog_'}
+            {post_id: '1'}, range: {'name.begins_with' => 'blog_'}
           )
           expect(posts.map(&:name)).to eql ['blog_post']
         end
@@ -278,39 +278,39 @@ describe Dynamoid::Finders do
       describe 'numeric comparisons' do
         before(:each) do
           @time = DateTime.now
-          p1 = Post.create(:post_id => 1, :posted_at => @time, :name => 'post')
-          p2 = Post.create(:post_id => 2, :posted_at => @time + 1.day, :name => 'post')
-          p3 = Post.create(:post_id => 3, :posted_at => @time + 2.days, :name => 'post')
+          p1 = Post.create(post_id: 1, posted_at: @time, name: 'post')
+          p2 = Post.create(post_id: 2, posted_at: @time + 1.day, name: 'post')
+          p3 = Post.create(post_id: 3, posted_at: @time + 2.days, name: 'post')
         end
 
         it 'filters based on gt (greater than)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => 'post'},
-            :range => {'posted_at.gt' => time_to_f(@time + 1.day)}
+            {name: 'post'},
+            range: {'posted_at.gt' => time_to_f(@time + 1.day)}
           )
           expect(posts.map(&:post_id).sort).to eql ['3']
         end
 
         it 'filters based on lt (less than)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => 'post'},
-            :range => {'posted_at.lt' => time_to_f(@time + 1.day)}
+            {name: 'post'},
+            range: {'posted_at.lt' => time_to_f(@time + 1.day)}
           )
           expect(posts.map(&:post_id).sort).to eql ['1']
         end
 
         it 'filters based on gte (greater than or equal to)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => 'post'},
-            :range => {'posted_at.gte' => time_to_f(@time + 1.day)}
+            {name: 'post'},
+            range: {'posted_at.gte' => time_to_f(@time + 1.day)}
           )
           expect(posts.map(&:post_id).sort).to eql ['2', '3']
         end
 
         it 'filters based on lte (less than or equal to)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => 'post'},
-            :range => {'posted_at.lte' => time_to_f(@time + 1.day)}
+            {name: 'post'},
+            range: {'posted_at.lte' => time_to_f(@time + 1.day)}
           )
           expect(posts.map(&:post_id).sort).to eql ['1', '2']
         end
@@ -318,8 +318,8 @@ describe Dynamoid::Finders do
         it 'filters based on between operator' do
           between = [time_to_f(@time - 1.day), time_to_f(@time + 1.5.day)]
           posts = Post.find_all_by_secondary_index(
-            {:name => 'post'},
-            :range => {'posted_at.between' => between}
+            {name: 'post'},
+            range: {'posted_at.between' => between}
           )
           expect(posts.map(&:post_id).sort).to eql ['1', '2']
         end

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -33,7 +33,7 @@ describe Dynamoid::Finders do
     expect { Address.find(a1.id, a2.id, 'fake-id') }.to raise_error(
       Dynamoid::Errors::RecordNotFound,
       "Couldn't find all Addresses with 'id': (#{a1.id}, #{a2.id}, fake-id) " +
-      "(found 2 results, but was looking for 3)")
+      '(found 2 results, but was looking for 3)')
   end
 
   it 'returns array if passed in array' do
@@ -45,13 +45,13 @@ describe Dynamoid::Finders do
   end
 
   it 'raises error if non-array id is passed in and no result found' do
-    expect { Address.find("not-existing-id") }.to raise_error(
+    expect { Address.find('not-existing-id') }.to raise_error(
       Dynamoid::Errors::RecordNotFound,
       "Couldn't find Address with 'id'=not-existing-id")
   end
 
   it 'raises error if array of ids is passed in and no result found' do
-    expect { Address.find(["not-existing-id"]) }.to raise_error(
+    expect { Address.find(['not-existing-id']) }.to raise_error(
       Dynamoid::Errors::RecordNotFound, "Couldn't find Address with 'id'=not-existing-id")
   end
 
@@ -162,7 +162,7 @@ describe Dynamoid::Finders do
     end
 
     it 'passes options to the adapter' do
-      pending "This test is broken as we are overriding the consistent_read option to true inside the adapter"
+      pending 'This test is broken as we are overriding the consistent_read option to true inside the adapter'
       user_ids = [%w(1 red), %w(1 green)]
       Dynamoid.adapter.expects(:read).with(anything, user_ids, :consistent_read => true)
       User.find_all(user_ids, :consistent_read => true)
@@ -185,31 +185,31 @@ describe Dynamoid::Finders do
     context 'local secondary index' do
       it 'queries the local secondary index' do
         time = DateTime.now
-        p1 = Post.create(:name => "p1", :post_id => 1, :posted_at => time)
-        p2 = Post.create(:name => "p2", :post_id => 1, :posted_at => time + 1.day)
-        p3 = Post.create(:name => "p3", :post_id => 2, :posted_at => time)
+        p1 = Post.create(:name => 'p1', :post_id => 1, :posted_at => time)
+        p2 = Post.create(:name => 'p2', :post_id => 1, :posted_at => time + 1.day)
+        p3 = Post.create(:name => 'p3', :post_id => 2, :posted_at => time)
 
         posts = Post.find_all_by_secondary_index(
           {:post_id => p1.post_id},
-          :range => {:name => "p1"}
+          :range => {:name => 'p1'}
         )
         post = posts.first
 
         expect(posts.count).to eql 1
-        expect(post.name).to eql "p1"
-        expect(post.post_id).to eql "1"
+        expect(post.name).to eql 'p1'
+        expect(post.post_id).to eql '1'
       end
     end
 
     context 'global secondary index' do
       it 'can sort' do
         time = DateTime.now
-        first_visit = Bar.create(:name => "Drank", :visited_at => (time - 1.day).to_i)
-        Bar.create(:name => "Drank", :visited_at => time.to_i)
-        last_visit = Bar.create(:name => "Drank", :visited_at => (time + 1.day).to_i)
+        first_visit = Bar.create(:name => 'Drank', :visited_at => (time - 1.day).to_i)
+        Bar.create(:name => 'Drank', :visited_at => time.to_i)
+        last_visit = Bar.create(:name => 'Drank', :visited_at => (time + 1.day).to_i)
 
         bars = Bar.find_all_by_secondary_index(
-            {:name => "Drank"}, :range => {"visited_at.lte" => (time + 10.days).to_i}
+            {:name => 'Drank'}, :range => {'visited_at.lte' => (time + 10.days).to_i}
         )
         first_bar = bars.first
         last_bar = bars.last
@@ -221,12 +221,12 @@ describe Dynamoid::Finders do
       end
       it 'honors :scan_index_forward => false' do
         time = DateTime.now
-        first_visit = Bar.create(:name => "Drank", :visited_at => time - 1.day)
-        Bar.create(:name => "Drank", :visited_at => time)
-        last_visit = Bar.create(:name => "Drank", :visited_at => time + 1.day)
-        different_bar = Bar.create(:name => "Junk", :visited_at => time + 7.days)
+        first_visit = Bar.create(:name => 'Drank', :visited_at => time - 1.day)
+        Bar.create(:name => 'Drank', :visited_at => time)
+        last_visit = Bar.create(:name => 'Drank', :visited_at => time + 1.day)
+        different_bar = Bar.create(:name => 'Junk', :visited_at => time + 7.days)
         bars = Bar.find_all_by_secondary_index(
-            {:name => "Drank"}, :range => {"visited_at.lte" => (time + 10.days).to_i},
+            {:name => 'Drank'}, :range => {'visited_at.lte' => (time + 10.days).to_i},
             :scan_index_forward => false
         )
         first_bar = bars.first
@@ -239,25 +239,25 @@ describe Dynamoid::Finders do
       end
       it 'queries gsi with hash key' do
         time = DateTime.now
-        p1 = Post.create(:post_id => 1, :posted_at => time, :length => "10")
-        p2 = Post.create(:post_id => 2, :posted_at => time, :length => "30")
-        p3 = Post.create(:post_id => 3, :posted_at => time, :length => "10")
+        p1 = Post.create(:post_id => 1, :posted_at => time, :length => '10')
+        p2 = Post.create(:post_id => 2, :posted_at => time, :length => '30')
+        p3 = Post.create(:post_id => 3, :posted_at => time, :length => '10')
 
-        posts = Post.find_all_by_secondary_index(:length => "10")
-        expect(posts.map(&:post_id).sort).to eql ["1", "3"]
+        posts = Post.find_all_by_secondary_index(:length => '10')
+        expect(posts.map(&:post_id).sort).to eql ['1', '3']
       end
 
       it 'queries gsi with hash and range key' do
         time = DateTime.now
-        p1 = Post.create(:post_id => 1, :posted_at => time, :name => "post1")
-        p2 = Post.create(:post_id => 2, :posted_at => time + 1.day, :name => "post1")
-        p3 = Post.create(:post_id => 3, :posted_at => time, :name => "post3")
+        p1 = Post.create(:post_id => 1, :posted_at => time, :name => 'post1')
+        p2 = Post.create(:post_id => 2, :posted_at => time + 1.day, :name => 'post1')
+        p3 = Post.create(:post_id => 3, :posted_at => time, :name => 'post3')
 
         posts = Post.find_all_by_secondary_index(
-          {:name => "post1"},
+          {:name => 'post1'},
           :range =>  {:posted_at => time_to_f(time)}
         )
-        expect(posts.map(&:post_id).sort).to eql ["1"]
+        expect(posts.map(&:post_id).sort).to eql ['1']
       end
     end
 
@@ -265,63 +265,63 @@ describe Dynamoid::Finders do
       describe 'string comparisons' do
         it 'filters based on begins_with operator' do
           time = DateTime.now
-          Post.create(:post_id => 1, :posted_at => time, :name => "fb_post")
-          Post.create(:post_id => 1, :posted_at => time + 1.day, :name => "blog_post")
+          Post.create(:post_id => 1, :posted_at => time, :name => 'fb_post')
+          Post.create(:post_id => 1, :posted_at => time + 1.day, :name => 'blog_post')
 
           posts = Post.find_all_by_secondary_index(
-            {:post_id => "1"}, :range => {"name.begins_with" => "blog_"}
+            {:post_id => '1'}, :range => {'name.begins_with' => 'blog_'}
           )
-          expect(posts.map(&:name)).to eql ["blog_post"]
+          expect(posts.map(&:name)).to eql ['blog_post']
         end
       end
 
       describe 'numeric comparisons' do
         before(:each) do
           @time = DateTime.now
-          p1 = Post.create(:post_id => 1, :posted_at => @time, :name => "post")
-          p2 = Post.create(:post_id => 2, :posted_at => @time + 1.day, :name => "post")
-          p3 = Post.create(:post_id => 3, :posted_at => @time + 2.days, :name => "post")
+          p1 = Post.create(:post_id => 1, :posted_at => @time, :name => 'post')
+          p2 = Post.create(:post_id => 2, :posted_at => @time + 1.day, :name => 'post')
+          p3 = Post.create(:post_id => 3, :posted_at => @time + 2.days, :name => 'post')
         end
 
         it 'filters based on gt (greater than)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => "post"},
-            :range => {"posted_at.gt" => time_to_f(@time + 1.day)}
+            {:name => 'post'},
+            :range => {'posted_at.gt' => time_to_f(@time + 1.day)}
           )
-          expect(posts.map(&:post_id).sort).to eql ["3"]
+          expect(posts.map(&:post_id).sort).to eql ['3']
         end
 
         it 'filters based on lt (less than)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => "post"},
-            :range => {"posted_at.lt" => time_to_f(@time + 1.day)}
+            {:name => 'post'},
+            :range => {'posted_at.lt' => time_to_f(@time + 1.day)}
           )
-          expect(posts.map(&:post_id).sort).to eql ["1"]
+          expect(posts.map(&:post_id).sort).to eql ['1']
         end
 
         it 'filters based on gte (greater than or equal to)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => "post"},
-            :range => {"posted_at.gte" => time_to_f(@time + 1.day)}
+            {:name => 'post'},
+            :range => {'posted_at.gte' => time_to_f(@time + 1.day)}
           )
-          expect(posts.map(&:post_id).sort).to eql ["2", "3"]
+          expect(posts.map(&:post_id).sort).to eql ['2', '3']
         end
 
         it 'filters based on lte (less than or equal to)' do
           posts = Post.find_all_by_secondary_index(
-            {:name => "post"},
-            :range => {"posted_at.lte" => time_to_f(@time + 1.day)}
+            {:name => 'post'},
+            :range => {'posted_at.lte' => time_to_f(@time + 1.day)}
           )
-          expect(posts.map(&:post_id).sort).to eql ["1", "2"]
+          expect(posts.map(&:post_id).sort).to eql ['1', '2']
         end
 
         it 'filters based on between operator' do
           between = [time_to_f(@time - 1.day), time_to_f(@time + 1.5.day)]
           posts = Post.find_all_by_secondary_index(
-            {:name => "post"},
-            :range => {"posted_at.between" => between}
+            {:name => 'post'},
+            :range => {'posted_at.between' => between}
           )
-          expect(posts.map(&:post_id).sort).to eql ["1", "2"]
+          expect(posts.map(&:post_id).sort).to eql ['1', '2']
         end
       end
     end

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -170,7 +170,6 @@ describe Dynamoid::Finders do
 
   end
 
-
   describe '.find_all_by_secondary_index' do
     def time_to_f(time)
       time.to_time.to_f

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -102,7 +102,7 @@ describe Dynamoid::Finders do
       user1 = User.create(:name => 'Josh', :email => 'josh@joshsymonds.com')
       user2 = User.create(:name => 'Justin', :email => 'justin@joshsymonds.com')
 
-      array = User.find_all_by_name_and_email('Gaga','josh@joshsymonds.com').to_a
+      array = User.find_all_by_name_and_email('Gaga', 'josh@joshsymonds.com').to_a
 
       expect(array).to be_empty
     end

--- a/spec/dynamoid/identity_map_spec.rb
+++ b/spec/dynamoid/identity_map_spec.rb
@@ -11,31 +11,31 @@ describe Dynamoid::IdentityMap do
 
   context 'object identity' do
     it 'maintains a single object' do
-      tweet = Tweet.create(:tweet_id => "x", :group => "one")
-      tweet1 = Tweet.where(:tweet_id => "x", :group => "one").first
+      tweet = Tweet.create(:tweet_id => 'x', :group => 'one')
+      tweet1 = Tweet.where(:tweet_id => 'x', :group => 'one').first
       expect(tweet).to equal(tweet1)
     end
   end
 
   context 'cache' do
     it 'uses cache' do
-      tweet = Tweet.create(:tweet_id => "x", :group => "one")
+      tweet = Tweet.create(:tweet_id => 'x', :group => 'one')
       expect(Dynamoid::Adapter).to receive(:read).never
-      tweet1 = Tweet.find_by_id("x", :range_key => "one")
+      tweet1 = Tweet.find_by_id('x', :range_key => 'one')
       expect(tweet).to equal(tweet1)
     end
 
     it 'clears cache on delete' do
-      tweet = Tweet.create(:tweet_id => "x", :group => "one")
+      tweet = Tweet.create(:tweet_id => 'x', :group => 'one')
       tweet.delete
-      expect(Tweet.find_by_id("x", :range_key => "one")).to be_nil
+      expect(Tweet.find_by_id('x', :range_key => 'one')).to be_nil
     end
   end
 
   context 'clear' do
     it 'clears the identiy map' do
-      Tweet.create(:tweet_id => "x", :group => "one")
-      Tweet.create(:tweet_id => "x", :group => "two")
+      Tweet.create(:tweet_id => 'x', :group => 'one')
+      Tweet.create(:tweet_id => 'x', :group => 'two')
 
       expect(Tweet.identity_map.size).to eq(2)
       Dynamoid::IdentityMap.clear

--- a/spec/dynamoid/identity_map_spec.rb
+++ b/spec/dynamoid/identity_map_spec.rb
@@ -11,31 +11,31 @@ describe Dynamoid::IdentityMap do
 
   context 'object identity' do
     it 'maintains a single object' do
-      tweet = Tweet.create(:tweet_id => 'x', :group => 'one')
-      tweet1 = Tweet.where(:tweet_id => 'x', :group => 'one').first
+      tweet = Tweet.create(tweet_id: 'x', group: 'one')
+      tweet1 = Tweet.where(tweet_id: 'x', group: 'one').first
       expect(tweet).to equal(tweet1)
     end
   end
 
   context 'cache' do
     it 'uses cache' do
-      tweet = Tweet.create(:tweet_id => 'x', :group => 'one')
+      tweet = Tweet.create(tweet_id: 'x', group: 'one')
       expect(Dynamoid::Adapter).to receive(:read).never
-      tweet1 = Tweet.find_by_id('x', :range_key => 'one')
+      tweet1 = Tweet.find_by_id('x', range_key: 'one')
       expect(tweet).to equal(tweet1)
     end
 
     it 'clears cache on delete' do
-      tweet = Tweet.create(:tweet_id => 'x', :group => 'one')
+      tweet = Tweet.create(tweet_id: 'x', group: 'one')
       tweet.delete
-      expect(Tweet.find_by_id('x', :range_key => 'one')).to be_nil
+      expect(Tweet.find_by_id('x', range_key: 'one')).to be_nil
     end
   end
 
   context 'clear' do
     it 'clears the identiy map' do
-      Tweet.create(:tweet_id => 'x', :group => 'one')
-      Tweet.create(:tweet_id => 'x', :group => 'two')
+      Tweet.create(tweet_id: 'x', group: 'one')
+      Tweet.create(tweet_id: 'x', group: 'two')
 
       expect(Tweet.identity_map.size).to eq(2)
       Dynamoid::IdentityMap.clear

--- a/spec/dynamoid/indexes_spec.rb
+++ b/spec/dynamoid/indexes_spec.rb
@@ -62,7 +62,7 @@ describe Dynamoid::Indexes do
 
           it 'adds the index to the global_secondary_indexes hash' do
             test_class = doc_class_with_gsi
-            index_key = "secondary_hash_field"
+            index_key = 'secondary_hash_field'
             expect(test_class.global_secondary_indexes.keys).to eql [index_key]
             expect(test_class.global_secondary_indexes[index_key]).to eq(@dummy_index)
           end
@@ -91,7 +91,7 @@ describe Dynamoid::Indexes do
 
           it 'adds the index to the global_secondary_indexes hash' do
             test_class = doc_class_with_gsi
-            index_key = "secondary_hash_field_secondary_range_field"
+            index_key = 'secondary_hash_field_secondary_range_field'
             expect(test_class.global_secondary_indexes[index_key]).to eq(@dummy_index)
           end
         end
@@ -142,7 +142,7 @@ describe Dynamoid::Indexes do
       end
       it 'adds the index to the local_secondary_indexes hash' do
         test_class = doc_class_with_lsi
-        index_key = "some_hash_field_secondary_range_field"
+        index_key = 'some_hash_field_secondary_range_field'
         expect(test_class.local_secondary_indexes.keys).to eql [index_key]
         expect(test_class.local_secondary_indexes[index_key]).to eq(@dummy_index)
       end
@@ -183,19 +183,19 @@ describe Dynamoid::Indexes do
     context 'when hash specified' do
       it 'generates an index key of the form <hash> if only hash is specified' do
         index_key = doc_class.index_key(:some_hash_field)
-        expect(index_key).to eq("some_hash_field")
+        expect(index_key).to eq('some_hash_field')
       end
     end
 
     context 'when hash and range specified' do
       it 'generates an index key of the form <hash>_<range>' do
         index_key = doc_class.index_key(:some_hash_field, :some_range_field)
-        expect(index_key).to eq("some_hash_field_some_range_field")
+        expect(index_key).to eq('some_hash_field_some_range_field')
       end
 
       it 'generates an index key of the form <hash> when range is nil' do
         index_key = doc_class.index_key(:some_hash_field, nil)
-        expect(index_key).to eq("some_hash_field")
+        expect(index_key).to eq('some_hash_field')
       end
     end
   end

--- a/spec/dynamoid/indexes_spec.rb
+++ b/spec/dynamoid/indexes_spec.rb
@@ -124,7 +124,7 @@ describe Dynamoid::Indexes do
         Class.new do
           include Dynamoid::Document
           table :name => :mytable, :key => :some_hash_field
-          range :some_range_field #@WHAT
+          range :some_range_field # @WHAT
 
           local_secondary_index(:range_key => :secondary_range_field)
         end

--- a/spec/dynamoid/indexes_spec.rb
+++ b/spec/dynamoid/indexes_spec.rb
@@ -215,7 +215,6 @@ describe Dynamoid::Indexes do
     end
   end
 
-
   # Index nested class.
   describe 'Index' do
     describe '#initialize' do
@@ -298,7 +297,6 @@ describe Dynamoid::Indexes do
         end
       end
 
-
       context 'correct parameters' do
         context 'with only required params' do
           let(:defaults_index) do
@@ -367,7 +365,6 @@ describe Dynamoid::Indexes do
 
       end
     end
-
 
     describe '#projection_type' do
       let(:doc_class) do

--- a/spec/dynamoid/indexes_spec.rb
+++ b/spec/dynamoid/indexes_spec.rb
@@ -25,7 +25,7 @@ describe Dynamoid::Indexes do
 
       it 'adds the index to the global_secondary_indexes hash' do
         index_key = doc_class.index_key(:some_hash_field)
-        doc_class.global_secondary_index(:hash_key => :some_hash_field)
+        doc_class.global_secondary_index(hash_key: :some_hash_field)
 
         expected_index = doc_class.global_secondary_indexes[index_key]
         expect(expected_index).to eq(@dummy_index)
@@ -34,8 +34,8 @@ describe Dynamoid::Indexes do
       it 'with a range key, also adds the index to the global_secondary_indexes hash' do
         index_key = doc_class.index_key(:some_hash_field, :some_range_field)
         doc_class.global_secondary_index({
-          :hash_key => :some_hash_field,
-          :range_key => :some_range_field
+          hash_key: :some_hash_field,
+          range_key: :some_range_field
         })
 
         expected_index = doc_class.global_secondary_indexes[index_key]
@@ -45,17 +45,17 @@ describe Dynamoid::Indexes do
       context 'with optional parameters' do
         context 'with a hash-only index' do
           let(:doc_class_with_gsi) do
-            doc_class.global_secondary_index(:hash_key => :secondary_hash_field)
+            doc_class.global_secondary_index(hash_key: :secondary_hash_field)
           end
 
           it 'creates the index with the correct options' do
             test_class = doc_class_with_gsi
             index_opts = {
-              :dynamoid_class => test_class,
-              :type => :global_secondary,
-              :read_capacity => Dynamoid::Config.read_capacity,
-              :write_capacity => Dynamoid::Config.write_capacity,
-              :hash_key => :secondary_hash_field
+              dynamoid_class: test_class,
+              type: :global_secondary,
+              read_capacity: Dynamoid::Config.read_capacity,
+              write_capacity: Dynamoid::Config.write_capacity,
+              hash_key: :secondary_hash_field
             }
             expect(Dynamoid::Indexes::Index).to have_received(:new).with(index_opts)
           end
@@ -71,20 +71,20 @@ describe Dynamoid::Indexes do
         context 'with a hash and range index' do
           let(:doc_class_with_gsi) do
             doc_class.global_secondary_index({
-              :hash_key => :secondary_hash_field,
-              :range_key => :secondary_range_field
+              hash_key: :secondary_hash_field,
+              range_key: :secondary_range_field
             })
           end
 
           it 'creates the index with the correct options' do
             test_class = doc_class_with_gsi
             index_opts = {
-              :dynamoid_class => test_class,
-              :type => :global_secondary,
-              :read_capacity => Dynamoid::Config.read_capacity,
-              :write_capacity => Dynamoid::Config.write_capacity,
-              :hash_key => :secondary_hash_field,
-              :range_key => :secondary_range_field
+              dynamoid_class: test_class,
+              type: :global_secondary,
+              read_capacity: Dynamoid::Config.read_capacity,
+              write_capacity: Dynamoid::Config.write_capacity,
+              hash_key: :secondary_hash_field,
+              range_key: :secondary_range_field
             }
             expect(Dynamoid::Indexes::Index).to have_received(:new).with(index_opts)
           end
@@ -106,7 +106,7 @@ describe Dynamoid::Indexes do
       end
       it 'with no :hash_key, throws an error' do
         expect do
-          doc_class.global_secondary_index(:range_key => :something)
+          doc_class.global_secondary_index(range_key: :something)
         end.to raise_error(
           Dynamoid::Errors::InvalidIndex, /hash_key.*specified/)
       end
@@ -123,20 +123,20 @@ describe Dynamoid::Indexes do
       let(:doc_class_with_lsi) do
         Class.new do
           include Dynamoid::Document
-          table :name => :mytable, :key => :some_hash_field
+          table name: :mytable, key: :some_hash_field
           range :some_range_field # @WHAT
 
-          local_secondary_index(:range_key => :secondary_range_field)
+          local_secondary_index(range_key: :secondary_range_field)
         end
       end
 
       it 'creates the index with the correct options' do
         test_class = doc_class_with_lsi
         index_opts = {
-          :dynamoid_class => test_class,
-          :type => :local_secondary,
-          :hash_key => :some_hash_field,
-          :range_key => :secondary_range_field
+          dynamoid_class: test_class,
+          type: :local_secondary,
+          hash_key: :some_hash_field,
+          range_key: :secondary_range_field
         }
         expect(Dynamoid::Indexes::Index).to have_received(:new).with(index_opts)
       end
@@ -152,7 +152,7 @@ describe Dynamoid::Indexes do
       let(:doc_class_with_table) do
         Class.new do
           include Dynamoid::Document
-          table :name => :mytable, :key => :some_hash_field
+          table name: :mytable, key: :some_hash_field
           range :some_range_field
         end
       end
@@ -166,14 +166,14 @@ describe Dynamoid::Indexes do
       it 'throws an error if the range_key isn`t specified' do
         test_class = doc_class_with_table
         expect do
-          test_class.local_secondary_index(:projected_attributes => :all)
+          test_class.local_secondary_index(projected_attributes: :all)
         end.to raise_error(Dynamoid::Errors::InvalidIndex, /range_key.*specified/)
       end
 
       it 'throws an error if the range_key is the same as the primary range key' do
         test_class = doc_class_with_table
         expect do
-          test_class.local_secondary_index(:range_key => :some_range_field)
+          test_class.local_secondary_index(range_key: :some_range_field)
         end.to raise_error(Dynamoid::Errors::InvalidIndex, /different.*:range_key/)
       end
     end
@@ -204,7 +204,7 @@ describe Dynamoid::Indexes do
     let(:doc_class) do
       Class.new do
         include Dynamoid::Document
-        table :name => :mytable
+        table name: :mytable
       end
     end
 
@@ -221,7 +221,7 @@ describe Dynamoid::Indexes do
       let(:doc_class) do
         Class.new do
           include Dynamoid::Document
-          table :name => :mytable, :key => :some_hash_field
+          table name: :mytable, key: :some_hash_field
 
           field :primary_hash_field
           field :primary_range_field
@@ -242,57 +242,57 @@ describe Dynamoid::Indexes do
         it 'throws an error if :type is invalid' do
           expect do
             Dynamoid::Indexes::Index.new(
-              :dynamoid_class => doc_class,
-              :hash_key => :primary_hash_field,
-              :type => :garbage)
+              dynamoid_class: doc_class,
+              hash_key: :primary_hash_field,
+              type: :garbage)
           end.to raise_error(Dynamoid::Errors::InvalidIndex, /Invalid.*:type/)
         end
 
         it 'throws an error when :hash_key is not a table attribute' do
           expect do
             Dynamoid::Indexes::Index.new(
-              :dynamoid_class => doc_class,
-              :hash_key => :garbage,
-              :type => :global_secondary)
+              dynamoid_class: doc_class,
+              hash_key: :garbage,
+              type: :global_secondary)
           end.to raise_error(Dynamoid::Errors::InvalidIndex, /No such field/)
         end
 
         it 'throws an error when :hash_key is of invalid type' do
           expect do
             Dynamoid::Indexes::Index.new(
-              :dynamoid_class => doc_class,
-              :hash_key => :array_field,
-              :type => :global_secondary)
+              dynamoid_class: doc_class,
+              hash_key: :array_field,
+              type: :global_secondary)
           end.to raise_error(Dynamoid::Errors::InvalidIndex, /hash_key.*/)
         end
 
         it 'throws an error when :range_key is of invalid type' do
           expect do
             Dynamoid::Indexes::Index.new(
-              :dynamoid_class => doc_class,
-              :hash_key => :primary_hash_field,
-              :type => :global_secondary,
-              :range_key => :array_field)
+              dynamoid_class: doc_class,
+              hash_key: :primary_hash_field,
+              type: :global_secondary,
+              range_key: :array_field)
           end.to raise_error(Dynamoid::Errors::InvalidIndex, /range_key.*/)
         end
 
         it 'throws an error when :range_key is not a table attribute' do
           expect do
            Dynamoid::Indexes::Index.new(
-              :dynamoid_class => doc_class,
-              :hash_key => :primary_hash_field,
-              :type => :global_secondary,
-              :range_key => :garbage)
+              dynamoid_class: doc_class,
+              hash_key: :primary_hash_field,
+              type: :global_secondary,
+              range_key: :garbage)
           end.to raise_error(Dynamoid::Errors::InvalidIndex, /No such field/)
         end
 
         it 'throws an error if :projected_attributes are invalid' do
           expect do
             Dynamoid::Indexes::Index.new(
-              :dynamoid_class => doc_class,
-              :hash_key => :primary_hash_field,
-              :type => :global_secondary,
-              :projected_attributes => :garbage)
+              dynamoid_class: doc_class,
+              hash_key: :primary_hash_field,
+              type: :global_secondary,
+              projected_attributes: :garbage)
           end.to raise_error(Dynamoid::Errors::InvalidIndex, /Invalid projected attributes/)
         end
       end
@@ -301,10 +301,10 @@ describe Dynamoid::Indexes do
         context 'with only required params' do
           let(:defaults_index) do
             Dynamoid::Indexes::Index.new(
-                :dynamoid_class => doc_class,
-                :hash_key => :primary_hash_field,
-                :range_key => :secondary_range_field,
-                :type => :local_secondary
+                dynamoid_class: doc_class,
+                hash_key: :primary_hash_field,
+                range_key: :secondary_range_field,
+                type: :local_secondary
             )
           end
 
@@ -317,12 +317,12 @@ describe Dynamoid::Indexes do
           end
 
           it 'sets the hash_key_schema' do
-            expected = {:primary_hash_field => :string}
+            expected = {primary_hash_field: :string}
             expect(defaults_index.hash_key_schema).to eql expected
           end
 
           it 'sets the range_key_schema' do
-            expected = {:secondary_range_field => :string}
+            expected = {secondary_range_field: :string}
             expect(defaults_index.range_key_schema).to eql expected
           end
 
@@ -341,13 +341,13 @@ describe Dynamoid::Indexes do
         context 'with other params specified' do
           let(:other_index) do
             Dynamoid::Indexes::Index.new(
-                :dynamoid_class => doc_class,
-                :name => :mont_blanc,
-                :hash_key => :secondary_hash_field,
-                :type => :global_secondary,
-                :projected_attributes => [:secondary_hash_field, :array_field],
-                :read_capacity => 100,
-                :write_capacity => 200
+                dynamoid_class: doc_class,
+                name: :mont_blanc,
+                hash_key: :secondary_hash_field,
+                type: :global_secondary,
+                projected_attributes: [:secondary_hash_field, :array_field],
+                read_capacity: 100,
+                write_capacity: 200
             )
           end
           it 'sets the provided attributes' do
@@ -371,7 +371,7 @@ describe Dynamoid::Indexes do
         Class.new do
           include Dynamoid::Document
 
-          table :name => :mytable, :key => :primary_hash_field
+          table name: :mytable, key: :primary_hash_field
 
           field :primary_hash_field
           field :secondary_hash_field
@@ -381,20 +381,20 @@ describe Dynamoid::Indexes do
 
       it 'projection type is :include' do
         projection_include = Dynamoid::Indexes::Index.new(
-            :dynamoid_class => doc_class,
-            :hash_key => :secondary_hash_field,
-            :type => :global_secondary,
-            :projected_attributes => [:secondary_hash_field, :array_field]
+            dynamoid_class: doc_class,
+            hash_key: :secondary_hash_field,
+            type: :global_secondary,
+            projected_attributes: [:secondary_hash_field, :array_field]
         ).projection_type
         expect(projection_include).to eq(:include)
       end
 
       it 'projection type is :all' do
         projection_all = Dynamoid::Indexes::Index.new(
-            :dynamoid_class => doc_class,
-            :hash_key => :secondary_hash_field,
-            :type => :global_secondary,
-            :projected_attributes => :all
+            dynamoid_class: doc_class,
+            hash_key: :secondary_hash_field,
+            type: :global_secondary,
+            projected_attributes: :all
         ).projection_type
 
         expect(projection_all).to eq(:all)

--- a/spec/dynamoid/indexes_spec.rb
+++ b/spec/dynamoid/indexes_spec.rb
@@ -33,10 +33,9 @@ describe Dynamoid::Indexes do
 
       it 'with a range key, also adds the index to the global_secondary_indexes hash' do
         index_key = doc_class.index_key(:some_hash_field, :some_range_field)
-        doc_class.global_secondary_index({
+        doc_class.global_secondary_index(
           hash_key: :some_hash_field,
-          range_key: :some_range_field
-        })
+          range_key: :some_range_field)
 
         expected_index = doc_class.global_secondary_indexes[index_key]
         expect(expected_index).to eq(@dummy_index)
@@ -70,10 +69,9 @@ describe Dynamoid::Indexes do
 
         context 'with a hash and range index' do
           let(:doc_class_with_gsi) do
-            doc_class.global_secondary_index({
+            doc_class.global_secondary_index(
               hash_key: :secondary_hash_field,
-              range_key: :secondary_range_field
-            })
+              range_key: :secondary_range_field)
           end
 
           it 'creates the index with the correct options' do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -423,7 +423,7 @@ describe Dynamoid::Persistence do
 
     it 'raises when undumping a column with an unknown field type' do
       expect do
-        clazz.new(:deliverable => true) #undump is called here
+        clazz.new(:deliverable => true) # undump is called here
       end.to raise_error(ArgumentError)
     end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -775,7 +775,7 @@ describe Dynamoid::Persistence do
 
     it 'makes multiple batch operations if the limit (25 items) exceeded' do
       expect(Dynamoid.adapter.client).to receive(:batch_write_item).exactly(2).times.and_call_original
-      Address.import(Array.new(26, {city: 'Chicago'}))
+      Address.import(Array.new(26, city: 'Chicago'))
     end
   end
 end

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -59,7 +59,7 @@ describe Dynamoid::Persistence do
         @user = User.create(:name => 'Josh')
         @user.destroy
 
-        expect(Dynamoid.adapter.read("dynamoid_tests_users", @user.id)).to be_nil
+        expect(Dynamoid.adapter.read('dynamoid_tests_users', @user.id)).to be_nil
       end
 
       it 'returns false when destroy fails (due to callback)' do
@@ -86,7 +86,7 @@ describe Dynamoid::Persistence do
   it 'assigns itself an id on save' do
     address.save
 
-    expect(Dynamoid.adapter.read("dynamoid_tests_addresses", address.id)[:id]).to eq address.id
+    expect(Dynamoid.adapter.read('dynamoid_tests_addresses', address.id)[:id]).to eq address.id
   end
 
   it 'prevents concurrent writes to tables with a lock_version' do
@@ -105,7 +105,7 @@ describe Dynamoid::Persistence do
     address.id = 'test123'
     address.save
 
-    expect(Dynamoid.adapter.read("dynamoid_tests_addresses", 'test123')).to_not be_empty
+    expect(Dynamoid.adapter.read('dynamoid_tests_addresses', 'test123')).to_not be_empty
   end
 
   it 'has a table name' do
@@ -123,7 +123,7 @@ describe Dynamoid::Persistence do
     before do
       reload_address
       Dynamoid.configure do |config|
-        config.namespace = ""
+        config.namespace = ''
       end
     end
 
@@ -174,7 +174,7 @@ describe Dynamoid::Persistence do
     @user = User.create(:name => 'Josh')
     @user.destroy
 
-    expect(Dynamoid.adapter.read("dynamoid_tests_users", @user.id)).to be_nil
+    expect(Dynamoid.adapter.read('dynamoid_tests_users', @user.id)).to be_nil
   end
 
   it 'keeps string attributes as strings' do
@@ -206,7 +206,7 @@ describe Dynamoid::Persistence do
     expect(@addr.send(:dump)[:config]).to eq config
   end
 
-  context "transforms booleans" do
+  context 'transforms booleans' do
     it 'handles true' do
       deliverable = true
       @addr = Address.new(:deliverable => deliverable)
@@ -283,7 +283,7 @@ describe Dynamoid::Persistence do
   end
 
   it 'dumps and undump a serialized field' do
-    address.options = (hash = {:x => [1, 2], "foobar" => 3.14})
+    address.options = (hash = {:x => [1, 2], 'foobar' => 3.14})
     expect(Address.undump(address.send(:dump))[:options]).to eq hash
   end
 
@@ -321,7 +321,7 @@ describe Dynamoid::Persistence do
   end
 
   it 'saves empty set as nil' do
-    tweet = Tweet.create(group: "one", tags: [])
+    tweet = Tweet.create(group: 'one', tags: [])
     expect(Tweet.find_by_tweet_id(tweet.tweet_id).tags).to eq nil
   end
 
@@ -387,7 +387,7 @@ describe Dynamoid::Persistence do
   end
 
   it 'works with a HashWithIndifferentAccess' do
-    hash = ActiveSupport::HashWithIndifferentAccess.new("city" => "Atlanta")
+    hash = ActiveSupport::HashWithIndifferentAccess.new('city' => 'Atlanta')
 
     expect{Address.create(hash)}.to_not raise_error
   end
@@ -505,10 +505,10 @@ describe Dynamoid::Persistence do
     it 'prevents concurrent saves to tables with a lock_version' do
       address.save!
       a2 = Address.find(address.id)
-      a2.update! { |a| a.set(:city => "Chicago") }
+      a2.update! { |a| a.set(:city => 'Chicago') }
 
       expect do
-        address.city = "Seattle"
+        address.city = 'Seattle'
         address.save!
       end.to raise_error(Dynamoid::Errors::StaleObjectError)
     end
@@ -518,7 +518,7 @@ describe Dynamoid::Persistence do
   context 'delete' do
     it 'deletes model with datetime range key' do
       expect do
-        msg = Message.create!(:message_id => 1, :time => DateTime.now, :text => "Hell yeah")
+        msg = Message.create!(:message_id => 1, :time => DateTime.now, :text => 'Hell yeah')
         msg.destroy
       end.to_not raise_error
     end
@@ -762,7 +762,7 @@ describe Dynamoid::Persistence do
 
         def self.name; 'Address'; end
 
-        before_save { raise "before save callback called" }
+        before_save { raise 'before save callback called' }
       end
 
       expect { klass.import([{city: 'Chicago'}]) }.not_to raise_error

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -10,13 +10,13 @@ describe Dynamoid::Persistence do
       end
 
       it 'creates a table' do
-        Address.create_table(:table_name => Address.table_name)
+        Address.create_table(table_name: Address.table_name)
 
         expect(Dynamoid.adapter.list_tables).to include 'dynamoid_tests_addresses'
       end
 
       it 'checks if a table already exists' do
-        Address.create_table(:table_name => Address.table_name)
+        Address.create_table(table_name: Address.table_name)
 
         expect(Address.table_exists?(Address.table_name)).to be_truthy
         expect(Address.table_exists?('crazytable')).to be_falsey
@@ -38,7 +38,7 @@ describe Dynamoid::Persistence do
     let(:klass) do
       Class.new do
         include Dynamoid::Document
-        table :name => :addresses
+        table name: :addresses
         field :city
 
         before_destroy {|i|
@@ -56,7 +56,7 @@ describe Dynamoid::Persistence do
 
     describe 'destroy' do
       it 'deletes an item completely' do
-        @user = User.create(:name => 'Josh')
+        @user = User.create(name: 'Josh')
         @user.destroy
 
         expect(Dynamoid.adapter.read('dynamoid_tests_users', @user.id)).to be_nil
@@ -171,63 +171,63 @@ describe Dynamoid::Persistence do
   end
 
   it 'deletes an item completely' do
-    @user = User.create(:name => 'Josh')
+    @user = User.create(name: 'Josh')
     @user.destroy
 
     expect(Dynamoid.adapter.read('dynamoid_tests_users', @user.id)).to be_nil
   end
 
   it 'keeps string attributes as strings' do
-    @user = User.new(:name => 'Josh')
+    @user = User.new(name: 'Josh')
     expect(@user.send(:dump)[:name]).to eq 'Josh'
   end
 
   it 'keeps raw Hash attributes as a Hash' do
-    config = {:acres => 5, :trees => {:cyprus => 30, :poplar => 10, :joshua => 1}, :horses => ['Lucky', 'Dummy'], :lake => 1, :tennis_court => 1}
-    @addr = Address.new(:config => config)
+    config = {acres: 5, trees: {cyprus: 30, poplar: 10, joshua: 1}, horses: ['Lucky', 'Dummy'], lake: 1, tennis_court: 1}
+    @addr = Address.new(config: config)
     expect(@addr.send(:dump)[:config]).to eq config
   end
 
   it 'keeps raw Array attributes as an Array' do
     config = ['windows', 'roof', 'doors']
-    @addr = Address.new(:config => config)
+    @addr = Address.new(config: config)
     expect(@addr.send(:dump)[:config]).to eq config
   end
 
   it 'keeps raw String attributes as a String' do
     config = 'Configy'
-    @addr = Address.new(:config => config)
+    @addr = Address.new(config: config)
     expect(@addr.send(:dump)[:config]).to eq config
   end
 
   it 'keeps raw Number attributes as a Number' do
     config = 100
-    @addr = Address.new(:config => config)
+    @addr = Address.new(config: config)
     expect(@addr.send(:dump)[:config]).to eq config
   end
 
   context 'transforms booleans' do
     it 'handles true' do
       deliverable = true
-      @addr = Address.new(:deliverable => deliverable)
+      @addr = Address.new(deliverable: deliverable)
       expect(@addr.send(:dump)[:deliverable]).to eq 't'
     end
 
     it 'handles false' do
       deliverable = false
-      @addr = Address.new(:deliverable => deliverable)
+      @addr = Address.new(deliverable: deliverable)
       expect(@addr.send(:dump)[:deliverable]).to eq 'f'
     end
 
     it 'handles t' do
       deliverable = 't'
-      @addr = Address.new(:deliverable => deliverable)
+      @addr = Address.new(deliverable: deliverable)
       expect(@addr.send(:dump)[:deliverable]).to eq 't'
     end
 
     it 'handles f' do
       deliverable = 'f'
-      @addr = Address.new(:deliverable => deliverable)
+      @addr = Address.new(deliverable: deliverable)
       expect(@addr.send(:dump)[:deliverable]).to eq 'f'
     end
   end
@@ -258,7 +258,7 @@ describe Dynamoid::Persistence do
   end
 
   it 'dumps date attributes' do
-    address = Address.create(:registered_on => '2017-06-18'.to_date)
+    address = Address.create(registered_on: '2017-06-18'.to_date)
     expect(Address.find(address.id).registered_on).to eq '2017-06-18'.to_date
 
     # check internal format - days since 1970-01-01
@@ -267,12 +267,12 @@ describe Dynamoid::Persistence do
   end
 
   it 'dumps integer attributes' do
-    @subscription = Subscription.create(:length => 10)
+    @subscription = Subscription.create(length: 10)
     expect(@subscription.send(:dump)[:length]).to eq 10
   end
 
   it 'dumps set attributes' do
-    @subscription = Subscription.create(:length => 10)
+    @subscription = Subscription.create(length: 10)
     @magazine = @subscription.magazine.create
 
     expect(@subscription.send(:dump)[:magazine_ids]).to eq Set[@magazine.hash_key]
@@ -362,7 +362,7 @@ describe Dynamoid::Persistence do
 
   it 'loads attributes from a hash' do
     @time = DateTime.now
-    @hash = {:name => 'Josh', :created_at => @time.to_f}
+    @hash = {name: 'Josh', created_at: @time.to_f}
 
     expect(User.undump(@hash)[:name]).to eq 'Josh'
     User.undump(@hash)[:created_at].to_f == @time.to_f
@@ -394,8 +394,8 @@ describe Dynamoid::Persistence do
 
   context 'create' do
     {
-      Tweet   => ['with range',    { :tweet_id => 1, :group => 'abc' }],
-      Message => ['without range', { :message_id => 1, :text => 'foo', :time => DateTime.now }]
+      Tweet   => ['with range',    { tweet_id: 1, group: 'abc' }],
+      Message => ['without range', { message_id: 1, text: 'foo', time: DateTime.now }]
     }.each_pair do |clazz, fields|
       it "checks for existence of an existing object #{fields[0]}" do
         t1 = clazz.new(fields[1])
@@ -413,7 +413,7 @@ describe Dynamoid::Persistence do
     let(:clazz) do
       Class.new do
         include Dynamoid::Document
-        table :name => :addresses
+        table name: :addresses
 
         field :city
         field :options, :serialized
@@ -423,7 +423,7 @@ describe Dynamoid::Persistence do
 
     it 'raises when undumping a column with an unknown field type' do
       expect do
-        clazz.new(:deliverable => true) # undump is called here
+        clazz.new(deliverable: true) # undump is called here
       end.to raise_error(ArgumentError)
     end
 
@@ -440,7 +440,7 @@ describe Dynamoid::Persistence do
     it 'creates table if it does not exist' do
       klass = Class.new do
         include Dynamoid::Document
-        table :name => :foo_bars
+        table name: :foo_bars
       end
 
       expect { klass.create }.not_to raise_error(Aws::DynamoDB::Errors::ResourceNotFoundException)
@@ -451,29 +451,29 @@ describe Dynamoid::Persistence do
   context 'update' do
 
     before :each do
-      @tweet = Tweet.create(:tweet_id => 1, :group => 'abc', :count => 5, :tags => Set.new(['db', 'sql']), :user_name => 'john')
+      @tweet = Tweet.create(tweet_id: 1, group: 'abc', count: 5, tags: Set.new(['db', 'sql']), user_name: 'john')
     end
 
     it 'runs before_update callbacks when doing #update' do
       expect_any_instance_of(CamelCase).to receive(:doing_before_update).once.and_return(true)
 
-      CamelCase.create(:color => 'blue').update do |t|
-        t.set(:color => 'red')
+      CamelCase.create(color: 'blue').update do |t|
+        t.set(color: 'red')
       end
     end
 
     it 'runs after_update callbacks when doing #update' do
       expect_any_instance_of(CamelCase).to receive(:doing_after_update).once.and_return(true)
 
-      CamelCase.create(:color => 'blue').update do |t|
-        t.set(:color => 'red')
+      CamelCase.create(color: 'blue').update do |t|
+        t.set(color: 'red')
       end
     end
 
     it 'support add/delete operation on a field' do
       @tweet.update do |t|
-        t.add(:count => 3)
-        t.delete(:tags => Set.new(['db']))
+        t.add(count: 3)
+        t.delete(tags: Set.new(['db']))
       end
 
       expect(@tweet.count).to eq(8)
@@ -481,23 +481,23 @@ describe Dynamoid::Persistence do
     end
 
     it 'checks the conditions on update' do
-      result = @tweet.update(:if => { :count => 5 }) do |t|
-        t.add(:count => 3)
+      result = @tweet.update(if: { count: 5 }) do |t|
+        t.add(count: 3)
       end
       expect(result).to be_truthy
 
       expect(@tweet.count).to eq(8)
 
-      result = @tweet.update(:if => { :count => 5 }) do |t|
-        t.add(:count => 3)
+      result = @tweet.update(if: { count: 5 }) do |t|
+        t.add(count: 3)
       end
       expect(result).to be_falsey
 
       expect(@tweet.count).to eq(8)
 
       expect do
-        @tweet.update!(:if => { :count => 5 }) do |t|
-          t.add(:count => 3)
+        @tweet.update!(if: { count: 5 }) do |t|
+          t.add(count: 3)
         end
       end.to raise_error(Dynamoid::Errors::StaleObjectError)
     end
@@ -505,7 +505,7 @@ describe Dynamoid::Persistence do
     it 'prevents concurrent saves to tables with a lock_version' do
       address.save!
       a2 = Address.find(address.id)
-      a2.update! { |a| a.set(:city => 'Chicago') }
+      a2.update! { |a| a.set(city: 'Chicago') }
 
       expect do
         address.city = 'Seattle'
@@ -518,7 +518,7 @@ describe Dynamoid::Persistence do
   context 'delete' do
     it 'deletes model with datetime range key' do
       expect do
-        msg = Message.create!(:message_id => 1, :time => DateTime.now, :text => 'Hell yeah')
+        msg = Message.create!(message_id: 1, time: DateTime.now, text: 'Hell yeah')
         msg.destroy
       end.to_not raise_error
     end
@@ -589,7 +589,7 @@ describe Dynamoid::Persistence do
     subject { Address.new() }
 
     it 'it persists raw Hash and reads the same back' do
-      config = {:acres => 5, :trees => {:cyprus => 30, :poplar => 10, :joshua => 1}, :horses => ['Lucky', 'Dummy'], :lake => 1, :tennis_court => 1}
+      config = {acres: 5, trees: {cyprus: 30, poplar: 10, joshua: 1}, horses: ['Lucky', 'Dummy'], lake: 1, tennis_court: 1}
       subject.config = config
       subject.save!
       subject.reload

--- a/spec/dynamoid/validations_spec.rb
+++ b/spec/dynamoid/validations_spec.rb
@@ -42,7 +42,7 @@ describe Dynamoid::Validations do
 
     expect { doc_class.create! }.to raise_error(Dynamoid::Errors::DocumentNotValid)
 
-    doc = doc_class.create!(:name => 'test')
+    doc = doc_class.create!(name: 'test')
     expect(doc.errors).to be_empty
   end
 

--- a/spec/dynamoid_spec.rb
+++ b/spec/dynamoid_spec.rb
@@ -1,11 +1,11 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Dynamoid do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Dynamoid::VERSION).not_to be nil
   end
 
-  it "does not puke when asked for the assocations of a new record" do
+  it 'does not puke when asked for the assocations of a new record' do
     expect(User.new.books).to eq([])
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,10 +15,9 @@ require 'dynamodb_local'
 ENV['ACCESS_KEY'] ||= 'abcd'
 ENV['SECRET_KEY'] ||= '1234'
 
-Aws.config.update({
-          region: 'us-west-2',
-          credentials: Aws::Credentials.new(ENV['ACCESS_KEY'], ENV['SECRET_KEY'])
-          })
+Aws.config.update(
+  region: 'us-west-2',
+  credentials: Aws::Credentials.new(ENV['ACCESS_KEY'], ENV['SECRET_KEY']))
 
 Dynamoid.configure do |config|
   config.endpoint = 'http://127.0.0.1:8000'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,28 +1,28 @@
-require "coveralls"
+require 'coveralls'
 Coveralls.wear!
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
-require "rspec"
-require "dynamoid"
-require "pry"
-require "aws-sdk-resources"
-require "byebug" if ENV["DEBUG"]
+require 'rspec'
+require 'dynamoid'
+require 'pry'
+require 'aws-sdk-resources'
+require 'byebug' if ENV['DEBUG']
 
-require "dynamodb_local"
+require 'dynamodb_local'
 
-ENV["ACCESS_KEY"] ||= "abcd"
-ENV["SECRET_KEY"] ||= "1234"
+ENV['ACCESS_KEY'] ||= 'abcd'
+ENV['SECRET_KEY'] ||= '1234'
 
 Aws.config.update({
-          region: "us-west-2",
-          credentials: Aws::Credentials.new(ENV["ACCESS_KEY"], ENV["SECRET_KEY"])
+          region: 'us-west-2',
+          credentials: Aws::Credentials.new(ENV['ACCESS_KEY'], ENV['SECRET_KEY'])
           })
 
 Dynamoid.configure do |config|
-  config.endpoint = "http://127.0.0.1:8000"
-  config.namespace = "dynamoid_tests"
+  config.endpoint = 'http://127.0.0.1:8000'
+  config.namespace = 'dynamoid_tests'
   config.warn_on_scan = false
   config.sync_retry_wait_seconds = 0
   config.sync_retry_max_times = 3
@@ -30,7 +30,7 @@ end
 
 Dynamoid.logger.level = Logger::FATAL
 
-MODELS = File.join(File.dirname(__FILE__), "app/models")
+MODELS = File.join(File.dirname(__FILE__), 'app/models')
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
@@ -38,12 +38,12 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 Dir["#{File.dirname(__FILE__)}/app/field_types/*.rb"].each {|f| require f}
 
-Dir[ File.join(MODELS, "*.rb") ].sort.each { |file| require file }
+Dir[ File.join(MODELS, '*.rb') ].sort.each { |file| require file }
 
 RSpec.configure do |config|
   config.order = :random
   config.raise_errors_for_deprecations!
-  config.alias_it_should_behave_like_to :configured_with, "configured with"
+  config.alias_it_should_behave_like_to :configured_with, 'configured with'
 
   config.include NewClassHelper
 


### PR DESCRIPTION
Fixed following issues:
- trailing whitespaces
- double quotes
- old Hash syntax
- indentation, excessive empty lines
etc

It was automatic correction with `rubocop`. The whole list of available corrections is here https://github.com/bbatsov/rubocop/wiki/Automatic-Corrections

Some declared autocorrections are still not implemented