### PR TITLE
Refactor `batch_write_item`

### DIFF
--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -105,7 +105,7 @@ module Dynamoid
           # turn ids into array of arrays each element being hash_key, range_key
           ids = ids.each_with_index.map{|id, i| [id, range_key[i]]}
         else
-          ids = range_key ? [[ids, range_key]] : ids
+          ids = range_key ? ids.map { |id| [id, range_key] } : ids
         end
 
         batch_delete_item(table => ids)

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -212,9 +212,7 @@ module Dynamoid
           }
         }
 
-        documents.each_slice(25) do |docs|
-          Dynamoid.adapter.batch_write_item(self.table_name, docs.map(&:dump))
-        end
+        Dynamoid.adapter.batch_write_item(self.table_name, documents.map(&:dump))
 
         documents.each { |d| d.new_record = false }
         documents

--- a/spec/dynamoid/adapter_spec.rb
+++ b/spec/dynamoid/adapter_spec.rb
@@ -7,6 +7,19 @@ describe Dynamoid::Adapter do
   let(:single_id){'123'}
   let(:many_ids){%w(1 2)}
 
+  {
+    1 => [:id],
+    2 => [:id],
+    3 => [:id, {range_key: {range: :number}}],
+    4 => [:id, {range_key: {range: :number}}]
+  }.each do |n, args|
+    name = "dynamoid_tests_TestTable#{n}"
+    let(:"test_table#{n}") do
+      Dynamoid.adapter.create_table(name, *args)
+      name
+    end
+  end
+
   describe 'connection management' do
     it 'does not auto-establish a connection' do
       expect_any_instance_of(described_class.adapter_plugin_class).to_not receive(:connect!)
@@ -59,64 +72,86 @@ describe Dynamoid::Adapter do
     subject.write(test_table, id: single_id)
   end
 
-  it 'reads through the adapter for one ID' do
-    expect(subject).to receive(:get_item).with(test_table, single_id, {}).and_return(true)
-    subject.read(test_table, single_id)
-  end
+  describe '#read' do
+    it 'reads through the adapter for one ID' do
+      expect(subject).to receive(:get_item).with(test_table, single_id, {}).and_return(true)
+      subject.read(test_table, single_id)
+    end
 
-  it 'reads through the adapter for many IDs' do
-    expect(subject).to receive(:batch_get_item).with({test_table => many_ids}, {}).and_return(true)
-    subject.read(test_table, many_ids)
-  end
+    it 'reads through the adapter for many IDs' do
+      expect(subject).to receive(:batch_get_item).with({test_table => many_ids}, {}).and_return(true)
+      subject.read(test_table, many_ids)
+    end
 
-  it 'delete through the adapter for one ID' do
-    expect(subject).to receive(:delete_item).with(test_table, single_id, {}).and_return(nil)
-    subject.delete(test_table, single_id)
-  end
+    it 'reads through the adapter for one ID and a range key' do
+      expect(subject).to receive(:get_item).with(test_table, single_id, range_key: 2.0).and_return(true)
+      subject.read(test_table, single_id, range_key: 2.0)
+    end
 
-  it 'deletes through the adapter for many IDs' do
-    expect(subject).to receive(:batch_delete_item).with(test_table => many_ids).and_return(nil)
-    subject.delete(test_table, many_ids)
-  end
-
-  it 'reads through the adapter for one ID and a range key' do
-    expect(subject).to receive(:get_item).with(test_table, single_id, range_key: 2.0).and_return(true)
-    subject.read(test_table, single_id, range_key: 2.0)
-  end
-
-  it 'reads through the adapter for many IDs and a range key' do
-    expect(subject).to receive(:batch_get_item).with({test_table => [['1', 2.0], ['2', 2.0]]}, {}).and_return(true)
-    subject.read(test_table, many_ids, range_key: 2.0)
-  end
-
-  it 'deletes through the adapter for one ID and a range key' do
-    expect(subject).to receive(:delete_item).with(test_table, single_id, range_key: 2.0).and_return(nil)
-    subject.delete(test_table, single_id, range_key: 2.0)
-  end
-
-  {
-    1 => [:id],
-    2 => [:id],
-    3 => [:id, {range_key: {range: :number}}],
-    4 => [:id, {range_key: {range: :number}}]
-  }.each do |n, args|
-    name = "dynamoid_tests_TestTable#{n}"
-    let(:"test_table#{n}") do
-      Dynamoid.adapter.create_table(name, *args)
-      name
+    it 'reads through the adapter for many IDs and a range key' do
+      expect(subject).to receive(:batch_get_item).with({test_table => [['1', 2.0], ['2', 2.0]]}, {}).and_return(true)
+      subject.read(test_table, many_ids, range_key: 2.0)
     end
   end
 
