### PR TITLE
Support native boolean type

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,13 @@ The primary use case for using a custom field type is to represent your business
 The boolean fields are stored as `"t", "f"` strings by default. DynamoDB
 supports boolean type natively. So if you want to use native boolean
 type or already have table with native boolean attribute you can easily
-acheive this with `store_as_boolean` option:
+achieve this with `store_as_native_boolean` option:
 
 ```ruby
 class Document
   include DynamoId::Document
 
-  field :active, :boolean, store_as_boolean: true
+  field :active, :boolean, store_as_native_boolean: true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,23 @@ By default, fields are assumed to be of type ```:string```. Other built-in types
 If built-in types do not suit you, you can use a custom field type represented by an arbitrary class, provided that the class supports a compatible serialization interface.
 The primary use case for using a custom field type is to represent your business logic with high-level types, while ensuring portability or backward-compatibility of the serialized representation.
 
+#### Note on boolean type
+
+The boolean fields are stored as `"t", "f"` strings by default. DynamoDB
+supports boolean type natively. So if you want to use native boolean
+type or already have table with native boolean attribute you can easily
+acheive this with `store_as_boolean` option:
+
+```ruby
+class Document
+  include DynamoId::Document
+
+  field :active, :boolean, store_as_boolean: true
+end
+```
+
+#### Magic Columns
+
 You get magic columns of id (string), created_at (datetime), and updated_at (datetime) for free.
 
 ```ruby
@@ -154,12 +171,16 @@ class User
 end
 ```
 
+#### Default Values
+
 You can optionally set a default value on a field using either a plain value or a lambda:
 
 ```ruby
   field :actions_taken, :integer, {default: 0}
   field :joined_at, :datetime, {default: ->(){Time.now}}
 ```
+
+#### Custom Types
 
 To use a custom type for a field, suppose you have a `Money` type.
 
@@ -215,20 +236,8 @@ This is especially important if you want to use your custom field as a numeric r
 number-oriented queries.  By default custom fields are persisted as a string attribute, but
 your custom class can override this with a `.dynamoid_field_type` class method, which would
 return either `:string` or `:number`.
-(DynamoDB supports some other attribute types, but Dynamoid does not yet.)
 
-The boolean fields are stored as `"t", "f"` strings by default. DynamoDB
-supports boolean type natively. So if you want to use native boolean
-type or already have table with native boolean attribute you can easily
-archive this with `store_as_boolean` option:
-
-```ruby
-class Document
-  include DynamoId::Document
-
-  field :active, :boolean, store_as_boolean: true
-end
-```
+DynamoDB may support some other attribute types that are not yet supported by.
 
 ### Associations
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,18 @@ your custom class can override this with a `.dynamoid_field_type` class method, 
 return either `:string` or `:number`.
 (DynamoDB supports some other attribute types, but Dynamoid does not yet.)
 
+The boolean fields are stored as `"t", "f"` strings by default. DynamoDB
+supports boolean type natively. So if you want to use native boolean
+type or already have table with native boolean attribute you can easily
+archive this with `store_as_boolean` option:
+
+```ruby
+class Document
+  include DynamoId::Document
+
+  field :active, :boolean, store_as_boolean: true
+end
+```
 
 ### Associations
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ number-oriented queries.  By default custom fields are persisted as a string att
 your custom class can override this with a `.dynamoid_field_type` class method, which would
 return either `:string` or `:number`.
 
-DynamoDB may support some other attribute types that are not yet supported by.
+DynamoDB may support some other attribute types that are not yet supported by Dynamoid.
 
 ### Associations
 

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -138,7 +138,6 @@ module Dynamoid
                   UNIX_EPOCH_DATE + value.to_i
                 end
               when :boolean
-                # persisted as 't', but because undump is called during initialize it can come in as true
                 if value == 't' || value == true
                   true
                 elsif value == 'f' || value == false
@@ -183,7 +182,15 @@ module Dynamoid
             when :raw
               !value.nil? ? value : nil
             when :boolean
-              !value.nil? ? value.to_s[0] : nil
+              if !value.nil?
+                if options[:store_as_boolean]
+                  !!value # native boolean type
+                else
+                  value.to_s[0] # => "f" or "t"
+                end
+              else
+                nil
+              end
             else
               raise ArgumentError, "Unknown type #{options[:type]}"
           end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -183,7 +183,7 @@ module Dynamoid
               !value.nil? ? value : nil
             when :boolean
               if !value.nil?
-                if options[:store_as_boolean]
+                if options[:store_as_native_boolean]
                   !!value # native boolean type
                 else
                   value.to_s[0] # => "f" or "t"

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -382,7 +382,7 @@ describe Dynamoid::Persistence do
     context "stored in boolean format" do
       let(:klass) do
         new_class do
-          field :active, :boolean, store_as_boolean: true
+          field :active, :boolean, store_as_native_boolean: true
         end
       end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -346,6 +346,68 @@ describe Dynamoid::Persistence do
     end
   end
 
+  describe "Boolean field" do
+    context "stored in string format" do
+      let(:klass) do
+        new_class do
+          field :active, :boolean
+        end
+      end
+
+      it "saves false as 'f'" do
+        obj = klass.create(active: false)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:active]).to eq "f"
+      end
+
+      it "saves 'f' as 'f'" do
+        obj = klass.create(active: "f")
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:active]).to eq "f"
+      end
+
+      it "saves true as 't'" do
+        obj = klass.create(active: true)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:active]).to eq "t"
+      end
+
+      it "saves 't' as 't'" do
+        obj = klass.create(active: 't')
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:active]).to eq "t"
+      end
+    end
+
+    context "stored in boolean format" do
+      let(:klass) do
+        new_class do
+          field :active, :boolean, store_as_boolean: true
+        end
+      end
+
+      it "saves false as false" do
+        obj = klass.create(active: false)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:active]).to eq false
+      end
+
+      it "saves true as true" do
+        obj = klass.create(active: true)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:active]).to eq true
+      end
+
+      it "saves and loads boolean field correctly" do
+        obj = klass.create(active: true)
+        expect(klass.find(obj.hash_key).active).to eq true
+
+        obj = klass.create(active: false)
+        expect(klass.find(obj.hash_key).active).to eq false
+      end
+    end
+  end
+
   it 'raises on an invalid boolean value' do
     expect do
       address.deliverable = true


### PR DESCRIPTION
Related issue https://github.com/Dynamoid/Dynamoid/issues/135

Add `store_as_boolean` option to store boolean field as `true`/`false` instead of `"t"`/`"f"`

Example

```ruby
field :active, :boolean, store_as_native_boolean: true
```

It isn't a breaking change and default behaviour isn't changed
