### PR TITLE
Add `foreign_key` option for `belongs_to` association

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ class User
   has_many :students, :class => User
   belongs_to :teacher, :class_name => :user
   belongs_to :group
+  belongs_to :group, :foreign_key => :group_id
   has_one :role
   has_and_belongs_to_many :friends, :inverse_of => :friending_users
 

--- a/lib/dynamoid/associations.rb
+++ b/lib/dynamoid/associations.rb
@@ -88,11 +88,21 @@ module Dynamoid
       #
       # @since 0.2.0
       def association(type, name, options = {})
-        field "#{name}_ids".to_sym, :set
+        # Declare document field.
+        # In simple case it's equivalent to
+        # field "#{name}_ids".to_sym, :set
+        assoc = Dynamoid::Associations.const_get(type.to_s.camelcase).new(nil, name, options)
+        field_name = assoc.declaration_field_name
+        field_type = assoc.declaration_field_type
+
+        field field_name.to_sym, field_type
+
         self.associations[name] = options.merge(type: type)
+
         define_method(name) do
           @associations[:"#{name}_ids"] ||= Dynamoid::Associations.const_get(type.to_s.camelcase).new(self, name, options)
         end
+
         define_method("#{name}=".to_sym) do |objects|
           @associations[:"#{name}_ids"] ||= Dynamoid::Associations.const_get(type.to_s.camelcase).new(self, name, options)
           @associations[:"#{name}_ids"].setter(objects)

--- a/lib/dynamoid/associations/belongs_to.rb
+++ b/lib/dynamoid/associations/belongs_to.rb
@@ -7,6 +7,34 @@ module Dynamoid #:nodoc:
     class BelongsTo
       include SingleAssociation
 
+      def declaration_field_name
+        if options[:foreign_key]
+          options[:foreign_key]
+        else
+          "#{name}_ids"
+        end
+      end
+
+      def declaration_field_type
+        if options[:foreign_key]
+          target_class.attributes[target_class.hash_key][:type]
+        else
+          :set
+        end
+      end
+
+      # Override default implemntation
+      # to handle case when we store id as scalar value, not as collaction
+      def associate(hash_key)
+        target.send(target_association).disassociate(source.hash_key) if target && target_association
+
+        if options[:foreign_key]
+          source.update_attribute(source_attribute, hash_key)
+        else
+          source.update_attribute(source_attribute, Set[hash_key])
+        end
+      end
+
       private
 
       # Find the target association, either has_many or has_one. Uses either options[:inverse_of] or the source class name and default parsing to

--- a/lib/dynamoid/associations/belongs_to.rb
+++ b/lib/dynamoid/associations/belongs_to.rb
@@ -8,11 +8,7 @@ module Dynamoid #:nodoc:
       include SingleAssociation
 
       def declaration_field_name
-        if options[:foreign_key]
-          options[:foreign_key]
-        else
-          "#{name}_ids"
-        end
+        options[:foreign_key] || "#{name}_ids"
       end
 
       def declaration_field_type
@@ -23,8 +19,8 @@ module Dynamoid #:nodoc:
         end
       end
 
-      # Override default implemntation
-      # to handle case when we store id as scalar value, not as collaction
+      # Override default implementation
+      # to handle case when we store id as scalar value, not as collection
       def associate(hash_key)
         target.send(target_association).disassociate(source.hash_key) if target && target_association
 

--- a/lib/dynamoid/associations/belongs_to.rb
+++ b/lib/dynamoid/associations/belongs_to.rb
@@ -24,21 +24,6 @@ module Dynamoid #:nodoc:
           return has_one_key_name if target_class.associations[has_one_key_name][:type] == :has_one
         end
       end
-
-      # Associate a source object to this association.
-      #
-      # @since 0.2.0
-      def associate_target(object)
-        object.update_attribute(target_attribute, target_ids.merge(Array(source.hash_key)))
-      end
-
-      # Disassociate a source object from this association.
-      #
-      # @since 0.2.0
-      def disassociate_target(object)
-        ids = object.send(target_attribute) || Set.new
-        object.update_attribute(target_attribute, ids - Array(source.hash_key))
-      end
     end
   end
 

--- a/lib/dynamoid/associations/has_and_belongs_to_many.rb
+++ b/lib/dynamoid/associations/has_and_belongs_to_many.rb
@@ -18,22 +18,6 @@ module Dynamoid #:nodoc:
         return nil if guess.nil? || guess[:type] != :has_and_belongs_to_many
         key_name
       end
-
-      # Associate a source object to this association.
-      #
-      # @since 0.2.0
-      def associate_target(object)
-        ids = object.send(target_attribute) || Set.new
-        object.update_attribute(target_attribute, ids.merge(Array(source.hash_key)))
-      end
-
-      # Disassociate a source object from this association.
-      #
-      # @since 0.2.0
-      def disassociate_target(object)
-        ids = object.send(target_attribute) || Set.new
-        object.update_attribute(target_attribute, ids - Array(source.hash_key))
-      end
     end
   end
 

