### PR TITLE
Add methods for low-level updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ end
 
 ### Note on set type
 
-There is `if` option to declare the type of set elements. You can use
+There is `of` option to declare the type of set elements. You can use
 `:integer` value only
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -188,6 +188,20 @@ class Document
 end
 ```
 
+### Note on set type
+
+There is `if` option to declare the type of set elements. You can use
+`:integer` value only
+
+```ruby
+class Document
+  include DynamoId::Document
+
+  field :tags, :set, of: :integer
+end
+```
+
+
 #### Magic Columns
 
 You get magic columns of id (string), created_at (datetime), and updated_at (datetime) for free.

--- a/README.md
+++ b/README.md
@@ -523,6 +523,41 @@ User.where("created_at.lt" => DateTime.now - 1.day).all
 
 It also supports .gte and .lte. Turning those into symbols and allowing a Rails SQL-style string syntax is in the works. You can only have one range argument per query, because of DynamoDB's inherent limitations, so use it sensibly!
 
+
+### Updating
+
+In order to update document you can use high level methods
+`#update_attrubutes`, `#update_attrubute` and `.update`.
+They run validation and collbacks.
+
+```ruby
+Address.find(id).update_attrubutes(city: 'Chicago')
+Address.find(id).update_attrubute(city, 'Chicago')
+Address.update(id, city: 'Chicago')
+Address.update(id, { city: 'Chicago' }, if: { deliverable: true })
+```
+
+There are also some low level methods `#update`, `.update_fields` and
+`.upsert`. They don't run validation and callbacks (except `#update` - it
+runs `update` callbacks). All of them support conditional updates.
+`#upsert` will create new document if document with specified `id`
+doesn't exist.
+
+```ruby
+Adderess.find(id).update do |i|
+  i.set city: 'Chicago'
+  i.add latitude: 100
+  i.delete set_of_numbers: 10
+end
+Adderess.find(id).update(if: { deliverable: true }) do |i|
+  i.set city: 'Chicago'
+end
+Address.update_fields(id, city: 'Chicago')
+Address.update_fields(id, { city: 'Chicago' }, if: { deliverable: true })
+Address.upsert(id, city: 'Chicago')
+Address.upsert(id, { city: 'Chicago' }, if: { deliverable: true })
+```
+
 ### Deleting
 
 In order to delete some items `delete_all` method should be used.

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -731,6 +731,10 @@ module Dynamoid
         conditions.delete(:unless_exists).try(:each) do |col|
           expected[col.to_s][:exists] = false
         end
+        conditions.delete(:if_exists).try(:each) do |col, val|
+          expected[col.to_s][:exists] = true
+          expected[col.to_s][:value] = val
+        end
         conditions.delete(:if).try(:each) do |col, val|
           expected[col.to_s][:value] = val
         end

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -161,6 +161,35 @@ module Dynamoid #:nodoc:
         end
       end
 
+      def upsert(hash_key_value, range_key_value=nil, attrs={}, conditions={})
+        optional_params = [range_key_value, attrs, conditions].compact
+        if optional_params.first.is_a?(Hash)
+          range_key_value = nil
+          attrs, conditions = optional_params[0 .. 1]
+        else
+          range_key_value = optional_params.first
+          attrs, conditions = optional_params[1 .. 2]
+        end
+
+        options = if range_key
+                    { range_key: dump_field(range_key_value, attributes[range_key]) }
+                  else
+                    {}
+                  end
+
+        options[:conditions] = conditions
+
+        begin
+          new_attrs = Dynamoid.adapter.update_item(table_name, hash_key_value, options) do |t|
+            attrs.symbolize_keys.each do |k, v|
+              t.set k => dump_field(v, attributes[k])
+            end
+          end
+          new(new_attrs)
+        rescue Dynamoid::Errors::ConditionalCheckFailedException
+        end
+      end
+
       def deep_subclasses
         subclasses + subclasses.map(&:deep_subclasses).flatten
       end

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -119,6 +119,18 @@ module Dynamoid #:nodoc:
         end
       end
 
+      def update(hash_key, range_key_value=nil, attrs)
+        if range_key.present?
+          range_key_value = dump_field(range_key_value, attributes[self.range_key])
+        else
+          range_key_value = nil
+        end
+
+        model = find(hash_key, range_key: range_key_value, consistent_read: true)
+        model.update_attributes(attrs)
+        model
+      end
+
       def deep_subclasses
         subclasses + subclasses.map(&:deep_subclasses).flatten
       end

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -186,6 +186,91 @@ describe Dynamoid::Document do
     end
   end
 
