### PR TITLE
Support `NE` condition operator

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -18,6 +18,7 @@ module Dynamoid
       # we declare schema in models
       FIELD_MAP = {
           eq:           'EQ',
+          ne:           'NE',
           gt:           'GT',
           lt:           'LT',
           gte:          'GE',

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -196,6 +196,8 @@ module Dynamoid #:nodoc:
         val = type_cast_condition_parameter(name, query[key])
 
         hash = case operation
+        when 'ne'
+          { ne: val }
         when 'gt'
           { gt: val }
         when 'lt'

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -247,6 +247,13 @@ describe Dynamoid::Criteria::Chain do
       expect(chain.where(id: 1, array: [1, 2]).all).to contain_exactly(document1)
     end
 
+    it 'supports ne' do
+      customer1 = model.create(name: 'a', last_name: 'a', age: 5)
+      customer2 = model.create(name: 'a', last_name: 'b', age: 9)
+
+      expect(model.where(name: 'a', 'age.ne' => 9).all).to contain_exactly(customer1)
+    end
+
     it 'supports lt' do
       customer1 = model.create(name: 'a', last_name: 'a', age: 5)
       customer2 = model.create(name: 'a', last_name: 'b', age: 9)
@@ -386,6 +393,13 @@ describe Dynamoid::Criteria::Chain do
       document2 = klass.create(array: ['b', 'c'])
 
       expect(klass.where(array: ['a', 'b']).all).to contain_exactly(document1)
+    end
+
+    it 'supports ne' do
+      customer1 = model.create(age: 5)
+      customer2 = model.create(age: 9)
+
+      expect(model.where('age.ne' => 9).all).to contain_exactly(customer1)
     end
 
     it 'supports lt' do


### PR DESCRIPTION
Now we can use `ne` operator in where conditions:

```ruby
Document.where('age.ne' => 10).all
```

Be aware it doesn't work for sort key in QUERY operation (when there is some condition on partition key)

https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html

Related issue https://github.com/Dynamoid/Dynamoid/issues/241