--- a/lib/dynamoid/associations/has_many.rb
+++ b/lib/dynamoid/associations/has_many.rb
@@ -18,21 +18,6 @@ module Dynamoid #:nodoc:
         return nil if guess.nil? || guess[:type] != :belongs_to
         key_name
       end
-
-      # Associate a source object to this association.
-      #
-      # @since 0.2.0
-      def associate_target(object)
-        object.update_attribute(target_attribute, Set[source.hash_key])
-      end
-
-      # Disassociate a source object from this association.
-      #
-      # @since 0.2.0
-      def disassociate_target(object)
-        object.update_attribute(target_attribute, nil)
-      end
-
     end
   end
 

--- a/lib/dynamoid/associations/has_one.rb
+++ b/lib/dynamoid/associations/has_one.rb
@@ -19,21 +19,6 @@ module Dynamoid #:nodoc:
         return nil if guess.nil? || guess[:type] != :belongs_to
         key_name
       end
-
-      # Associate a source object to this association.
-      #
-      # @since 0.2.0
-      def associate_target(object)
-        object.update_attribute(target_attribute, Set[source.hash_key])
-      end
-
-      # Disassociate a source object from this association.
-      #
-      # @since 0.2.0
-      def disassociate_target(object)
-        ids = object.send(target_attribute) || Set.new
-        object.update_attribute(target_attribute, ids - Array(source.hash_key))
-      end
     end
   end
 

--- a/lib/dynamoid/associations/single_association.rb
+++ b/lib/dynamoid/associations/single_association.rb
@@ -8,9 +8,10 @@ module Dynamoid #:nodoc:
       delegate :class, to: :target
 
       def setter(object)
-        delete
-
-        return if object.nil?
+        if object.nil?
+          delete
+          return
+        end
 
         associate(object.hash_key)
         self.target = object
@@ -63,6 +64,7 @@ module Dynamoid #:nodoc:
       end
 
       def associate(hash_key)
+        target.send(target_association).disassociate(source.hash_key) if target && target_association
         source.update_attribute(source_attribute, Set[hash_key])
       end
 

--- a/lib/dynamoid/associations/single_association.rb
+++ b/lib/dynamoid/associations/single_association.rb
@@ -12,15 +12,15 @@ module Dynamoid #:nodoc:
 
         return if object.nil?
 
-        source.update_attribute(source_attribute, Set[object.hash_key])
+        associate(object.hash_key)
         self.target = object
-        self.send(:associate_target, object) if target_association
+        object.send(target_association).associate(source.hash_key) if target_association
         object
       end
 
       def delete
-        self.send(:disassociate_target, target) if target && target_association
-        source.update_attribute(source_attribute, nil)
+        target.send(target_association).disassociate(source.hash_key) if target && target_association
+        disassociate
         target
       end
 
@@ -60,6 +60,14 @@ module Dynamoid #:nodoc:
         # This is needed to that ActiveSupport's #blank? and #present?
         # methods work as expected for SingleAssociations.
         target.nil?
+      end
+
+      def associate(hash_key)
+        source.update_attribute(source_attribute, Set[hash_key])
+      end
+
+      def disassociate(hash_key=nil)
+        source.update_attribute(source_attribute, nil)
       end
 
       private

--- a/spec/dynamoid/associations/belongs_to_spec.rb
+++ b/spec/dynamoid/associations/belongs_to_spec.rb
@@ -63,36 +63,124 @@ describe Dynamoid::Associations::BelongsTo do
     end
   end
 
-  describe '{association}=' do
+  describe 'assigning' do
     context 'has many' do
-      it 'stores the same object on this side' do
-        subscription = Subscription.create
-        magazine = Magazine.create
+      let(:subscription) { Subscription.create }
 
+      it 'associates model on this side' do
+        magazine = Magazine.create
         subscription.magazine = magazine
