### PR TITLE
Handle unprocessed items in batch operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,15 +706,15 @@ Calls to `update` and `update!` also increment the `lock_version`, however they 
 ### Backoff strategies
 
 
-You can use several methods what do efficiently in batch mode like `.find_all` and `.import`.
+You can use several methods that run efficiently in batch mode like `.find_all` and `.import`.
 
 The backoff strategy will be used when, for any reason, some items could not be processed as part of a batch mode command.
-Operations will be re-run to process this items.
+Operations will be re-run to process these items.
 
 Exponential backoff is the recommended way to handle throughput limits exceeding and throttling on the table.
 
 There are two built-in strategies - constant delay and truncated binary exponential backoff.
-By default no backoff is used but you can specify one of the build-in ones:
+By default no backoff is used but you can specify one of the built-in ones:
 
 ```ruby
 Dynamoid.configure do |config|
@@ -725,6 +725,14 @@ Dynamoid.configure do |config|
   config.backoff = { exponential: { base_backoff: 0.2.seconds, ceiling: 10 } }
 end
 
+```
+
+You can just specify strategy without any arguments to use default presets:
+
+```ruby
+Dynamoid.configure do |config|
+  config.backoff = :constant
+end
 ```
 
 You can use your own strategy in following way:

--- a/README.md
+++ b/README.md
@@ -708,13 +708,13 @@ Calls to `update` and `update!` also increment the `lock_version`, however they 
 
 You can use several methods what do efficiently in batch mode like `.find_all` and `.import`.
 
-By some reasons, for instanse table throughput limit is exceeded, some items could be not processed.
-By default operations will be re-run to process this items.
+The backoff strategy will be used when, for any reason, some items could not be processed as part of a batch mode command.
+Operations will be re-run to process this items.
 
-Recommended way to handle throughput limits exceeding and throttling on the table is to use exponential backoff.
+Exponential backoff is the recommended way to handle throughput limits exceeding and throttling on the table.
 
