### PR TITLE
Store dates as ISO-8601 formatted strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,18 @@ class Document
 end
 ```
 
+#### Note on date type
+
+By default date fields are persisted as days count since 1 January 1970 like UNIX time. If you prefer dates to be stored as ISO-8601 formatted strings instead then set `store_as_string` to `true`
+
+```ruby
+class Document
+  include DynamoId::Document
+
+  field :sent_at, :datetime, store_as_string: true
+end
+```
+
 #### Note on datetime type
 
 By default datetime fields are persisted as UNIX timestamps with milisecond precission in DynamoDB. If you prefer datetimes to be stored as ISO-8601 formatted strings instead then set `store_as_string` to `true`
@@ -613,6 +625,8 @@ Listed below are all configuration options.
 * `models_dir` - `dynamoid:create_tables` rake task loads DynamoDb models from this directory. Default is `app/models`. In Rails application you should set `./app/models` value
 * `application_timezone` - Dynamoid converts all `datetime` fields to specified time zone when loads data from the storage.
   Acceptable values - `utc`, `local` (to use system time zone) and time zone name e.g. `Eastern Time (US & Canada)`. Default is `local`
+* `store_datetime_as_string` - if `true` then Dynamoid stores :datetime fields in ISO 8601 string format. Default is `false`
+* `store_date_as_string` - if `true` then Dynamoid stores :date fields in ISO 8601 string format. Default is `false`
 
 
 ## Concurrency

--- a/README.md
+++ b/README.md
@@ -166,13 +166,13 @@ end
 
 #### Note on datetime type
 
-By default datetime fields are persisted as UNIX timestamps with milisecond precission in DynamoDB. If you prefer datetimes to be stored as ISO-8601 formatted strings instead then set `store_as_native_string` to `true`
+By default datetime fields are persisted as UNIX timestamps with milisecond precission in DynamoDB. If you prefer datetimes to be stored as ISO-8601 formatted strings instead then set `store_as_string` to `true`
 
 ```ruby
 class Document
   include DynamoId::Document
 