+
+        expect(subscription.magazine).to eq(magazine)
+      end
+
+      it 'associates model on that side' do
+        magazine = Magazine.create
+        subscription.magazine = magazine
+
+        expect(magazine.subscriptions.to_a).to eq([subscription])
+      end
+
+      it 're-associates model on this side' do
+        magazine_old = Magazine.create
+        magazine_new = Magazine.create
+        subscription.magazine = magazine_old
+
+        expect {
+          subscription.magazine = magazine_new
+        }.to change { subscription.magazine.target }.from(magazine_old).to(magazine_new)
+      end
+
+      it 're-associates model on that side' do
+        magazine_old = Magazine.create
+        magazine_new = Magazine.create
+        subscription.magazine = magazine_old
+
+        expect {
+          subscription.magazine = magazine_new
+        }.to change { magazine_new.subscriptions.target }.from([]).to([subscription])
+      end
+
+      it 'deletes previous model from association' do
+        magazine_old = Magazine.create
+        magazine_new = Magazine.create
+        subscription.magazine = magazine_old
+
+        expect {
+          subscription.magazine = magazine_new
+        }.to change { magazine_old.subscriptions.to_a }.from([subscription]).to([])
+      end
+
+      it 'stores the same object on this side' do
+        magazine = Magazine.create
+        subscription.magazine = magazine
+
         expect(subscription.magazine.target.object_id).to eq(magazine.object_id)
       end
 
       it 'does not store the same object on that side' do
-        subscription = Subscription.create
         magazine = Magazine.create
-
         subscription.magazine = magazine
+
         expect(magazine.subscriptions.target[0].object_id).to_not eq(subscription.object_id)
       end
     end
 
     context 'has one' do
-      it 'stores the same object on this side' do
-        sponsor = Sponsor.create
-        magazine = Magazine.create
+      let(:sponsor) { Sponsor.create }
 
+      it 'associates model on this side' do
+        magazine = Magazine.create
         sponsor.magazine = magazine
+
+        expect(sponsor.magazine).to eq(magazine)
+      end
+
+      it 'associates model on that side' do
+        magazine = Magazine.create
+        sponsor.magazine = magazine
+
+        expect(magazine.sponsor).to eq(sponsor)
+      end
+
+      it 're-associates model on this side' do
+        magazine_old = Magazine.create
+        magazine_new = Magazine.create
+        sponsor.magazine = magazine_old
+
+        expect {
+          sponsor.magazine = magazine_new
+        }.to change { sponsor.magazine.target }.from(magazine_old).to(magazine_new)
+      end
+
+      it 're-associates model on this side' do
+        magazine_old = Magazine.create
+        magazine_new = Magazine.create
+        sponsor.magazine = magazine_old
+
+        expect {
+          sponsor.magazine = magazine_new
+        }.to change { magazine_new.sponsor.target }.from(nil).to(sponsor)
+      end
+
+      it 'deletes previous model from association' do
+        magazine_old = Magazine.create
+        magazine_new = Magazine.create
+        sponsor.magazine = magazine_old
+
+        expect {
+          sponsor.magazine = magazine_new
+        }.to change { magazine_old.sponsor.target }.from(sponsor).to(nil)
+      end
+
+      it 'stores the same object on this side' do
+        magazine = Magazine.create
+        sponsor.magazine = magazine
+
         expect(sponsor.magazine.target.object_id).to eq(magazine.object_id)
       end
 
       it 'does not store the same object on that side' do
-        sponsor = Sponsor.create
         magazine = Magazine.create
 
         sponsor.magazine = magazine

--- a/spec/dynamoid/associations/has_and_belongs_to_many_spec.rb
+++ b/spec/dynamoid/associations/has_and_belongs_to_many_spec.rb
@@ -42,6 +42,21 @@ describe Dynamoid::Associations::HasAndBelongsToMany do
     expect(user.subscriptions.size).to eq 0
   end
 
+  describe 'assigning' do
+    let(:subscription) { Subscription.create }
+    let(:user) { User.create }
+
+    it 'associates model on this side' do
+      subscription.users << user
+      expect(subscription.users.to_a).to eq([user])
+    end
+
+    it 'associates model on that side' do
+      subscription.users << user
+      expect(user.subscriptions.to_a).to eq([subscription])
+    end
+  end
+
   describe '#delete' do
     it 'clears association on this side' do
       subscription = Subscription.create

--- a/spec/dynamoid/associations/has_many_spec.rb
+++ b/spec/dynamoid/associations/has_many_spec.rb
@@ -98,14 +98,13 @@ describe Dynamoid::Associations::HasMany do
     end
 
     it 'deletes previous model from association' do
-      skip 'it is a bug'
       magazine_old = Magazine.create
       magazine_new = Magazine.create
       magazine_old.subscriptions << subscription
 
       expect {
         magazine_new.subscriptions << subscription
-      }.to change { magazine_old.subscriptions.to_a }.from([subscription]).to([])
+      }.to change { Magazine.find(magazine_old.title).subscriptions.to_a }.from([subscription]).to([])
     end
   end
 

--- a/spec/dynamoid/associations/has_many_spec.rb
+++ b/spec/dynamoid/associations/has_many_spec.rb
@@ -63,6 +63,52 @@ describe Dynamoid::Associations::HasMany do
     expect(magazine.camel_cases.count).to eq 2
   end
 