+  describe '.update_fields' do
+    let(:document_class) do
+      new_class do
+        field :title
+        field :version, :integer
+        field :published_on, :date
+      end
+    end
+
+    it 'changes field value' do
+      obj = document_class.create(title: 'Old title')
+      expect {
+        document_class.update_fields(obj.id, title: 'New title')
+      }.to change { document_class.find(obj.id).title }.from('Old title').to('New title')
+    end
+
+    it 'changes field value to nil' do
+      obj = document_class.create(title: 'New Document')
+      expect {
+        document_class.update_fields(obj.id, title: nil)
+      }.to change { document_class.find(obj.id).title }.from('New Document').to(nil)
+    end
+
+    it 'returns updated document' do
+      obj = document_class.create(title: 'Old title')
+      result = document_class.update_fields(obj.id, title: 'New title')
+
+      expect(result.id).to eq obj.id
+      expect(result.title).to eq 'New title'
+    end
+
+    it 'checks the conditions on update' do
+      obj = document_class.create(title: 'Old title', version: 1)
+      expect {
+        document_class.update_fields(obj.id, { title: 'New title' }, if: { version: 1 })
+      }.to change { document_class.find(obj.id).title }.to('New title')
+
+      obj = document_class.create(title: 'Old title', version: 1)
+      expect {
+        result = document_class.update_fields(obj.id, { title: 'New title' }, if: { version: 6 })
+      }.not_to change { document_class.find(obj.id).title }
+    end
+
+    it 'does not create new document if it does not exist yet' do
+      document_class.create_table
+
+      expect {
+        document_class.update_fields('some-fake-id', title: 'Title')
+      }.not_to change { document_class.count }
+    end
+
+    it 'accepts range key if it is declared' do
+      document_class_with_range = new_class do
+        field :title
+        range :category
+      end
+
+      obj = document_class_with_range.create(category: 'New')
+
+      expect {
+        document_class_with_range.update_fields(obj.id, 'New', title: '[Updated]')
+      }.to change {
+        document_class_with_range.find(obj.id, range_key: 'New').title
+      }.to('[Updated]')
+    end
+
+    it 'converts range key value' do
+      document_class_with_range = new_class do
+        field :title
+        range :published_on, :date
+      end
+
+      obj = document_class_with_range.create(title: 'Old', published_on: '2018-02-23'.to_date)
+      document_class_with_range.update_fields(obj.id, '2018-02-23'.to_date, title: 'New')
+      expect(obj.reload.title).to eq 'New'
+    end
+
+    it 'converts attributes values' do
+      obj = document_class.create
+      document_class.update_fields(obj.id, published_on: '2018-02-23'.to_date)
+      attributes = Dynamoid.adapter.get_item(document_class.table_name, obj.id)
+      expect(attributes[:published_on]).to eq 17585
+    end
+  end
+
   context '.reload' do
     let(:address){ Address.create }
     let(:message){ Message.create(text: 'Nice, supporting datetime range!', time: Time.now.to_datetime) }

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -124,6 +124,68 @@ describe Dynamoid::Document do
     expect(address.errors.full_messages).to be_empty
   end
 
+  describe '.update' do
+    let(:document_class) do
+      new_class do
+        field :name
+
+        validates :name, presence: true, length: { minimum: 5 }
+        def self.name; 'Document' end
+      end
+    end
+
+    it 'loads and saves document' do
+      d = document_class.create(name: 'Document#1')
+
+      expect {
+        document_class.update(d.id, name: '[Updated]')
+      }.to change { d.reload.name }.from('Document#1').to('[Updated]')
+    end
+
+    it 'returns updated document' do
+      d = document_class.create(name: 'Document#1')
+      d2 = document_class.update(d.id, name: '[Updated]')
+
+      expect(d2).to be_a(document_class)
+      expect(d2.name).to eq '[Updated]'
+    end
+
+    it 'does not save invalid document' do
+      d = document_class.create(name: 'Document#1')
+      d2 = nil
+
+      expect {
+        d2 = document_class.update(d.id, name: '[Up')
+      }.not_to change { d.reload.name }
+      expect(d2).not_to be_valid
+    end
+
+    it 'accepts range key value if document class declares it' do
+      klass = new_class do
+        field :name
+        range :status
+      end
+
+      d = klass.create(status: 'old', name: 'Document#1')
+      expect {
+        klass.update(d.id, 'old', name: '[Updated]')
+      }.to change { d.reload.name }.to('[Updated]')
+    end
+
+    it 'converts range key value to proper format' do
+      klass = new_class do
+        field :name
+        range :activated_on, :date
+        field :another_date, :datetime
+      end
+
+      d = klass.create(activated_on: '2018-01-14'.to_date, name: 'Document#1')
+      expect {
+        klass.update(d.id, '2018-01-14'.to_date, name: '[Updated]')
+      }.to change { d.reload.name }.to('[Updated]')
+    end
+  end
+
   context '.reload' do
     let(:address){ Address.create }
     let(:message){ Message.create(text: 'Nice, supporting datetime range!', time: Time.now.to_datetime) }


### PR DESCRIPTION
* Added `Document.update(id, [range key], attributes)`
* Added `Document.update_fields(id, [range key], attributes, [conditions])`
* Added `Document.upsert(id, [range key], attributes, [conditions])`

`conditions` means `if: { version: 3 }`

`Document.update` loads document, changes attributes and saves. It runs all callbacks and validations.

`Document.update_fields` sends to DynamoDB only changed attributes. It doesn't run callbacks and validations.

`Document.upsert` does the same but it creates new document if there is no document with specified `id`.

All of them return updated document if updating is successful. They use low-level `UpdateItem` api call (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html)

----

Related issues https://github.com/Dynamoid/Dynamoid/issues/218, https://github.com/Dynamoid/Dynamoid/issues/119