-There are two default backoff strategies - constant delay and truncated binary exponential backoff.
-By default no backof is used but you can specify one of the default ones:
+There are two built-in strategies - constant delay and truncated binary exponential backoff.
+By default no backoff is used but you can specify one of the build-in ones:
 
 ```ruby
 Dynamoid.configure do |config|

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -80,12 +80,12 @@ module Dynamoid
     #                        unless multiple ids are passed in.
     #
     # @since 0.2.0
-    def read(table, ids, options = {})
+    def read(table, ids, options = {}, &blk)
       range_key = options.delete(:range_key)
 
       if ids.respond_to?(:each)
         ids = ids.collect{|id| range_key ? [id, range_key] : id}
-        batch_get_item({table => ids}, options)
+        batch_get_item({table => ids}, options, &blk)
       else
         options[:range_key] = range_key if range_key
         get_item(table, ids, options)

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -144,8 +144,12 @@ module Dynamoid
       # Method delegation with benchmark to the underlying adapter. Faster than relying on method_missing.
       #
       # @since 0.2.0
-      define_method(m) do |*args|
-        benchmark("#{m.to_s}", *args) {adapter.send(m, *args)}
+      define_method(m) do |*args, &blk|
+        if blk.present?
+          benchmark("#{m.to_s}", *args) { adapter.send(m, *args, &blk) }
+        else
+          benchmark("#{m.to_s}", *args) { adapter.send(m, *args) }
+        end
       end
     end
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -112,8 +112,7 @@ module Dynamoid
 
         begin
           while items.present? do
-            batch = items.take(BATCH_WRITE_ITEM_REQUESTS_LIMIT)
-            items.shift(BATCH_WRITE_ITEM_REQUESTS_LIMIT)
+            batch = items.shift(BATCH_WRITE_ITEM_REQUESTS_LIMIT)
             requests = batch.map { |item| { put_request: { item: item } } }
 
             response = client.batch_write_item(
@@ -186,8 +185,7 @@ module Dynamoid
           rng = tbl.range_key.to_s
 
           while ids.present? do
-            batch = ids.take(Dynamoid::Config.batch_size)
-            ids.shift(Dynamoid::Config.batch_size)
+            batch = ids.shift(Dynamoid::Config.batch_size)
 
             request_items = Hash.new{|h, k| h[k] = []}
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -84,10 +84,10 @@ module Dynamoid
         @client
       end
 
-      # Puts multiple items in one tables
+      # Puts multiple items in one table
       #
-      # If optional block is passed method calls passed block for each written batch of items.
-      # Block receives boolean flag what indicates there are some unprocessed items.
+      # If optional block is passed it will be called for each written batch of items, meaning once per batch.
+      # Block receives boolean flag which is true if there are some unprocessed items, otherwise false.
       #
       # @example Saves several items to the table testtable
       #   Dynamoid::AdapterPlugin::AwsSdkV2.batch_write_item('table1', [{ id: '1', name: 'a' }, { id: '2', name: 'b'}])
@@ -141,10 +141,12 @@ module Dynamoid
 
       # Get many items at once from DynamoDB. More efficient than getting each item individually.
       #
-      # If optional block is passed method call returns `nil` and calls passed block for each batch of items.
+      # If optional block is passed `nil` will be returned and the block will be called for each read batch of items,
+      # meaning once per batch.
+      #
       # Block receives parameters:
       # * hash with items like `{ table_name: [items]}`
-      # * and boolean flag what indicates there are some unprocessed keys.
+      # * and boolean flag is true if there are some unprocessed keys, otherwise false.
       #
       # @example Retrieve IDs 1 and 2 from the table testtable
       #   Dynamoid::AdapterPlugin::AwsSdkV2.batch_get_item('table1' => ['1', '2'])

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v2.rb
@@ -93,27 +93,28 @@ module Dynamoid
       # See:
       # * http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
       # * http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#batch_write_item-instance_method
-      #
-      # TODO handle rejections because of exceeding limit for the whole request - 16 MB,
-      # item size limit - 400 KB or because provisioned throughput is exceeded
       def batch_write_item table_name, objects, options = {}
-        requests = []
-
-        objects.each_slice(BATCH_WRITE_ITEM_REQUESTS_LIMIT) do |os|
-          requests << os.map { |o| { put_request: { item: sanitize_item(o) } } }
-        end
+        items = objects.map { |o| sanitize_item(o) }
 
         begin
-          requests.each do |request_items|
-            client.batch_write_item(
+          while items.present? do
+            batch = items.take(BATCH_WRITE_ITEM_REQUESTS_LIMIT)
+            items.shift(BATCH_WRITE_ITEM_REQUESTS_LIMIT)
+            requests = batch.map { |item| { put_request: { item: item } } }
+
+            response = client.batch_write_item(
               {
                 request_items: {
-                  table_name => request_items,
+                  table_name => requests,
                 },
                 return_consumed_capacity: 'TOTAL',
                 return_item_collection_metrics: 'SIZE'
               }.merge!(options)
             )
+
+            if response.unprocessed_items.present?
+              items += response.unprocessed_items[table_name].map { |r| r.put_request.item }
+            end
           end
         rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException => e
           raise Dynamoid::Errors::ConditionalCheckFailedException, e

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -65,10 +65,14 @@ module Dynamoid
     end
 
     def build_backoff
-      name = backoff.keys[0]
-      args = backoff.values[0]
+      if backoff.is_a?(Hash)
+        name = backoff.keys[0]
+        args = backoff.values[0]
 
-      backoff_strategies[name].call(args)
+        backoff_strategies[name].call(args)
+      else
+        backoff_strategies[backoff].call
+      end
     end
   end
 end

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 require 'uri'
 require 'dynamoid/config/options'
+require 'dynamoid/config/backoff_strategies/constant_backoff'
+require 'dynamoid/config/backoff_strategies/exponential_backoff'
 
 module Dynamoid
 
@@ -30,6 +32,11 @@ module Dynamoid
     option :application_timezone, default: :local # available values - :utc, :local, time zone names
     option :store_datetime_as_string, default: false # store Time fields in ISO 8601 string format
     option :store_date_as_string, default: false # store Date fields in ISO 8601 string format
+    option :backoff, default: nil # callable object to handle exceeding of table throughput limit
+    option :backoff_strategies, default: {
+      constant: BackoffStrategies::ConstantBackoff,
+      exponential: BackoffStrategies::ExponentialBackoff
+    }
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.
     #
@@ -57,5 +64,11 @@ module Dynamoid
       end
     end
 
+    def build_backoff
+      name = backoff.keys[0]
+      args = backoff.values[0]
+
+      backoff_strategies[name].call(args)
+    end
   end
 end

--- a/lib/dynamoid/config/backoff_strategies/constant_backoff.rb
+++ b/lib/dynamoid/config/backoff_strategies/constant_backoff.rb
@@ -2,7 +2,7 @@ module Dynamoid
   module Config
     module BackoffStrategies
       class ConstantBackoff
-        def self.call(n)
+        def self.call(n = 1)
           -> { sleep n }
         end
       end

--- a/lib/dynamoid/config/backoff_strategies/constant_backoff.rb
+++ b/lib/dynamoid/config/backoff_strategies/constant_backoff.rb
@@ -1,0 +1,11 @@
+module Dynamoid
+  module Config
+    module BackoffStrategies
+      class ConstantBackoff
+        def self.call(n)
+          -> { sleep n }
+        end
+      end
+    end
+  end
+end

--- a/lib/dynamoid/config/backoff_strategies/exponential_backoff.rb
+++ b/lib/dynamoid/config/backoff_strategies/exponential_backoff.rb
@@ -4,14 +4,15 @@ module Dynamoid
       # Truncated binary exponential backoff algorithm
       # See https://en.wikipedia.org/wiki/Exponential_backoff
       class ExponentialBackoff
-        def self.call(opts)
+        def self.call(opts = {})
+          opts = { base_backoff: 0.5, ceiling: 3 }.merge(opts)
           base_backoff = opts[:base_backoff]
           ceiling = opts[:ceiling]
 
           times = 1
 
           lambda do
-            power = times <= ceiling ? times - 1 : ceiling - 1
+            power = [times - 1, ceiling - 1].min
             backoff = base_backoff * (2 ** power)
             sleep backoff
 

--- a/lib/dynamoid/config/backoff_strategies/exponential_backoff.rb
+++ b/lib/dynamoid/config/backoff_strategies/exponential_backoff.rb
@@ -1,0 +1,24 @@
+module Dynamoid
+  module Config
+    module BackoffStrategies
+      # Truncated binary exponential backoff algorithm
+      # See https://en.wikipedia.org/wiki/Exponential_backoff
+      class ExponentialBackoff
+        def self.call(opts)
+          base_backoff = opts[:base_backoff]
+          ceiling = opts[:ceiling]
+
+          times = 1
+
+          lambda do
+            power = times <= ceiling ? times - 1 : ceiling - 1
+            backoff = base_backoff * (2 ** power)
+            sleep backoff
+
+            times += 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dynamoid/config/backoff_strategies/exponential_backoff_spec.rb
+++ b/spec/dynamoid/config/backoff_strategies/exponential_backoff_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe Dynamoid::Config::BackoffStrategies::ExponentialBackoff do
+  let(:base_backoff) { 1 }
+  let(:ceiling) { 5 }
+  let(:backoff) { described_class.call(base_backoff: base_backoff, ceiling: ceiling) }
+
+  it 'sleeps the first time for specified base backoff time' do
+    expect(described_class).to receive(:sleep).with(base_backoff)
+    backoff.call
+  end
+
+  it 'sleeps for exponentialy increasing time' do
+    seconds = []
+    allow(described_class).to receive(:sleep) do |s|
+      seconds << s
+    end
+
+    backoff.call
+    expect(seconds).to eq [base_backoff]
+
+    backoff.call
+    expect(seconds).to eq [base_backoff, base_backoff * 2]
+
+    backoff.call
+    expect(seconds).to eq [base_backoff, base_backoff * 2, base_backoff * 4]
+
+    backoff.call
+    expect(seconds).to eq [base_backoff, base_backoff * 2, base_backoff * 4, base_backoff * 8]
+  end
+
+  it 'stops to increase time after ceiling times' do
+    seconds = []
+    allow(described_class).to receive(:sleep) do |s|
+      seconds << s
+    end
+
+    6.times { backoff.call }
+    expect(seconds).to eq [
+      base_backoff,
+      base_backoff * 2,
+      base_backoff * 4,
+      base_backoff * 8,
+      base_backoff * 16,
+      base_backoff * 16
+    ]
+  end
+end

--- a/spec/dynamoid/config/backoff_strategies/exponential_backoff_spec.rb
+++ b/spec/dynamoid/config/backoff_strategies/exponential_backoff_spec.rb
@@ -45,4 +45,28 @@ RSpec.describe Dynamoid::Config::BackoffStrategies::ExponentialBackoff do
       base_backoff * 16
     ]
   end
+
+  it 'can be called without parameters' do
+    backoff = nil
+    expect do
+      backoff = described_class.call
+    end.not_to raise_error
+  end
+
+  it 'uses base backoff = 0.5 and ceiling = 3 by default' do
+    backoff = described_class.call
+
+    seconds = []
+    allow(described_class).to receive(:sleep) do |s|
+      seconds << s
+    end
+
+    4.times { backoff.call }
+    expect(seconds).to eq([
+      0.5,
+      0.5 * 2,
+      0.5 * 4,
+      0.5 * 4
+    ])
+  end
 end


### PR DESCRIPTION
Exponential backoff is a [recommended](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.BatchOperations) way to handle throughput limits exceeding and throttling on the table.

There are two batch operations - `.find_all` and `.import`.

In this PR we:
* add handling of unprocessed items in batch operations
* allow to use backoff for them

---
Changes:
* `batch_get_items` and `batch_write_item` re-try to handle all unprocessed keys
* `batch_get_items` and `batch_write_item` accept optional block to provide boolean flag if there are unprocessed items in each batch
* add `backoff` and `backoff_strategies` config options
* `find_all` and `import` take into account `backoff` config option

---

There are two simple examples of backoff - constant delay (`:constant`) and [truncated binary exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) (`:exponential`)

Backoff should be specified in following way:

```ruby
Dynamoid.config.backoff = { constant: 2.seconds }
Dynamoid.config.backoff = { exponential: { base_backoff: 0.2.seconds, ceiling: 10 } }
```
User is able to add custom strategies in following way:

```ruby
Dynamoid.config.backoff_strategies[:custom] = lambda do |n|
  -> { sleep  rand(n) }
end
Dynamoid.config.backoff = { custom: 10 }
```
---
Related issue https://github.com/Dynamoid/Dynamoid/issues/226