+  describe 'assigning' do
+    let(:magazine) { Magazine.create }
+    let(:subscription) { Subscription.create }
+
+    it 'associates model on this side' do
+      magazine.subscriptions << subscription
+      expect(magazine.subscriptions.to_a).to eq([subscription])
+    end
+
+    it 'associates model on that side' do
+      magazine.subscriptions << subscription
+      expect(subscription.magazine).to eq(magazine)
+    end
+
+    it 're-associates new model on this side' do
+      magazine_old = Magazine.create
+      magazine_new = Magazine.create
+      magazine_old.subscriptions << subscription
+
+      expect {
+        magazine_new.subscriptions << subscription
+      }.to change { magazine_new.subscriptions.to_a }.from([]).to([subscription])
+    end
+
+    it 're-associates new model on that side' do
+      magazine_old = Magazine.create
+      magazine_new = Magazine.create
+      magazine_old.subscriptions << subscription
+
+      expect {
+        magazine_new.subscriptions << subscription
+      }.to change { subscription.magazine.target }.from(magazine_old).to(magazine_new)
+    end
+
+    it 'deletes previous model from association' do
+      skip 'it is a bug'
+      magazine_old = Magazine.create
+      magazine_new = Magazine.create
+      magazine_old.subscriptions << subscription
+
+      expect {
+        magazine_new.subscriptions << subscription
+      }.to change { magazine_old.subscriptions.to_a }.from([subscription]).to([])
+    end
+  end
+
   describe '#delete' do
     it 'clears association on this side' do
       magazine = Magazine.create

--- a/spec/dynamoid/associations/has_one_spec.rb
+++ b/spec/dynamoid/associations/has_one_spec.rb
@@ -50,21 +50,65 @@ describe Dynamoid::Associations::HasOne do
     expect(subscription.customer).to eq user
   end
 
-  describe '{association}=' do
+  describe 'assigning' do
     context 'belongs to' do
-      it 'stores the same object on this side' do
-        magazine = Magazine.create!
-        sponsor = Sponsor.create!
+      let(:magazine) { Magazine.create }
 
+      it 'associates model on this side' do
+        sponsor = Sponsor.create
         magazine.sponsor = sponsor
+
+        expect(magazine.sponsor).to eq(sponsor)
+      end
+
+      it 'associates model on that side' do
+        sponsor = Sponsor.create
+        magazine.sponsor = sponsor
+
+        expect(sponsor.magazine).to eq(magazine)
+      end
+
+      it 're-associates model on this side' do
+        sponsor_old = Sponsor.create
+        sponsor_new = Sponsor.create
+        magazine.sponsor = sponsor_old
+
+        expect {
+          magazine.sponsor = sponsor_new
+        }.to change { magazine.sponsor.target }.from(sponsor_old).to(sponsor_new)
+      end
+
+      it 're-associates model on that side' do
+        sponsor_old = Sponsor.create
+        sponsor_new = Sponsor.create
+
+        magazine.sponsor = sponsor_old
+        expect {
+          magazine.sponsor = sponsor_new
+        }.to change { sponsor_new.magazine.target }.from(nil).to(magazine)
+      end
+
+      it 'deletes previous model from association' do
+        sponsor_old = Sponsor.create
+        sponsor_new = Sponsor.create
+
+        magazine.sponsor = sponsor_old
+        expect {
+          magazine.sponsor = sponsor_new
+        }.to change { sponsor_old.magazine.target }.from(magazine).to(nil)
+      end
+
+      it 'stores the same object on this side' do
+        sponsor = Sponsor.create
+        magazine.sponsor = sponsor
+
         expect(magazine.sponsor.target.object_id).to eq(sponsor.object_id)
       end
 
       it 'does not store the same object on that side' do
-        magazine = Magazine.create!
         sponsor = Sponsor.create!
-
         magazine.sponsor = sponsor
+
         expect(sponsor.magazine.target.object_id).not_to eq(magazine.object_id)
       end
     end

--- a/spec/support/new_class_helper.rb
+++ b/spec/support/new_class_helper.rb
@@ -1,8 +1,8 @@
 module NewClassHelper
-  def new_class(&blk)
+  def new_class(table_name: nil, &blk)
     klass = Class.new do
       include Dynamoid::Document
-      table name: :documents
+      table name: (table_name || :documents)
     end
     klass.class_eval(&blk) if block_given?
     klass


### PR DESCRIPTION
Added `foreign_key` option.

Example:

```ruby
class User
  include Dynamoid::Document

  belongs_to :department, foreign_key: :office_id
end
```

By default foreign key (of `belongs_to` association) is stored in `"{name}_ids"` field as array of one element

`foreign_key` option allows to specify field name and store id of associated document as scalar (string/number/etc) value

Related issues: https://github.com/Dynamoid/Dynamoid/issues/129, https://github.com/Dynamoid/Dynamoid/issues/114