### PR TITLE
Vagrant: gnupg2 for rvm verification

### DIFF
--- a/.dev/vagrant/salt/rvm/init.sls
+++ b/.dev/vagrant/salt/rvm/init.sls
@@ -11,6 +11,7 @@ rvm-deps:
       - curl
       - git-core
       - subversion
+      - gnupg2
 
 mri-deps:
   pkg.installed:
@@ -39,6 +40,11 @@ mri-deps:
       - subversion
       - ruby
 
+gpg-trust:
+  cmd.run:
+    - name: command curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
+    - user: vagrant
+
 ruby-{{ pillar['ruby']['version'] }}:
   rvm.installed:
     - name: {{ pillar['ruby']['version'] }}
@@ -65,3 +71,8 @@ bundler.install:
     - ruby: ruby-{{ pillar['ruby']['version'] }}
     - rdoc: false
     - ri: false
+
+bundle:
+  cmd.run:
+    - name: (cd /vagrant && bundle install)
+    - user: vagrant


### PR DESCRIPTION
- [Update] When install RVM, it would fail in verifying public key
  for download. Added command to download fingerprint using
  gpg2 as suggested by RVM.
- [Update] Also added bundle install after everything.

Was running on a new machine and found it wouldn't install correctly so updated to install correctly. Feel free to try otherwise, tested with Vagrant 2.0.1 and Virtualbox 5.2.0. Thanks!