-  it 'deletes through the adapter for many IDs and a range key' do
-    Dynamoid.adapter.put_item(test_table3, id: '1', range: 1.0)
-    Dynamoid.adapter.put_item(test_table3, id: '2', range: 1.0)
-    Dynamoid.adapter.put_item(test_table3, id: '2', range: 2.0)
+  describe '#delete' do
+    it 'deletes through the adapter for one ID' do
+      Dynamoid.adapter.put_item(test_table1, id: '1')
+      Dynamoid.adapter.put_item(test_table1, id: '2')
 
-    expect(subject).to receive(:batch_delete_item).and_call_original
-    expect {
-      subject.delete(test_table3, ['1', '2'], range_key: 1.0)
-    }.to change {
-      Dynamoid.adapter.scan(test_table3).to_a.size
-    }.from(3).to(1)
+      expect {
+        subject.delete(test_table1, '1')
+      }.to change {
+        Dynamoid.adapter.scan(test_table1).to_a.size
+      }.from(2).to(1)
+
+      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq nil
+    end
+
+    it 'deletes through the adapter for many IDs' do
+      Dynamoid.adapter.put_item(test_table1, id: '1')
+      Dynamoid.adapter.put_item(test_table1, id: '2')
+      Dynamoid.adapter.put_item(test_table1, id: '3')
+
+      expect {
+        subject.delete(test_table1, ['1', '2'])
+      }.to change {
+        Dynamoid.adapter.scan(test_table1).to_a.size
+      }.from(3).to(1)
+
+      expect(Dynamoid.adapter.get_item(test_table1, '1')).to eq nil
+      expect(Dynamoid.adapter.get_item(test_table1, '2')).to eq nil
+    end
+
+    it 'deletes through the adapter for one ID and a range key' do
+      Dynamoid.adapter.put_item(test_table3, id: '1', range: 1.0)
+      Dynamoid.adapter.put_item(test_table3, id: '2', range: 2.0)
+
+      expect {
+        subject.delete(test_table3, '1', range_key: 1.0)
+      }.to change {
+        Dynamoid.adapter.scan(test_table3).to_a.size
+      }.from(2).to(1)
+
+      expect(Dynamoid.adapter.get_item(test_table3, '1', range_key: 1.0)).to eq nil
+    end
+
+    it 'deletes through the adapter for many IDs and a range key' do
+      Dynamoid.adapter.put_item(test_table3, id: '1', range: 1.0)
+      Dynamoid.adapter.put_item(test_table3, id: '1', range: 2.0)
+      Dynamoid.adapter.put_item(test_table3, id: '2', range: 1.0)
+      Dynamoid.adapter.put_item(test_table3, id: '2', range: 2.0)
+
+      expect(subject).to receive(:batch_delete_item).and_call_original
+
+      expect {
+        subject.delete(test_table3, ['1', '2'], range_key: 1.0)
+      }.to change {
+        Dynamoid.adapter.scan(test_table3).to_a.size
+      }.from(4).to(2)
+
+      expect(Dynamoid.adapter.get_item(test_table3, '1', range_key: 1.0)).to eq nil
+      expect(Dynamoid.adapter.get_item(test_table3, '2', range_key: 1.0)).to eq nil
+    end
   end
 end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -43,7 +43,7 @@ describe Dynamoid::Criteria::Chain do
 
     it 'Scans when there is only not-equal operator for hash key' do
       chain = Dynamoid::Criteria::Chain.new(Address)
-      chain.query = { 'id.in': ['test'] }
+      chain.query = { 'id.in' => ['test'] }
       expect(chain).to receive(:records_via_scan)
       chain.all
     end

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -769,13 +769,8 @@ describe Dynamoid::Persistence do
     end
 
     it 'makes batch operation' do
-      expect(Dynamoid.adapter.client).to receive(:batch_write_item).exactly(1).times.and_call_original
+      expect(Dynamoid.adapter).to receive(:batch_write_item).and_call_original
       Address.import([{city: 'Chicago'}, {city: 'New York'}])
-    end
-
-    it 'makes multiple batch operations if the limit (25 items) exceeded' do
-      expect(Dynamoid.adapter.client).to receive(:batch_write_item).exactly(2).times.and_call_original
-      Address.import(Array.new(26, city: 'Chicago'))
     end
   end
 end


### PR DESCRIPTION
* Added slicing by 25 requests in `#batch_write_item` like it does in `#batch_delete_item`
* Fixed `#delete` method for case `adapter.delete(table_name, [1, 2, 3], range_key: 1)`