### PR TITLE
Update outdated warning message

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -161,7 +161,10 @@ module Dynamoid #:nodoc:
       def records_via_scan
         if Dynamoid::Config.warn_on_scan
           Dynamoid.logger.warn 'Queries without an index are forced to use scan and are generally much slower than indexed queries!'
-          Dynamoid.logger.warn "You can index this query by adding this to #{source.to_s.downcase}.rb: index [#{query.keys.sort.collect{|name| ":#{name}"}.join(', ')}]"
+          Dynamoid.logger.warn "You can index this query by adding index declaration to #{source.to_s.downcase}.rb:"
+          Dynamoid.logger.warn "* global_secondary_index hash_key: 'some-name', range_key: 'some-another-name'"
+          Dynamoid.logger.warn "* local_secondary_indexe range_key: 'some-name'"
+          Dynamoid.logger.warn "Not indexed attributes: #{query.keys.sort.collect{|name| ":#{name}"}.join(', ')}"
         end
 
         Enumerator.new do |yielder|

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -100,7 +100,10 @@ describe Dynamoid::Criteria do
 
     it 'logs warnings' do
       expect(Dynamoid.logger).to receive(:warn).with('Queries without an index are forced to use scan and are generally much slower than indexed queries!')
-      expect(Dynamoid.logger).to receive(:warn).with('You can index this query by adding this to user.rb: index [:name, :password]')
+      expect(Dynamoid.logger).to receive(:warn).with("You can index this query by adding index declaration to user.rb:")
+      expect(Dynamoid.logger).to receive(:warn).with("* global_secondary_index hash_key: 'some-name', range_key: 'some-another-name'")
+      expect(Dynamoid.logger).to receive(:warn).with("* local_secondary_indexe range_key: 'some-name'")
+      expect(Dynamoid.logger).to receive(:warn).with("Not indexed attributes: :name, :password")
 
       User.where(name: 'x', password: 'password').all
     end


### PR DESCRIPTION
When Scan operation is performing the following outdated warning is printing:

```
Dynamoid.logger.warn "You can index this query by adding this to #{source.to_s.downcase}.rb: index [#{query.keys.sort.collect{|name| ":#{name}"}.join(', ')}]"
```

What suggests to add following index declaration:
```
index [<list of attributes>]
```

It's incorrect declaration because indexes can be declared with `global_secondary_index` or `local_secondary_indexe `