-  field :sent_at, :datetime, store_as_native_string: true
+  field :sent_at, :datetime, store_as_string: true
 end
 ```
 

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -28,6 +28,7 @@ module Dynamoid
     option :convert_big_decimal, default: false
     option :models_dir, default: 'app/models' # perhaps you keep your dynamoid models in a different directory?
     option :application_timezone, default: :local # available values - :utc, :local, time zone names
+    option :store_date_as_string, default: false # store Date fields in ISO 8601 string format
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.
     #

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -28,6 +28,7 @@ module Dynamoid
     option :convert_big_decimal, default: false
     option :models_dir, default: 'app/models' # perhaps you keep your dynamoid models in a different directory?
     option :application_timezone, default: :local # available values - :utc, :local, time zone names
+    option :store_datetime_as_string, default: false # store Time fields in ISO 8601 string format
     option :store_date_as_string, default: false # store Date fields in ISO 8601 string format
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -255,7 +255,7 @@ module Dynamoid
           ? Dynamoid.config.store_datetime_as_string \
           : options[:store_as_string]
 
-        use_string_format ? value.iso8601 : value.to_time.to_f
+        use_string_format ? value.to_time.iso8601 : value.to_time.to_f
       end
 
       def format_date(value, options)

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -124,7 +124,7 @@ module Dynamoid
                 if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)
                   value.to_date
                 else
-                  UNIX_EPOCH_DATE + value.to_i
+                  parse_date(value, options)
                 end
               when :boolean
                 if value == 't' || value == true
@@ -176,7 +176,7 @@ module Dynamoid
             when :datetime
               !value.nil? ? format_datetime(value, options) : nil
             when :date
-              !value.nil? ? (value.to_date - UNIX_EPOCH_DATE).to_i : nil
+              !value.nil? ? format_date(value, options) : nil
             when :serialized
               options[:serializer] ? options[:serializer].dump(value) : value.to_yaml
             when :raw
@@ -254,6 +254,14 @@ module Dynamoid
         options[:store_as_native_string] ? value.iso8601 : value.to_time.to_f
       end
 
+      def format_date(value, options)
+        unless options[:store_as_native_string]
+          (value.to_date - UNIX_EPOCH_DATE).to_i
+        else
+          value.to_date.iso8601
+        end
+      end
+
       def parse_datetime(value, options)
         return value if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)
 
@@ -265,6 +273,14 @@ module Dynamoid
             Time.at(value).to_datetime
           when String
             ActiveSupport::TimeZone[Dynamoid::Config.application_timezone].at(value).to_datetime
+        end
+      end
+
+      def parse_date(value, options)
+        unless options[:store_as_native_string]
+          UNIX_EPOCH_DATE + value.to_i
+        else
+          Date.iso8601(value)
         end
       end
 

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -251,17 +251,17 @@ module Dynamoid
       end
 
       def format_datetime(value, options)
-        use_string_format = options[:store_as_native_string].nil? \
+        use_string_format = options[:store_as_string].nil? \
           ? Dynamoid.config.store_datetime_as_string \
-          : options[:store_as_native_string]
+          : options[:store_as_string]
 
         use_string_format ? value.iso8601 : value.to_time.to_f
       end
 
       def format_date(value, options)
-        use_string_format = options[:store_as_native_string].nil? \
+        use_string_format = options[:store_as_string].nil? \
           ? Dynamoid.config.store_date_as_string \
-          : options[:store_as_native_string]
+          : options[:store_as_string]
 
         unless use_string_format
           (value.to_date - UNIX_EPOCH_DATE).to_i
@@ -273,9 +273,9 @@ module Dynamoid
       def parse_datetime(value, options)
         return value if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)
 
-        use_string_format = options[:store_as_native_string].nil? \
+        use_string_format = options[:store_as_string].nil? \
           ? Dynamoid.config.store_datetime_as_string \
-          : options[:store_as_native_string]
+          : options[:store_as_string]
         value = DateTime.iso8601(value).to_time.to_i if use_string_format
 
         case Dynamoid::Config.application_timezone
@@ -289,9 +289,9 @@ module Dynamoid
       end
 
       def parse_date(value, options)
-        use_string_format = options[:store_as_native_string].nil? \
+        use_string_format = options[:store_as_string].nil? \
           ? Dynamoid.config.store_date_as_string \
-          : options[:store_as_native_string]
+          : options[:store_as_string]
 
         unless use_string_format
           UNIX_EPOCH_DATE + value.to_i

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -255,7 +255,11 @@ module Dynamoid
       end
 
       def format_date(value, options)
-        unless options[:store_as_native_string]
+        use_string_format = options[:store_as_native_string].nil? \
+          ? Dynamoid.config.store_date_as_string \
+          : options[:store_as_native_string]
+
+        unless use_string_format
           (value.to_date - UNIX_EPOCH_DATE).to_i
         else
           value.to_date.iso8601
@@ -277,7 +281,11 @@ module Dynamoid
       end
 
       def parse_date(value, options)
-        unless options[:store_as_native_string]
+        use_string_format = options[:store_as_native_string].nil? \
+          ? Dynamoid.config.store_date_as_string \
+          : options[:store_as_native_string]
+
+        unless use_string_format
           UNIX_EPOCH_DATE + value.to_i
         else
           Date.iso8601(value)

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -251,7 +251,11 @@ module Dynamoid
       end
 
       def format_datetime(value, options)
-        options[:store_as_native_string] ? value.iso8601 : value.to_time.to_f
+        use_string_format = options[:store_as_native_string].nil? \
+          ? Dynamoid.config.store_datetime_as_string \
+          : options[:store_as_native_string]
+
+        use_string_format ? value.iso8601 : value.to_time.to_f
       end
 
       def format_date(value, options)
@@ -269,7 +273,11 @@ module Dynamoid
       def parse_datetime(value, options)
         return value if value.is_a?(Date) || value.is_a?(DateTime) || value.is_a?(Time)
 
-        value = DateTime.iso8601(value).to_time.to_i if options[:store_as_native_string]
+        use_string_format = options[:store_as_native_string].nil? \
+          ? Dynamoid.config.store_datetime_as_string \
+          : options[:store_as_native_string]
+        value = DateTime.iso8601(value).to_time.to_i if use_string_format
+
         case Dynamoid::Config.application_timezone
           when :utc
             ActiveSupport::TimeZone['UTC'].at(value).to_datetime

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -449,7 +449,7 @@ describe Dynamoid::Persistence do
         date = Date.today
         obj = klass.create(sent_at: date)
         attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
-        expect(attributes[:sent_at]).to eq date.iso8601
+        expect(attributes[:sent_at]).to eq date.to_time.iso8601
       end
 
       it 'saves as :string if global option :store_date_time_as_string is true' do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -434,7 +434,7 @@ describe Dynamoid::Persistence do
     context "Stored in :string format" do
       let(:klass) do
         new_class do
-          field :sent_at, :datetime, { store_as_native_string: true }
+          field :sent_at, :datetime, { store_as_string: true }
         end
       end
 
@@ -486,7 +486,7 @@ describe Dynamoid::Persistence do
     context 'stored in :string format' do
       it 'stores in ISO 8601 format' do
         klass = new_class do
-          field :signed_up_on, :date, store_as_native_string: true
+          field :signed_up_on, :date, store_as_string: true
         end
 
         model = klass.create(signed_up_on: '25-09-2017'.to_date)
@@ -513,7 +513,7 @@ describe Dynamoid::Persistence do
 
       it 'prioritize field option over global one' do
         klass = new_class do
-          field :signed_up_on, :date, store_as_native_string: true
+          field :signed_up_on, :date, store_as_string: true
         end
 
         store_date_as_string = Dynamoid.config.store_date_as_string

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -454,6 +454,22 @@ describe Dynamoid::Persistence do
     end
   end
 
+  describe 'Date field' do
+    context 'stored in :string format' do
+      it 'stores in ISO 8601 format' do
+        klass = new_class do
+          field :signed_up_on, :date, store_as_native_string: true
+        end
+
+        model = klass.create(signed_up_on: '25-09-2017'.to_date)
+        expect(klass.find(model.id).signed_up_on).to eq('25-09-2017'.to_date)
+
+        attributes = Dynamoid.adapter.get_item(klass.table_name, model.id)
+        expect(attributes[:signed_up_on]).to eq '2017-09-25'
+      end
+    end
+  end
+
   describe "Set field" do
     let(:klass) do
       new_class do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -451,6 +451,34 @@ describe Dynamoid::Persistence do
         attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
         expect(attributes[:sent_at]).to eq date.iso8601
       end
+
+      it 'saves as :string if global option :store_date_time_as_string is true' do
+        klass2 = new_class do
+          field :sent_at, :datetime
+        end
+
+        store_datetime_as_string = Dynamoid.config.store_datetime_as_string
+        Dynamoid.config.store_datetime_as_string = true
+
+        time = Time.now
+        obj = klass2.create(sent_at: time)
+        attributes = Dynamoid.adapter.get_item(klass2.table_name, obj.hash_key)
+        expect(attributes[:sent_at]).to eq time.iso8601
+
+        Dynamoid.config.store_datetime_as_string = store_datetime_as_string
+      end
+
+      it 'prioritize field option over global one' do
+        store_datetime_as_string = Dynamoid.config.store_datetime_as_string
+        Dynamoid.config.store_datetime_as_string = false
+
+        time = Time.now
+        obj = klass.create(sent_at: time)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, obj.hash_key)
+        expect(attributes[:sent_at]).to eq time.iso8601
+
+        Dynamoid.config.store_datetime_as_string = store_datetime_as_string
+      end
     end
   end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -467,6 +467,36 @@ describe Dynamoid::Persistence do
         attributes = Dynamoid.adapter.get_item(klass.table_name, model.id)
         expect(attributes[:signed_up_on]).to eq '2017-09-25'
       end
+
+      it 'stores in string format when global option :store_date_as_string is true' do
+        klass = new_class do
+          field :signed_up_on, :date
+        end
+
+        store_date_as_string = Dynamoid.config.store_date_as_string
+        Dynamoid.config.store_date_as_string = true
+
+        model = klass.create(signed_up_on: '25-09-2017'.to_date)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, model.id)
+        expect(attributes[:signed_up_on]).to eq '2017-09-25'
+
+        Dynamoid.config.store_date_as_string = store_date_as_string
+      end
+
+      it 'prioritize field option over global one' do
+        klass = new_class do
+          field :signed_up_on, :date, store_as_native_string: true
+        end
+
+        store_date_as_string = Dynamoid.config.store_date_as_string
+        Dynamoid.config.store_date_as_string = false
+
+        model = klass.create(signed_up_on: '25-09-2017'.to_date)
+        attributes = Dynamoid.adapter.get_item(klass.table_name, model.id)
+        expect(attributes[:signed_up_on]).to eq '2017-09-25'
+
+        Dynamoid.config.store_date_as_string = store_date_as_string
+      end
     end
   end
 


### PR DESCRIPTION
Similar to https://github.com/Dynamoid/Dynamoid/pull/223

* handle `store_as_string` field option for `date` fields
* rename `datetime` option `store_as_native_string` to `store_as_string`
* add global config options `store_datetime_as_string` and `store_date_as_string`