### PR TITLE
Disable type conversion for Set and Array condition values

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -258,6 +258,8 @@ module Dynamoid #:nodoc:
       end
 
       def type_cast_condition_parameter(key, value)
+        return value if [:array, :set].include?(source.attributes[key.to_sym][:type])
+
         if !value.respond_to?(:to_ary)
           source.dump_field(value, source.attributes[key.to_sym])
         else

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -408,6 +408,30 @@ describe Dynamoid::Criteria::Chain do
         .to contain_exactly(customer1, customer3)
     end
 
+    it 'supports contains for set' do
+      klass = new_class do
+        field :set, :set
+      end
+      document1 = klass.create(set: ['a', 'b'])
+      document2 = klass.create(set: ['b', 'c'])
+
+      expect(klass.where('set.contains' => 'a').all).to contain_exactly(document1)
+      expect(klass.where('set.contains' => 'b').all).to contain_exactly(document1, document2)
+      expect(klass.where('set.contains' => 'c').all).to contain_exactly(document2)
+    end
+
+    it 'supports contains for array' do
+      klass = new_class do
+        field :array, :array
+      end
+      document1 = klass.create(array: ['a', 'b'])
+      document2 = klass.create(array: ['b', 'c'])
+
+      expect(klass.where('array.contains' => 'a').all).to contain_exactly(document1)
+      expect(klass.where('array.contains' => 'b').all).to contain_exactly(document1, document2)
+      expect(klass.where('array.contains' => 'c').all).to contain_exactly(document2)
+    end
+
     it 'supports not_contains' do
       customer1 = model.create(job_title: 'Environmental Air Quality Consultant')
       customer2 = model.create(job_title: 'Environmental Project Manager')


### PR DESCRIPTION
Fix `contains` operator for `set` fields

Example:
`Document.where("set.contains" => "foo").all`

Related issue https://github.com/Dynamoid/Dynamoid/issues/220