### PR TITLE
[WIP] Use string format for date and datetime by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,8 +683,8 @@ Listed below are all configuration options.
 * `models_dir` - `dynamoid:create_tables` rake task loads DynamoDb models from this directory. Default is `./app/models`.
 * `application_timezone` - Dynamoid converts all `datetime` fields to specified time zone when loads data from the storage.
   Acceptable values - `utc`, `local` (to use system time zone) and time zone name e.g. `Eastern Time (US & Canada)`. Default is `utc`
-* `store_datetime_as_string` - if `true` then Dynamoid stores :datetime fields in ISO 8601 string format. Default is `false`
-* `store_date_as_string` - if `true` then Dynamoid stores :date fields in ISO 8601 string format. Default is `false`
+* `store_datetime_as_string` - if `true` then Dynamoid stores :datetime fields in ISO 8601 string format. Otherwise Unix epoch time is used. Default is `true`
+* `store_date_as_string` - if `true` then Dynamoid stores :date fields in ISO 8601 string format. Otherwise date is stored as number of days since 1 January 1970. Default is `true`
 * `backoff` - is a hash: key is a backoff strategy (symbol), value is parameters for the strategy. Is used in batch operations. Default id `nil`
 * `backoff_strategies`: is a hash and contains all available strategies. Default is { constant: ..., exponential: ...}
 

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -31,8 +31,8 @@ module Dynamoid
     option :convert_big_decimal, default: false
     option :models_dir, default: './app/models' # perhaps you keep your dynamoid models in a different directory?
     option :application_timezone, default: :utc # available values - :utc, :local, time zone name like "Hawaii"
-    option :store_datetime_as_string, default: false # store Time fields in ISO 8601 string format
-    option :store_date_as_string, default: false # store Date fields in ISO 8601 string format
+    option :store_datetime_as_string, default: true # store Time fields in ISO 8601 string format
+    option :store_date_as_string, default: true # store Date fields in ISO 8601 string format
     option :backoff, default: nil # callable object to handle exceeding of table throughput limit
     option :backoff_strategies, default: {
       constant: BackoffStrategies::ConstantBackoff,


### PR DESCRIPTION
I propose to store Date and DateTime in string format **by default** because
- it's more universal format
- it's more readable
- and easier to work with.