### PR TITLE
Support start() on scan and support hashes for both scan and query start()

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,8 +431,8 @@ You can thus limit the number of evaluated records, or select a record from whic
 ```ruby
 Address.record_limit(5).start(address) # Only 5 addresses starting at `address`
 ```
-Where `address` is an instance of the model or a hash {the_model_hash_key: 'value', the_model_range_key: 'value'}:
-Keep in mind that if you are passing a hash to `.start()` you need to explicitly define all required keys in it, including range keys and secondary global indexes, if any, when querying and, range keys, if any, when scanning. Otherwise you'll get an `Aws::DynamoDB::Errors::ValidationException` either for `Exclusive Start Key must have same size as table's key schema` or `The provided starting key is invalid`
+Where `address` is an instance of the model or a hash `{the_model_hash_key: 'value', the_model_range_key: 'value'}`:
+Keep in mind that if you are passing a hash to `.start()` you need to explicitly define all required keys in it including range keys, depending on table or secondary indexes signatures, otherwise you'll get an `Aws::DynamoDB::Errors::ValidationException` either for `Exclusive Start Key must have same size as table's key schema` or `The provided starting key is invalid`
 
 If you are potentially running over a large data set and this is especially true when using certain filters, you may
 want to consider limiting the number of scanned records (the number of records DynamoDB infrastructure looks through

--- a/README.md
+++ b/README.md
@@ -426,11 +426,13 @@ There are three types of limits that you can query with:
 Using these in various combinations results in the underlying requests to be made in the smallest size possible and
 the query returns once `record_limit` or `scan_limit` is satisfied. It will attempt to batch whenever possible.
 
-You can thus limit the number of evaluated records, or select a record from which to start, to support pagination:
+You can thus limit the number of evaluated records, or select a record from which to start in order to support pagination.
 
 ```ruby
 Address.record_limit(5).start(address) # Only 5 addresses starting at `address`
 ```
+Where `address` is an instance of the model or a hash {the_model_hash_key: 'value', the_model_range_key: 'value'}:
+Keep in mind that if you are passing a hash to `.start()` you need to explicitly define all required keys in it, including range keys and secondary global indexes, if any, when querying and, range keys, if any, when scanning. Otherwise you'll get an `Aws::DynamoDB::Errors::ValidationException` either for `Exclusive Start Key must have same size as table's key schema` or `The provided starting key is invalid`
 
 If you are potentially running over a large data set and this is especially true when using certain filters, you may
 want to consider limiting the number of scanned records (the number of records DynamoDB infrastructure looks through

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -614,7 +614,7 @@ module Dynamoid
             if request[:limit] && scan_limit && scan_limit - scan_count < request[:limit]
               request[:limit] = scan_limit - scan_count
             end
-            
+
             results = client.scan(request)
             results.items.each { |row| y << result_item_to_hash(row) }
 

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -311,20 +311,17 @@ module Dynamoid #:nodoc:
       # If using a secondary index then we must include the index's composite key
       # as well as the tables composite key.
       def start_key
+        return @start if @start.is_a?(Hash)
         hash_key = @hash_key || source.hash_key
         range_key = @range_key || source.range_key
 
         key = {}
-        key[:hash_key_element] = type_cast_condition_parameter(hash_key, @start.send(hash_key))
-        key[:range_key_element] = type_cast_condition_parameter(range_key, @start.send(range_key)) if range_key
+        key[hash_key] = type_cast_condition_parameter(hash_key, @start.send(hash_key))
+        key[range_key] = type_cast_condition_parameter(range_key, @start.send(range_key)) if range_key
+        # Add table composite keys if they differ from secondary index used composite key
+        key[source.hash_key] = type_cast_condition_parameter(source.hash_key, @start.hash_key) if hash_key != source.hash_key
 
-        # Add table composite keys if differ from secondary index used composite key
-        if hash_key != source.hash_key
-          key[:table_hash_key_element] = type_cast_condition_parameter(source.hash_key, @start.hash_key)
-        end
-        if source.range_key && range_key != source.range_key
-          key[:table_range_key_element] = type_cast_condition_parameter(source.range_key, @start.range_value)
-        end
+        key[source.range_key] = type_cast_condition_parameter(source.range_key, @start.range_value) if source.range_key && range_key != source.range_key
 
         key
       end
@@ -336,7 +333,7 @@ module Dynamoid #:nodoc:
         opts[:record_limit] = @record_limit if @record_limit
         opts[:scan_limit] = @scan_limit if @scan_limit
         opts[:batch_size] = @batch_size if @batch_size
-        opts[:next_token] = start_key if @start
+        opts[:exclusive_start_key] = start_key if @start
         opts[:scan_index_forward] = @scan_index_forward
         opts
       end
@@ -359,7 +356,7 @@ module Dynamoid #:nodoc:
         opts[:record_limit] = @record_limit if @record_limit
         opts[:scan_limit] = @scan_limit if @scan_limit
         opts[:batch_size] = @batch_size if @batch_size
-        opts[:next_token] = start_key if @start
+        opts[:exclusive_start_key] = start_key if @start
         opts[:consistent_read] = true if @consistent_read
         opts
       end

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -306,7 +306,7 @@ module Dynamoid #:nodoc:
         # Could not utilize any indices so we'll have to scan
         false
       end
-#"
+
       # Start key needs to be set up based on the index utilized
       # If using a secondary index then we must include the index's composite key
       # as well as the tables composite key.

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -306,7 +306,7 @@ module Dynamoid #:nodoc:
         # Could not utilize any indices so we'll have to scan
         false
       end
-
+#"
       # Start key needs to be set up based on the index utilized
       # If using a secondary index then we must include the index's composite key
       # as well as the tables composite key.
@@ -317,12 +317,16 @@ module Dynamoid #:nodoc:
 
         key = {}
         key[hash_key] = type_cast_condition_parameter(hash_key, @start.send(hash_key))
-        key[range_key] = type_cast_condition_parameter(range_key, @start.send(range_key)) if range_key
+        if range_key
+          key[range_key] = type_cast_condition_parameter(range_key, @start.send(range_key))
+        end
         # Add table composite keys if they differ from secondary index used composite key
-        key[source.hash_key] = type_cast_condition_parameter(source.hash_key, @start.hash_key) if hash_key != source.hash_key
-
-        key[source.range_key] = type_cast_condition_parameter(source.range_key, @start.range_value) if source.range_key && range_key != source.range_key
-
+        if hash_key != source.hash_key
+          key[source.hash_key] = type_cast_condition_parameter(source.hash_key, @start.hash_key)
+        end
+        if source.range_key && range_key != source.range_key
+          key[source.range_key] = type_cast_condition_parameter(source.range_key, @start.range_value)
+        end
         key
       end
 

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -674,8 +674,20 @@ describe Dynamoid::Criteria::Chain do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
         expect(chain.where(city: 'San Francisco').start(@customer2).all).to contain_exactly(@customer3)
+        # Repeat with hash notation
+        expect(chain).to receive(:records_via_query).and_call_original
+        expect(chain.where(city: 'San Francisco').start({city: @customer2.city, age: @customer2.age, name: @customer2.name, customerid: @customer2.customerid}).all).to contain_exactly(@customer3)
       end
 
+      it 'supports scan with start on hash key & range key' do
+        chain = Dynamoid::Criteria::Chain.new(model)
+        expect(chain).to receive(:records_via_scan).and_call_original
+        expect(chain.scan_limit(1).start(@customer2)).to contain_exactly(@customer4)
+        # Repeat with hash notation
+        expect(chain).to receive(:records_via_scan).and_call_original
+        expect(chain.scan_limit(1).start({name: @customer2.name, customerid: @customer2.customerid})).to contain_exactly(@customer4)
+      end
+      
       it "does not use index if a condition for index hash key is other than 'equal'" do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_scan).and_call_original


### PR DESCRIPTION
Refactored start_key on chain.rb  to return correctly exclusive_start_key  instead of next_token, removed the conversion of next_token into exclusive_start_key from both query and scan  methods in the plugin adapter (aws_sdk_v2.rb). Also added the option to pass a hash to start. Added tests for the hash when querying, and added test for both record and hash when scanning with start. Slight change to the readme to mention the possibility of passing a hash