### PR TITLE
Failing spec for filtering in sets

### DIFF
--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -326,6 +326,8 @@ describe Dynamoid::Criteria::Chain do
         table name: :customer
         field :age, :integer
         field :job_title, :string
+        field :skill_list, :array
+        field :skill_set, :set
       end
     }
 
@@ -406,6 +408,22 @@ describe Dynamoid::Criteria::Chain do
 
       expect(model.where('job_title.contains' => 'Consul').all)
         .to contain_exactly(customer1, customer3)
+    end
+
+    it 'support contains for array' do
+      customer1 = model.create(job_title: 'Environmental Air Quality Consultant', skill_list: [1, 'ruby'])
+      customer2 = model.create(job_title: 'Creative Consultant')
+
+      expect(model.where('skill_list.contains' => 'ruby').all)
+        .to contain_exactly(customer1)
+    end
+
+    it 'support contains for set' do
+      customer1 = model.create(job_title: 'Environmental Air Quality Consultant', skill_set: Set.new(['ruby']))
+      customer2 = model.create(job_title: 'Creative Consultant')
+
+      expect(model.where('skill_set.contains' => 'ruby').all)
+        .to contain_exactly(customer1)
     end
 
     it 'supports not_contains' do


### PR DESCRIPTION
Wrote a quick failing spec highlighting some problems I ran into when using Set

I don't understand why it passes for Array but not for Set, but thought I'd throw this here to get some quick guidance. 
 
I get this error on running the spec: 

```
Dynamoid::Criteria::Chain
  Scan conditions
    support contains for set (FAILED - 1)

Failures:

  1) Dynamoid::Criteria::Chain Scan conditions  support contains for set
     Failure/Error: !value.nil? ? Set.new(value) : nil
     
     ArgumentError:
       value must be enumerable
     # ./lib/dynamoid/persistence.rb:173:in `new'
     # ./lib/dynamoid/persistence.rb:173:in `dump_field'
     # ./lib/dynamoid/criteria/chain.rb:262:in `type_cast_condition_parameter'
     # ./lib/dynamoid/criteria/chain.rb:196:in `field_hash'
     # ./lib/dynamoid/criteria/chain.rb:346:in `block (2 levels) in scan_query'
     # ./lib/dynamoid/criteria/chain.rb:344:in `each'
     # ./lib/dynamoid/criteria/chain.rb:344:in `block in scan_query'
     # ./lib/dynamoid/criteria/chain.rb:343:in `tap'
     # ./lib/dynamoid/criteria/chain.rb:343:in `scan_query'
     # ./lib/dynamoid/criteria/chain.rb:168:in `block in records_via_scan'
     # ./spec/dynamoid/criteria/chain_spec.rb:425:in `block (3 levels) in <top (required)>'

```

This pr will probably be closed on fixing this error, as this is unlikely to be the right place for this spec but thought it might help. 