### PR TITLE
Fix global index detection

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -294,7 +294,7 @@ module Dynamoid #:nodoc:
         # But only do so if projects ALL attributes otherwise we won't
         # get back full data
         source.global_secondary_indexes.each do |_, gsi|
-          next unless query_keys.include?(gsi.hash_key.to_s) && gsi.projected_attributes == :all
+          next unless query.keys.map(&:to_s).include?(gsi.hash_key.to_s) && gsi.projected_attributes == :all
           @hash_key = gsi.hash_key
           @range_key = gsi.range_key
           @index_name = gsi.name

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -604,6 +604,15 @@ describe Dynamoid::Criteria::Chain do
         expect(chain).to receive(:records_via_query).and_call_original
         expect(chain.where(city: 'San Francisco').start(@customer2).all).to contain_exactly(@customer3)
       end
+
+      it "does not use index if a condition for index hash key is other than 'equal'" do
+        chain = Dynamoid::Criteria::Chain.new(model)
+        expect(chain).to receive(:records_via_scan).and_call_original
+        expect(chain.where('city.begins_with' => 'San').count).to eq(3)
+        expect(chain.hash_key).to be_nil
+        expect(chain.range_key).to be_nil
+        expect(chain.index_name).to be_nil
+      end
     end
 
     it 'supports query on global secondary index with correct start key without table range key' do


### PR DESCRIPTION
Fix issue with incorrect using of global secondary index.

```ruby
class Message
  include Dynamoid::Document

  table key: :guid
  field :message_thread_guid

  global_secondary_index hash_key: :message_thread_guid, projected_attributes: :all
end
```

Querying with condition other than "equal" for hash-key of some index 

```ruby
Message.where('message_thread_guid.in' => ['1', '2']).to_a
```
leads to "Aws::DynamoDB::Errors::ValidationException: One or more parameter values were invalid: Condition parameter type does not match schema type" error

