### PR TITLE
Implement fixed datatype for elements in set

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -117,7 +117,7 @@ module Dynamoid
                   value
                 end
               when :set
-                Set.new(value)
+                undump_set(options, value)
               when :datetime
                 parse_datetime(value, options)
               when :date
@@ -138,6 +138,17 @@ module Dynamoid
                 raise ArgumentError, "Unknown type #{options[:type]}"
             end
           end
+        end
+      end
+
+      def undump_set(options, value)
+        case options[:of]
+        when :integer
+          value.map { |v| Integer(v) }.to_set
+        when :number
+          value.map { |v| BigDecimal.new(v.to_s) }.to_set
+        else
+          value.is_a?(Set) ? value : Set.new(value)
         end
       end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -454,6 +454,31 @@ describe Dynamoid::Persistence do
     end
   end
 
+  describe "Set field" do
+    let(:klass) do
+      new_class do
+        field :string_set, :set
+        field :integer_set, :set, { of: :integer }
+        field :number_set, :set, { of: :number }
+      end
+    end
+
+    it "stored a string set" do
+      obj = klass.create(string_set: Set.new(['a','b']))
+      expect(obj.reload[:string_set]).to eq(Set.new(['a','b']))
+    end
+
+    it "stored an integer set" do
+      obj = klass.create(integer_set: Set.new([1,2]))
+      expect(obj.reload[:integer_set]).to eq(Set.new([1,2]))
+    end
+
+    it "stored a number set" do
+      obj = klass.create(number_set: Set.new([1,2]))
+      expect(obj.reload[:number_set]).to eq(Set.new([BigDecimal(1),BigDecimal(2)]))
+    end
+  end
+
   it 'raises on an invalid boolean value' do
     expect do
       address.deliverable = true


### PR DESCRIPTION
Currently a set of integers stored in a set, returns a set of big decimal numbers.
```
model = Class.new do
  include Dynamoid::Document
  table name: :customer
  field :tag_ids, :set
end

model.create(tag_ids: Set.new([1,2]))

model.tag_ids => A set of Big Decimal numbers
```

This pr allows you to add a set_collection_type, and if integer is specified, it will return a set of integers. 

```
model = Class.new do
  include Dynamoid::Document
  table name: :customer
  field :tag_ids, :set, { of: :integer }
end

model.create(tag_ids: Set.new([1,2]))

model.tag_ids => Set.new(1,2)
```



