### PR TITLE
Upgrade AWS SDK to V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Breaking
 
-* N/A
+* Improvement: [#267](https://github.com/Dynamoid/Dynamoid/pull/267) Upgrade AWS SDK to V3 (@andrykonchin)
 
 ## Improvements
 

--- a/README.md
+++ b/README.md
@@ -38,16 +38,8 @@ gem 'dynamoid', '~> 2'
 ```
 ## Prerequisities
 
-Dynamoid depends on the aws-sdk, and this is tested on the current version of aws-sdk (~> 2), rails (>= 4).
+Dynamoid depends on the aws-sdk, and this is tested on the current version of aws-sdk (~> 3), rails (>= 4).
 Hence the configuration as needed for aws to work will be dealt with by aws setup.
-
-Here are the steps to setup aws-sdk.
-
-```ruby
-gem 'aws-sdk', '~>2'
-```
-
-(or) include the aws-sdk in your Gemfile.
 
 ### AWS SDK Version Compatibility
 

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ the table since a query against GSI then a query on base table is still likely f
 
 Listed below are all configuration options.
 
-* `adapter` - usefull only for the gem developers to switch to a new adapter. Default and the only available value is `aws_sdk_v2`
+* `adapter` - usefull only for the gem developers to switch to a new adapter. Default and the only available value is `aws_sdk_v3`
 * `namespace` - prefix for table names, default is `dynamoid_#{application_name}_#{environment}` for Rails application and `dynamoid` otherwise
 * `logger` - by default it's a `Rails.logger` in Rails application and `stdout` otherwise. You can disable logging by setting `nil` or `false` values. Set `true` value to use defaults
 * `access_key` - DynamoDb custom credentials for AWS, override global AWS credentials if they present

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -39,24 +39,16 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # This form of switching the gem dependencies is not compatible with wwtd & appraisal
-  # if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.2")
-  #   spec.add_runtime_dependency(%q<activemodel>, [">= 4", "< 5.1.0"])
-  #   spec.add_development_dependency(%q<activesupport>, [">= 4", "< 5.1.0"])
-  # else
-  #   spec.add_runtime_dependency(%q<activemodel>, ["~> 4"])
-  #   spec.add_development_dependency(%q<activesupport>, ["~> 4"])
-  # end
-  spec.add_runtime_dependency(%q<activemodel>, [">= 4"])
-  spec.add_development_dependency(%q<activesupport>, [">= 4"])
-  spec.add_runtime_dependency(%q<aws-sdk-dynamodb>, ["~> 1"])
-  spec.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
+  spec.add_runtime_dependency "activemodel", ">=4"
+  spec.add_runtime_dependency "aws-sdk-dynamodb", "~> 1"
+  spec.add_runtime_dependency "concurrent-ruby", ">= 1.0"
+
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "appraisal", "~> 2.1"
-  spec.add_development_dependency "wwtd", "~> 1.3"
-  spec.add_development_dependency(%q<yard>, [">= 0"])
-  spec.add_development_dependency "coveralls", "~> 0.8"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "wwtd"
+  spec.add_development_dependency "yard"
+  spec.add_development_dependency "coveralls"
 end

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   # end
   spec.add_runtime_dependency(%q<activemodel>, [">= 4"])
   spec.add_development_dependency(%q<activesupport>, [">= 4"])
-  spec.add_runtime_dependency(%q<aws-sdk-resources>, ["~> 2"])
+  spec.add_runtime_dependency(%q<aws-sdk-dynamodb>, ["~> 1"])
   spec.add_runtime_dependency(%q<concurrent-ruby>, [">= 1.0"])
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bundler", "~> 1.14"

--- a/lib/dynamoid.rb
+++ b/lib/dynamoid.rb
@@ -1,3 +1,4 @@
+require 'aws-sdk-dynamodb'
 require 'delegate'
 require 'time'
 require 'securerandom'

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -1,8 +1,8 @@
 module Dynamoid
   module AdapterPlugin
 
-    # The AwsSdkV2 adapter provides support for the aws-sdk version 2 for ruby.
-    class AwsSdkV2
+    # The AwsSdkV3 adapter provides support for the aws-sdk version 2 for ruby.
+    class AwsSdkV3
       EQ = 'EQ'.freeze
       RANGE_MAP = {
           range_greater_than: 'GT',
@@ -90,10 +90,10 @@ module Dynamoid
       # Block receives boolean flag which is true if there are some unprocessed items, otherwise false.
       #
       # @example Saves several items to the table testtable
-      #   Dynamoid::AdapterPlugin::AwsSdkV2.batch_write_item('table1', [{ id: '1', name: 'a' }, { id: '2', name: 'b'}])
+      #   Dynamoid::AdapterPlugin::AwsSdkV3.batch_write_item('table1', [{ id: '1', name: 'a' }, { id: '2', name: 'b'}])
       #
       # @example Pass block
-      #   Dynamoid::AdapterPlugin::AwsSdkV2.batch_write_item('table1', items) do |bool|
+      #   Dynamoid::AdapterPlugin::AwsSdkV3.batch_write_item('table1', items) do |bool|
       #     if bool
       #       puts 'there are unprocessed items'
       #     end
@@ -148,10 +148,10 @@ module Dynamoid
       # * and boolean flag is true if there are some unprocessed keys, otherwise false.
       #
       # @example Retrieve IDs 1 and 2 from the table testtable
-      #   Dynamoid::AdapterPlugin::AwsSdkV2.batch_get_item('table1' => ['1', '2'])
+      #   Dynamoid::AdapterPlugin::AwsSdkV3.batch_get_item('table1' => ['1', '2'])
       #
       # @example Pass block to receive each batch
-      #   Dynamoid::AdapterPlugin::AwsSdkV2.batch_get_item('table1' => ids) do |hash, bool|
+      #   Dynamoid::AdapterPlugin::AwsSdkV3.batch_get_item('table1' => ids) do |hash, bool|
       #     puts hash['table1']
       #
       #     if bool
@@ -237,7 +237,7 @@ module Dynamoid
       # @example Delete IDs 1 and 2 from the table testtable
       #   Dynamoid::AdapterPlugin::AwsSdk.batch_delete_item('table1' => ['1', '2'])
       # or
-      #   Dynamoid::AdapterPlugin::AwsSdkV2.batch_delete_item('table1' => [['hk1', 'rk2'], ['hk1', 'rk2']]]))
+      #   Dynamoid::AdapterPlugin::AwsSdkV3.batch_delete_item('table1' => [['hk1', 'rk2'], ['hk1', 'rk2']]]))
       #
       # @param [Hash] options the hash of tables and IDs to delete
       #

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -13,7 +13,7 @@ module Dynamoid
     include ActiveModel::Observing if defined?(ActiveModel::Observing)
 
     # All the default options.
-    option :adapter, default: 'aws_sdk_v2'
+    option :adapter, default: 'aws_sdk_v3'
     option :namespace, default: defined?(Rails) ? "dynamoid_#{Rails.application.class.parent_name}_#{Rails.env}" : 'dynamoid'
     option :access_key, default: nil
     option :secret_key, default: nil

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -1,7 +1,7 @@
-require 'dynamoid/adapter_plugin/aws_sdk_v2'
+require 'dynamoid/adapter_plugin/aws_sdk_v3'
 require File.expand_path(File.dirname(__FILE__) + '../../../spec_helper')
 
-describe Dynamoid::AdapterPlugin::AwsSdkV2 do
+describe Dynamoid::AdapterPlugin::AwsSdkV3 do
   #
   # These let() definitions create tables "dynamoid_tests_TestTable<N>" and return the
   # name of the table.
@@ -350,7 +350,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         lsi = data.table.local_secondary_indexes.first
 
         # test
-        expect(Dynamoid::AdapterPlugin::AwsSdkV2::PARSE_TABLE_STATUS.call(resp)).to eq(Dynamoid::AdapterPlugin::AwsSdkV2::TABLE_STATUSES[:active])
+        expect(Dynamoid::AdapterPlugin::AwsSdkV3::PARSE_TABLE_STATUS.call(resp)).to eq(Dynamoid::AdapterPlugin::AwsSdkV3::TABLE_STATUSES[:active])
         expect(lsi.index_name).to eql 'dynamoid_tests_table_lsi_index_id_range2'
         expect(lsi.key_schema.map(&:to_hash)).to eql [
           {attribute_name: 'id', key_type: 'HASH'},
@@ -379,7 +379,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV2 do
         gsi = data.table.global_secondary_indexes.first
 
         # test
-        expect(Dynamoid::AdapterPlugin::AwsSdkV2::PARSE_TABLE_STATUS.call(resp)).to eq(Dynamoid::AdapterPlugin::AwsSdkV2::TABLE_STATUSES[:active])
+        expect(Dynamoid::AdapterPlugin::AwsSdkV3::PARSE_TABLE_STATUS.call(resp)).to eq(Dynamoid::AdapterPlugin::AwsSdkV3::TABLE_STATUSES[:active])
         expect(gsi.index_name).to eql 'dynamoid_tests_table_gsi_index_hash2_range2'
         expect(gsi.key_schema.map(&:to_hash)).to eql [
           {attribute_name: 'hash2', key_type: 'HASH'},

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'rspec'
 require 'dynamoid'
 require 'pry'
-require 'aws-sdk-resources'
 require 'byebug' if ENV['DEBUG']
 
 require 'dynamodb_local'


### PR DESCRIPTION
So now:
- we use SDK 3
- require only `aws-sdk-core` and `aws-sdk-dynamodb` gems
- client doesn't have to require SDK manually

Instructions https://github.com/aws/aws-sdk-ruby#upgrade-from-version-2