### PR TITLE
Add option to store datetimes as ISO-8601 formatted strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,13 +166,13 @@ end
 
 #### Note on datetime type
 
-By default datetime fields are persisted as UNIX timestamps with milisecond precission in DynamoDB. If you prefer datetimes to be stored as ISO-8601 formatted strings instead then set `convert_date_to_string` to `true`
+By default datetime fields are persisted as UNIX timestamps with milisecond precission in DynamoDB. If you prefer datetimes to be stored as ISO-8601 formatted strings instead then set `store_as_native_string` to `true`
 
 ```ruby
 class Document
   include DynamoId::Document
 
-  field :sent_at, :datetime, convert_date_to_string: true
+  field :sent_at, :datetime, store_as_native_string: true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Listed below are all configuration options.
 * `sync_retry_max_times` - when Dynamoid creates or deletes table synchronously it checks for completion specified times. Default is 60 (times). It's a bit over 2 minutes by default
 * `sync_retry_wait_seconds` - time to wait between retries. Default is 2 (seconds)
 * `convert_big_decimal` - if `true` then Dynamoid converts numbers stored in `Hash` in `raw` field to float. Default is `false`
-* `convert_date_to_string` - if `true`, datetimes will be stores as ISO-8601 formatted strings. When `false`, datetimes will be stores as UNIX timestamps with milisecond precission. Defaule is `false`
+* `convert_date_to_string` - if `true`, datetimes will be stores as ISO-8601 formatted strings. When `false`, datetimes will be stores as UNIX timestamps with milisecond precission. Default is `false`
 * `models_dir` - `dynamoid:create_tables` rake task loads DynamoDb models from this directory. Default is `app/models`. In Rails application you should set `./app/models` value
 * `application_timezone` - Dynamoid converts all `datetime` fields to specified time zone when loads data from the storage.
   Acceptable values - `utc`, `local` (to use system time zone) and time zone name e.g. `Eastern Time (US & Canada)`. Default is `local`

--- a/README.md
+++ b/README.md
@@ -164,6 +164,18 @@ class Document
 end
 ```
 
+#### Note on datetime type
+
+By default datetime fields are persisted as UNIX timestamps with milisecond precission in DynamoDB. If you prefer datetimes to be stored as ISO-8601 formatted strings instead then set `convert_date_to_string` to `true`
+
+```ruby
+class Document
+  include DynamoId::Document
+
+  field :sent_at, :datetime, convert_date_to_string: true
+end
+```
+
 #### Magic Columns
 
 You get magic columns of id (string), created_at (datetime), and updated_at (datetime) for free.
@@ -598,7 +610,6 @@ Listed below are all configuration options.
 * `sync_retry_max_times` - when Dynamoid creates or deletes table synchronously it checks for completion specified times. Default is 60 (times). It's a bit over 2 minutes by default
 * `sync_retry_wait_seconds` - time to wait between retries. Default is 2 (seconds)
 * `convert_big_decimal` - if `true` then Dynamoid converts numbers stored in `Hash` in `raw` field to float. Default is `false`
-* `convert_date_to_string` - if `true`, datetimes will be stores as ISO-8601 formatted strings. When `false`, datetimes will be stores as UNIX timestamps with milisecond precission. Default is `false`
 * `models_dir` - `dynamoid:create_tables` rake task loads DynamoDb models from this directory. Default is `app/models`. In Rails application you should set `./app/models` value
 * `application_timezone` - Dynamoid converts all `datetime` fields to specified time zone when loads data from the storage.
   Acceptable values - `utc`, `local` (to use system time zone) and time zone name e.g. `Eastern Time (US & Canada)`. Default is `local`

--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ Listed below are all configuration options.
 * `sync_retry_max_times` - when Dynamoid creates or deletes table synchronously it checks for completion specified times. Default is 60 (times). It's a bit over 2 minutes by default
 * `sync_retry_wait_seconds` - time to wait between retries. Default is 2 (seconds)
 * `convert_big_decimal` - if `true` then Dynamoid converts numbers stored in `Hash` in `raw` field to float. Default is `false`
+* `convert_date_to_string` - if `true`, datetimes will be stores as ISO-8601 formatted strings. When `false`, datetimes will be stores as UNIX timestamps with milisecond precission. Defaule is `false`
 * `models_dir` - `dynamoid:create_tables` rake task loads DynamoDb models from this directory. Default is `app/models`. In Rails application you should set `./app/models` value
 * `application_timezone` - Dynamoid converts all `datetime` fields to specified time zone when loads data from the storage.
   Acceptable values - `utc`, `local` (to use system time zone) and time zone name e.g. `Eastern Time (US & Canada)`. Default is `local`

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -26,7 +26,6 @@ module Dynamoid
     option :sync_retry_max_times, default: 60 # a bit over 2 minutes
     option :sync_retry_wait_seconds, default: 2
     option :convert_big_decimal, default: false
-    option :convert_date_to_string, default: false
     option :models_dir, default: 'app/models' # perhaps you keep your dynamoid models in a different directory?
     option :application_timezone, default: :local # available values - :utc, :local, time zone names
 

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -26,6 +26,7 @@ module Dynamoid
     option :sync_retry_max_times, default: 60 # a bit over 2 minutes
     option :sync_retry_wait_seconds, default: 2
     option :convert_big_decimal, default: false
+    option :convert_date_to_string, default: false
     option :models_dir, default: 'app/models' # perhaps you keep your dynamoid models in a different directory?
     option :application_timezone, default: :local # available values - :utc, :local, time zone names
 

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -197,7 +197,7 @@ module Dynamoid
               :string
             else
               raise 'unknown type'
-            end
+          end
         end
       end
 

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -240,13 +240,13 @@ module Dynamoid
       end
 
       def format_datetime(value, options)
