### PR TITLE
Fix equal conditions for collection fields

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -497,14 +497,12 @@ module Dynamoid
 
         key_conditions = {
           hk => {
-            # TODO: Provide option for other operators like NE, IN, LE, etc
             comparison_operator: EQ,
             attribute_value_list: attribute_value_list(EQ, opts.delete(:hash_value).freeze)
           }
         }
 
         opts.each_pair do |k, v|
-          # TODO: ATM, only few comparison operators are supported, provide support for all operators
           next unless(op = RANGE_MAP[k])
           key_conditions[rng] = {
             comparison_operator: op,


### PR DESCRIPTION
Fix `EQ` condition for `array` fields for both `Scan` and `Query` requests.

E.g `where(array: [1, 2, 3])` leads to exception:

```
Aws::DynamoDB::Errors::ValidationException:
  One or more parameter values were invalid: Invalid number of argument(s) for the EQ ComparisonOperator
```