### PR TITLE
Type casting in finders

### DIFF
--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -82,13 +82,9 @@ module Dynamoid
     #
     # @since 0.2.0
     def read(table, ids, options = {}, &blk)
-      range_key = options.delete(:range_key)
-
       if ids.respond_to?(:each)
-        ids = ids.collect { |id| range_key ? [id, range_key] : id }
         batch_get_item({ table => ids }, options, &blk)
       else
-        options[:range_key] = range_key if range_key
         get_item(table, ids, options)
       end
     end

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -131,10 +131,6 @@ module Dynamoid #:nodoc:
       # @example Update document
       #   Post.update(101, read: true)
       def update(hash_key, range_key_value = nil, attrs)
-        range_key_value = if range_key.present?
-                            Dumping.dump_field(range_key_value, attributes[range_key])
-                          end
-
         model = find(hash_key, range_key: range_key_value, consistent_read: true)
         model.update_attributes(attrs)
         model
@@ -324,8 +320,13 @@ module Dynamoid #:nodoc:
     #
     # @since 0.2.0
     def reload
-      range_key_value = range_value ? dumped_range_value : nil
-      self.attributes = self.class.find(hash_key, range_key: range_key_value, consistent_read: true).attributes
+      options = { consistent_read: true }
+
+      if self.class.range_key
+        options[:range_key] = range_value
+      end
+
+      self.attributes = self.class.find(hash_key, options).attributes
       @associations.values.each(&:reset)
       self
     end

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -115,7 +115,11 @@ module Dynamoid #:nodoc:
       def exists?(id_or_conditions = {})
         case id_or_conditions
         when Hash then where(id_or_conditions).first.present?
-        else !!find_by_id(id_or_conditions)
+        else
+          begin
+            find_by_id(id_or_conditions)
+          rescue Dynamoid::Errors::RecordNotFound
+          end
         end
       end
 

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -118,7 +118,9 @@ module Dynamoid #:nodoc:
         else
           begin
             find_by_id(id_or_conditions)
+            true
           rescue Dynamoid::Errors::RecordNotFound
+            false
           end
         end
       end

--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -46,7 +46,7 @@ module Dynamoid
                   end
         expects_array = ids.first.is_a?(Array)
 
-        ids = Array(ids.flatten.uniq)
+        ids = Array(ids.flatten(1).uniq)
         if ids.count == 1
           result = find_by_id(ids.first, options)
           if result.nil?

--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -48,7 +48,12 @@ module Dynamoid
 
         ids = Array(ids.flatten(1).uniq)
         if ids.count == 1
-          result = find_by_id(ids.first, options)
+          result = if ids.first.is_a? Array
+                     id, range_key = ids.first
+                     find_by_id(id, options.merge(range_key: range_key))
+                   else
+                     find_by_id(ids.first, options)
+                   end
           if result.nil?
             message = "Couldn't find #{name} with '#{hash_key}'=#{ids[0]}"
             raise Errors::RecordNotFound, message

--- a/spec/dynamoid/adapter_spec.rb
+++ b/spec/dynamoid/adapter_spec.rb
@@ -91,11 +91,6 @@ describe Dynamoid::Adapter do
       expect(subject).to receive(:get_item).with(test_table, single_id, range_key: 2.0).and_return(true)
       subject.read(test_table, single_id, range_key: 2.0)
     end
-
-    it 'reads through the adapter for many IDs and a range key' do
-      expect(subject).to receive(:batch_get_item).with({ test_table => [['1', 2.0], ['2', 2.0]] }, {}).and_return(true)
-      subject.read(test_table, many_ids, range_key: 2.0)
-    end
   end
 
   describe '#delete' do

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -206,7 +206,6 @@ describe Dynamoid::Document do
 
     describe 'type casting' do
       it 'uses type casted value of sort key to call UpdateItem' do
-        skip 'blocked by missing type casting in finders'
         document_class_with_range = new_class do
           range :count, :integer
           field :title

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -150,9 +150,6 @@ describe Dynamoid::Document do
         field :name
 
         validates :name, presence: true, length: { minimum: 5 }
-        def self.name
-          'Document'
-        end
       end
     end
 

