### PR TITLE
Change default time zone to UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Listed below are all configuration options.
 * `convert_big_decimal` - if `true` then Dynamoid converts numbers stored in `Hash` in `raw` field to float. Default is `false`
 * `models_dir` - `dynamoid:create_tables` rake task loads DynamoDb models from this directory. Default is `./app/models`.
 * `application_timezone` - Dynamoid converts all `datetime` fields to specified time zone when loads data from the storage.
-  Acceptable values - `utc`, `local` (to use system time zone) and time zone name e.g. `Eastern Time (US & Canada)`. Default is `local`
+  Acceptable values - `utc`, `local` (to use system time zone) and time zone name e.g. `Eastern Time (US & Canada)`. Default is `utc`
 * `store_datetime_as_string` - if `true` then Dynamoid stores :datetime fields in ISO 8601 string format. Default is `false`
 * `store_date_as_string` - if `true` then Dynamoid stores :date fields in ISO 8601 string format. Default is `false`
 * `backoff` - is a hash: key is a backoff strategy (symbol), value is parameters for the strategy. Is used in batch operations. Default id `nil`

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -30,7 +30,7 @@ module Dynamoid
     option :sync_retry_wait_seconds, default: 2
     option :convert_big_decimal, default: false
     option :models_dir, default: './app/models' # perhaps you keep your dynamoid models in a different directory?
-    option :application_timezone, default: :local # available values - :utc, :local, time zone names
+    option :application_timezone, default: :utc # available values - :utc, :local, time zone name like "Hawaii"
     option :store_datetime_as_string, default: false # store Time fields in ISO 8601 string format
     option :store_date_as_string, default: false # store Date fields in ISO 8601 string format
     option :backoff, default: nil # callable object to handle exceeding of table throughput limit


### PR DESCRIPTION
Default application time zone was set to `local` to be backward compatible.
Now it's changed.

I believe the default time zone should be UTC (like it is in Rails) and major release is right time to make this change.

It makes sense to make it equal to Rails `config.time_zone` by default in Rails application but maybe next time.