-        options[:convert_date_to_string] ? value.iso8601 : value.to_time.to_f
+        options[:store_as_native_string] ? value.iso8601 : value.to_time.to_f
       end
 
       def parse_datetime(value, options)
         return value if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)
 
-        value = DateTime.iso8601(value).to_time.to_i if options[:convert_date_to_string]
+        value = DateTime.iso8601(value).to_time.to_i if options[:store_as_native_string]
         case Dynamoid::Config.application_timezone
           when :utc
             ActiveSupport::TimeZone['UTC'].at(value).to_datetime

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -233,46 +233,27 @@ describe Dynamoid::Persistence do
   end
 
   context 'when dumps datetime attribute' do
-    shared_examples 'dump_datetime_attributes' do
-      it 'loads time in local time zone if config.application_timezone == :local', application_timezone: :local do
-        time = Time.now
-        user = User.create(last_logged_in_at: time)
-        user = User.find(user.id)
-        expect(user.last_logged_in_at).to be_a(DateTime)
-        # we can't compare objects directly because lose precision of milliseconds in conversions
-        expect(user.last_logged_in_at.to_s).to eq time.to_datetime.to_s
-      end
-
-      it 'loads time in specified time zone if config.application_timezone == time zone name', application_timezone: 'Hawaii' do
-        time = '2017-06-20 08:00:00 +0300'.to_time
-        user = User.create(last_logged_in_at: time)
-        user = User.find(user.id)
-        expect(user.last_logged_in_at).to eq '2017-06-19 19:00:00 -1000'.to_datetime # Hawaii UTC-10
-      end
-
-      it 'loads time in UTC if config.application_timezone = :utc', convert_date_to_string: :true do
-        time = '2017-06-20 08:00:00 +0300'.to_time
-        user = User.create(last_logged_in_at: time)
-        user = User.find(user.id)
-        expect(user.last_logged_in_at).to eq '2017-06-20 05:00:00 +0000'.to_datetime
-      end
+    it 'loads time in local time zone if config.application_timezone == :local', application_timezone: :local do
+      time = Time.now
+      user = User.create(last_logged_in_at: time)
+      user = User.find(user.id)
+      expect(user.last_logged_in_at).to be_a(DateTime)
+      # we can't compare objects directly because lose precision of milliseconds in conversions
+      expect(user.last_logged_in_at.to_s).to eq time.to_datetime.to_s
     end
 
-    include_examples 'dump_datetime_attributes'
+    it 'loads time in specified time zone if config.application_timezone == time zone name', application_timezone: 'Hawaii' do
+      time = '2017-06-20 08:00:00 +0300'.to_time
+      user = User.create(last_logged_in_at: time)
+      user = User.find(user.id)
+      expect(user.last_logged_in_at).to eq '2017-06-19 19:00:00 -1000'.to_datetime # Hawaii UTC-10
+    end
 
-    context 'when convert_date_to_string == true' do
-      before { Dynamoid::Config.convert_date_to_string = true }
-      after { Dynamoid::Config.convert_date_to_string = false }
-
-      include_examples 'dump_datetime_attributes'
-
-      it 'dumps datetime as a string' do
-        time = '2017-06-20 08:00:00 +0300'.to_time
-        user = User.create(last_logged_in_at: time)
-        user = User.find(user.id)
-        expect(user.dump[:last_logged_in_at]).to be_a(String)
-        expect(user.dump[:last_logged_in_at]).to eq '2017-06-20T05:00:00+00:00'
-      end
+    it 'loads time in UTC if config.application_timezone = :utc', application_timezone: :utc do
+      time = '2017-06-20 08:00:00 +0300'.to_time
+      user = User.create(last_logged_in_at: time)
+      user = User.find(user.id)
+      expect(user.last_logged_in_at).to eq '2017-06-20 05:00:00 +0000'.to_datetime
     end
   end
 
@@ -423,6 +404,52 @@ describe Dynamoid::Persistence do
 
         obj = klass.create(active: false)
         expect(klass.find(obj.hash_key).active).to eq false
+      end
+    end
+  end
+
+  describe "Datetime field" do
+    context "Stored in :number format" do
+      let(:klass) do
+        new_class do
+          field :sent_at, :datetime
+        end
+      end
+
+      it "saves time as :number" do
+        time = Time.now
+        obj = klass.create(sent_at: time)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:sent_at]).to eq BigDecimal.new(time.to_f.to_s)
+      end
+
+      it "saves date as :number" do
+        date = Date.today
+        obj = klass.create(sent_at: date)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:sent_at]).to eq BigDecimal.new(date.to_time.to_f.to_s)
+      end
+    end
+
+    context "Stored in :string format" do
+      let(:klass) do
+        new_class do
+          field :sent_at, :datetime, { convert_date_to_string: true }
+        end
+      end
+
+      it "saves time as a :string" do
+        time = Time.now
+        obj = klass.create(sent_at: time)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:sent_at]).to eq time.iso8601
+      end
+
+      it "saves date as :string" do
+        date = Date.today
+        obj = klass.create(sent_at: date)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:sent_at]).to eq date.iso8601
       end
     end
   end

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -434,7 +434,7 @@ describe Dynamoid::Persistence do
     context "Stored in :string format" do
       let(:klass) do
         new_class do
-          field :sent_at, :datetime, { convert_date_to_string: true }
+          field :sent_at, :datetime, { store_as_native_string: true }
         end
       end
 


### PR DESCRIPTION
Currently datetimes are stored in DynamoDB as `:number` (UNIX timestamps)

This pr add the option to store these timestamps as `:string` (ISO 8601)

Reference: 
> https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBMapper.DataTypes.html
> Date (as ISO_8601 millisecond-precision string, shifted to UTC)