--- a/spec/dynamoid/dumping_spec.rb
+++ b/spec/dynamoid/dumping_spec.rb
@@ -92,14 +92,10 @@ describe 'Dumping' do
         end
 
         models = (1..100).map { klass.create(expired_at: Time.now) }
-        loaded_models = models.map do |m|
-          klass.find(m.id, range_key: Dynamoid::Dumping.dump_field(m.expired_at, klass.attributes[:expired_at]))
-        end
+        loaded_models = models.map { |m| klass.find(m.id, range_key: m.expired_at) }
 
         expect do
-          loaded_models.map do |m|
-            klass.find(m.id, range_key: Dynamoid::Dumping.dump_field(m.expired_at, klass.attributes[:expired_at]))
-          end
+          loaded_models.map { |m| klass.find(m.id, range_key: m.expired_at) }
         end.not_to raise_error
       end
 

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -1,65 +1,210 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'spec_helper'
 
 describe Dynamoid::Finders do
   let!(:address) { Address.create(city: 'Chicago') }
 
-  it 'finds an existing address' do
-    found = Address.find(address.id)
+  describe '.find' do
+    let(:klass) do
+      new_class
+    end
 
-    expect(found).to eq address
-    expect(found.city).to eq 'Chicago'
+    let(:klass_with_composite_key) do
+      new_class do
+        range :age, :integer
+      end
+    end
+
+    context 'one primary key provided' do
+      context 'simple primary key' do
+        it 'finds' do
+          obj = klass.create
+          expect(klass.find(obj.id)).to eql(obj)
+        end
+
+        it 'raises RecordNotFound error when found nothing' do
+          klass.create_table
+          expect {
+            klass.find('wrong-id')
+          }.to raise_error(Dynamoid::Errors::RecordNotFound, "Couldn't find Document with 'id'=wrong-id")
+        end
+      end
+
+      context 'composite primary key' do
+        it 'finds' do
+          obj = klass_with_composite_key.create(age: 12)
+          expect(klass_with_composite_key.find(obj.id, range_key: 12)).to eql(obj)
+        end
+
+        it 'raises RecordNotFound error when found nothing' do
+          klass_with_composite_key.create_table
+          expect {
+            klass_with_composite_key.find('wrong-id', range_key: 100500)
+          }.to raise_error(Dynamoid::Errors::RecordNotFound, "Couldn't find Document with 'id'=wrong-id")
+        end
+      end
+
+      it 'returns persisted? object' do
+        obj = klass.create
+        expect(klass.find(obj.id)).to be_persisted
+      end
+    end
+
+    context 'multiple primary keys provided' do
+      context 'simple primary key' do
+        it 'finds with an array of keys' do
+          objects = (1 .. 2).map { klass.create }
+          obj1, obj2 = objects
+          expect(klass.find([obj1.id, obj2.id])).to match_array(objects)
+        end
+
+        it 'finds with one key' do
+          obj = klass_with_composite_key.create(age: 12)
+          expect(klass_with_composite_key.find([[obj.id, obj.age]])).to eq([obj])
+        end
+
+        it 'returns an empty array if an empty array passed' do
+          klass.create_table
+          expect(klass.find([])).to eql([])
+        end
+
+        it 'raises RecordNotFound error when some objects are not found' do
+          objects = (1 .. 2).map { klass.create }
+          obj1, obj2 = objects
+
+          expect {
+            klass.find([obj1.id, obj2.id, 'wrong-id'])
+          }.to raise_error(
+            Dynamoid::Errors::RecordNotFound,
+            "Couldn't find all Documents with 'id': (#{obj1.id}, #{obj2.id}, wrong-id) " \
+            '(found 2 results, but was looking for 3)'
+          )
+        end
+
+        it 'raises RecordNotFound for single object if only one primary key provided and no result found' do
+          klass.create_table
+          expect {
+            klass.find(['wrong-id'])
+          }.to raise_error(Dynamoid::Errors::RecordNotFound, "Couldn't find Document with 'id'=wrong-id")
+        end
+
+        it 'finds with a list of keys' do
+          objects = (1 .. 2).map { klass.create }
+          obj1, obj2 = objects
+          expect(klass.find(obj1.id, obj2.id)).to match_array(objects)
+        end
+      end
+
+      context 'composite primary key' do
+        it 'finds with an array of keys' do
+          objects = (1 .. 2).map { |i| klass_with_composite_key.create(age: i) }
+          obj1, obj2 = objects
+          expect(klass_with_composite_key.find([[obj1.id, obj1.age], [obj2.id, obj2.age]])).to match_array(objects)
+        end
+
+        it 'finds with one key' do
+          obj = klass_with_composite_key.create(age: 12)
+          expect(klass_with_composite_key.find([[obj.id, obj.age]])).to eq([obj])
+        end
+
+        it 'returns an empty array if an empty array passed' do
+          klass_with_composite_key.create_table
+          expect(klass_with_composite_key.find([])).to eql([])
+        end
+
+        it 'raises RecordNotFound error when some objects are not found' do
+          obj = klass_with_composite_key.create(age: 12)
+          expect {
+            klass_with_composite_key.find([[obj.id, obj.age], ['wrong-id', 100500]])
+          }.to raise_error(
+            Dynamoid::Errors::RecordNotFound,
+            "Couldn't find all Documents with 'id': (#{obj.id}, 12, wrong-id, 100500) " \
+            '(found 1 results, but was looking for 2)')
+        end
+
+        it 'raises RecordNotFound for single object if only one primary key provided and no result found' do
+          klass_with_composite_key.create_table
+          expect {
+            klass_with_composite_key.find([['wrong-id', 100500]])
+          }.to raise_error(Dynamoid::Errors::RecordNotFound, %Q{Couldn't find Document with 'id'=["wrong-id", 100500]})
+        end
+
+        it 'finds with a list of keys' do
+          pending 'still is not implemented'
+
+          objects = (1 .. 2).map { |i| klass_with_composite_key.create(age: i) }
+          obj1, obj2 = objects
+          expect(klass_with_composite_key.find([obj1.id, obj1.age], [obj2.id, obj2.age])).to match_array(objects)
+        end
+      end
+
+      it 'returns persisted? objects' do
+        objects = (1 .. 2).map { |i| klass_with_composite_key.create(age: i) }
+        obj1, obj2 = objects
+
+        objects = klass_with_composite_key.find([[obj1.id, obj1.age], [obj2.id, obj2.age]])
+        obj1, obj2 = objects
+
+        expect(obj1).to be_persisted
+        expect(obj2).to be_persisted
+      end
+
+      context 'backoff is specified' do
+        before do
+          @old_backoff = Dynamoid.config.backoff
+          @old_backoff_strategies = Dynamoid.config.backoff_strategies.dup
+
+          @counter = 0
+          Dynamoid.config.backoff_strategies[:simple] = ->(_) { -> { @counter += 1 } }
+          Dynamoid.config.backoff = { simple: nil }
+        end
+
+        after do
+          Dynamoid.config.backoff = @old_backoff
+          Dynamoid.config.backoff_strategies = @old_backoff_strategies
+        end
+
+        it 'returns items' do
+          users = (1..10).map { User.create }
+
+          results = User.find_all(users.map(&:id))
+          expect(results).to match_array(users)
+        end
+
+        it 'returns empty array when there are no results' do
+          User.create_table
+          expect(User.find_all(['some-fake-id'])).to eq []
+        end
+
+        it 'uses specified backoff when some items are not processed' do
+          # batch_get_item has following limitations:
+          # * up to 100 items at once
+          # * up to 16 MB at once
+          #
+          # So we write data as large as possible and read it back
+          # 100 * 400 KB (limit for item) = ~40 MB
+          # 40 MB / 16 MB = 3 times
+
+          ids = (1..100).map(&:to_s)
+          users = ids.map do |id|
+            name = ' ' * (400.kilobytes - 120) # 400KB - length(attribute names)
+            User.create(id: id, name: name)
+          end
+
+          results = User.find_all(users.map(&:id))
+          expect(results).to match_array(users)
+
+          expect(@counter).to eq 2
+        end
+
+        it 'uses new backoff after successful call without unprocessed items' do
+          skip 'it is difficult to test'
+        end
+      end
+    end
   end
 
-  it 'is not a new object' do
-    found = Address.find(address.id)
-
-    expect(found.new_record).to be_falsey
-  end
-
-  it 'raises error when nothing is found' do
-    expect { Address.find('1234') }.to raise_error(
-      Dynamoid::Errors::RecordNotFound, "Couldn't find Address with 'id'=1234"
-    )
-  end
-
-  it 'finds multiple ids' do
-    address2 = Address.create(city: 'Illinois')
-
-    expect(Set.new(Address.find(address.id, address2.id))).to eq Set.new([address, address2])
-  end
-
-  it 'raises error when passed several ids and some models were not found' do
-    a1 = Address.create
-    a2 = Address.create
-    expect { Address.find(a1.id, a2.id, 'fake-id') }.to raise_error(
-      Dynamoid::Errors::RecordNotFound,
-      "Couldn't find all Addresses with 'id': (#{a1.id}, #{a2.id}, fake-id) " \
-      '(found 2 results, but was looking for 3)'
-    )
-  end
-
-  it 'returns array if passed in array' do
-    expect(Address.find([address.id])).to eq [address]
-  end
-
-  it 'returns object if non array id is passed in' do
-    expect(Address.find(address.id)).to eq address
-  end
-
-  it 'raises error if non-array id is passed in and no result found' do
-    expect { Address.find('not-existing-id') }.to raise_error(
-      Dynamoid::Errors::RecordNotFound,
-      "Couldn't find Address with 'id'=not-existing-id"
-    )
-  end
-
-  it 'raises error if array of ids is passed in and no result found' do
-    expect { Address.find(['not-existing-id']) }.to raise_error(
-      Dynamoid::Errors::RecordNotFound, "Couldn't find Address with 'id'=not-existing-id"
-    )
-  end
 
   # TODO: ATM, adapter sets consistent read to be true for all query. Provide option for setting consistent_read option
   # it 'sends consistent option to the adapter' do
@@ -147,82 +292,11 @@ describe Dynamoid::Finders do
   end
 
   context 'find_all' do
-    it 'should return a array of users' do
-      users = (1..10).map { User.create }
-      expect(User.find_all(users.map(&:id))).to match_array(users)
-    end
-
-    it 'should return a array of tweets' do
-      tweets = (1..10).map { |i| Tweet.create(tweet_id: i.to_s, group: "group_#{i}") }
-      expect(Tweet.find_all(tweets.map { |t| [t.tweet_id, t.group] })).to match_array(tweets)
-    end
-
-    it 'should return an empty array' do
-      expect(User.find_all([])).to eq([])
-    end
-
-    it 'returns empty array when there are no results' do
-      expect(Address.find_all('bad' + address.id.to_s)).to eq []
-    end
-
     it 'passes options to the adapter' do
       pending 'This test is broken as we are overriding the consistent_read option to true inside the adapter'
       user_ids = [%w[1 red], %w[1 green]]
       Dynamoid.adapter.expects(:read).with(anything, user_ids, consistent_read: true)
       User.find_all(user_ids, consistent_read: true)
-    end
-
-    context 'backoff is specified' do
-      before do
-        @old_backoff = Dynamoid.config.backoff
-        @old_backoff_strategies = Dynamoid.config.backoff_strategies.dup
-
-        @counter = 0
-        Dynamoid.config.backoff_strategies[:simple] = ->(_) { -> { @counter += 1 } }
-        Dynamoid.config.backoff = { simple: nil }
-      end
-
-      after do
-        Dynamoid.config.backoff = @old_backoff
-        Dynamoid.config.backoff_strategies = @old_backoff_strategies
-      end
-
-      it 'returns items' do
-        users = (1..10).map { User.create }
-
-        results = User.find_all(users.map(&:id))
-        expect(results).to match_array(users)
-      end
-
-      it 'returns empty array when there are no results' do
-        User.create_table
-        expect(User.find_all(['some-fake-id'])).to eq []
-      end
-
-      it 'uses specified backoff when some items are not processed' do
-        # batch_get_item has following limitations:
-        # * up to 100 items at once
-        # * up to 16 MB at once
-        #
-        # So we write data as large as possible and read it back
-        # 100 * 400 KB (limit for item) = ~40 MB
-        # 40 MB / 16 MB = 3 times
-
-        ids = (1..100).map(&:to_s)
-        users = ids.map do |id|
-          name = ' ' * (400.kilobytes - 120) # 400KB - length(attribute names)
-          User.create(id: id, name: name)
-        end
-
-        results = User.find_all(users.map(&:id))
-        expect(results).to match_array(users)
-
-        expect(@counter).to eq 2
-      end
-
-      it 'uses new backoff after successful call without unprocessed items' do
-        skip 'it is difficult to test'
-      end
     end
   end
 

--- a/spec/dynamoid/identity_map_spec.rb
+++ b/spec/dynamoid/identity_map_spec.rb
@@ -30,7 +30,7 @@ describe Dynamoid::IdentityMap do
     it 'clears cache on delete' do
       tweet = Tweet.create(tweet_id: 'x', group: 'one')
       tweet.delete
-      expect(Tweet.find_by_id('x', range_key: 'one')).to be_nil
+      expect { Tweet.find_by_id('x', range_key: 'one') }.to raise_error(Dynamoid::Errors::RecordNotFound)
     end
   end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -361,32 +361,19 @@ describe Dynamoid::Persistence do
   end
 
   context 'single table inheritance (STI)' do
-    let!(:class_a) do
-      new_class do
+    before do
+      A = new_class class_name: 'A' do
         field :type
       end
-    end
-
-    let!(:class_b) do
-      Class.new(class_a) do
+      B = Class.new(A) do
+        def self.name; 'B'; end
       end
-    end
-
-    let!(:class_c) do
-      Class.new(class_a) do
+      C = Class.new(A) do
+        def self.name; 'C'; end
       end
-    end
-
-    let!(:class_d) do
-      Class.new(class_b) do
+      D = Class.new(B) do
+        def self.name; 'D'; end
       end
-    end
-
-    before do
-      A = class_a
-      B = class_b
-      C = class_c
-      D = class_d
     end
 
     after do
@@ -397,31 +384,31 @@ describe Dynamoid::Persistence do
     end
 
     it 'saves subclass objects in the parent table' do
-      b = class_b.create
-      expect(class_a.find(b.id)).to eql b
+      b = B.create
+      expect(A.find(b.id)).to eql b
     end
 
     it 'loads subclass item when querying the parent table' do
-      b = class_b.create!
-      c = class_c.create!
-      d = class_d.create!
+      b = B.create!
+      c = C.create!
+      d = D.create!
 
-      expect(class_a.all.to_a).to contain_exactly(b, c, d)
+      expect(A.all.to_a).to contain_exactly(b, c, d)
     end
 
     it 'does not load parent item when quering the child table' do
-      a = class_a.create!
-      b = class_b.create!
+      a = A.create!
+      b = B.create!
 
-      expect(class_b.all.to_a).to eql([b])
+      expect(B.all.to_a).to eql([b])
     end
 
     it 'does not load items of sibling class' do
-      b = class_b.create!
-      c = class_c.create!
+      b = B.create!
+      c = C.create!
 
-      expect(class_b.all.to_a).to eql([b])
-      expect(class_c.all.to_a).to eql([c])
+      expect(B.all.to_a).to eql([b])
+      expect(C.all.to_a).to eql([c])
     end
   end
 

--- a/spec/support/new_class_helper.rb
+++ b/spec/support/new_class_helper.rb
@@ -3,10 +3,17 @@
 module NewClassHelper
   def new_class(options = {}, &blk)
     table_name = options[:table_name] || :documents
+    class_name = (options[:class_name] || table_name).to_s.classify
 
     klass = Class.new do
       include Dynamoid::Document
       table name: table_name
+
+      @class_name = class_name
+
+      def self.name
+        @class_name
+      end
     end
     klass.class_exec(options, &blk) if block_given?
     klass


### PR DESCRIPTION
Based on https://github.com/Dynamoid/Dynamoid/pull/278

* Type cast sort key passed to finder methods `find`, `find_all` and `find_by_id`
* Fixe some bugs in `.find`
* As a side effect `find_all` and `find_by_id` raise a RecordNotFound errors now.