### PR TITLE
Set timestamps

### DIFF
--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -236,9 +236,14 @@ module Dynamoid #:nodoc:
 
         options[:conditions] = conditions
 
+        attrs = attrs.symbolize_keys
+        if Dynamoid::Config.timestamps
+          attrs[:updated_at] ||= DateTime.now.in_time_zone(Time.zone)
+        end
+
         begin
           new_attrs = Dynamoid.adapter.update_item(table_name, hash_key_value, options) do |t|
-            attrs.symbolize_keys.each do |k, v|
+            attrs.each do |k, v|
               value_casted = TypeCasting.cast_field(v, attributes[k])
               value_dumped = Dumping.dump_field(value_casted, attributes[k])
               t.set(k => value_dumped)

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -181,9 +181,14 @@ module Dynamoid #:nodoc:
         (conditions[:if_exists] ||= {})[hash_key] = hash_key_value
         options[:conditions] = conditions
 
+        attrs = attrs.symbolize_keys
+        if Dynamoid::Config.timestamps
+          attrs[:updated_at] ||= DateTime.now.in_time_zone(Time.zone)
+        end
+
         begin
           new_attrs = Dynamoid.adapter.update_item(table_name, hash_key_value, options) do |t|
-            attrs.symbolize_keys.each do |k, v|
+            attrs.each do |k, v|
               value_casted = TypeCasting.cast_field(v, attributes[k])
               value_dumped = Dumping.dump_field(value_casted, attributes[k])
               t.set(k => value_dumped)

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -78,6 +78,14 @@ module Dynamoid
       #   User.import([{ name: 'a' }, { name: 'b' }])
       def import(objects)
         documents = objects.map do |attrs|
+          attrs = attrs.symbolize_keys
+
+          if Dynamoid::Config.timestamps
+            time_now = DateTime.now.in_time_zone(Time.zone)
+            attrs[:created_at] ||= time_now
+            attrs[:updated_at] ||= time_now
+          end
+
           build(attrs).tap do |item|
             item.hash_key = SecureRandom.uuid if item.hash_key.blank?
           end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -164,6 +164,12 @@ module Dynamoid
           new_attrs = Dynamoid.adapter.update_item(self.class.table_name, hash_key, options.merge(conditions: conditions)) do |t|
             t.add(lock_version: 1) if self.class.attributes[:lock_version]
 
+            if Dynamoid::Config.timestamps
+              time_now = DateTime.now.in_time_zone(Time.zone)
+              time_now_dumped = Dumping.dump_field(time_now, self.class.attributes[:updated_at])
+              t.set(updated_at: time_now_dumped)
+            end
+
             yield t
           end
           load(Undumping.undump_attributes(new_attrs, self.class.attributes))

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -425,6 +425,39 @@ describe Dynamoid::Document do
       expect(attributes[:published_on]).to eq 17_585
     end
 
+    describe 'timestamps' do
+      it 'sets updated_at if Config.timestamps=true', config: { timestamps: true } do
+        obj = document_class.create(title: 'Old title')
+
+        travel 1.hour do
+          time_now = Time.now
+
+          expect {
+            document_class.upsert(obj.id, title: 'New title')
+          }.to change { obj.reload.updated_at.to_i }.to(time_now.to_i)
+        end
+      end
+
+      it 'uses provided value of updated_at if Config.timestamps=true', config: { timestamps: true } do
+        obj = document_class.create(title: 'Old title')
+
+        travel 1.hour do
+          updated_at = Time.now + 1.hour
+
+          expect {
+            document_class.upsert(obj.id, title: 'New title', updated_at: updated_at)
+          }.to change { obj.reload.updated_at.to_i }.to(updated_at.to_i)
+        end
+      end
+
+      it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
+        obj = document_class.create(title: 'Old title')
+        document_class.upsert(obj.id, title: 'New title')
+        expect(obj.reload.title).to eql('New title')
+        expect(obj.reload.updated_at).to eql(nil)
+      end
+    end
+
     describe 'type casting' do
       it 'uses casted value of sort key to call UpdateItem' do
         document_class_with_range = new_class do

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -376,6 +376,43 @@ describe Dynamoid::Fields do
         expect(raw_attributes(obj)[:count]).to eql(101)
       end
     end
+
+    describe 'timestamps' do
+      let(:klass) do
+        new_class do
+          field :title
+        end
+      end
+
+      it 'sets updated_at if Config.timestamps=true', config: { timestamps: true } do
+        obj = klass.create(title: 'Old title')
+
+        travel 1.hour do
+          time_now = Time.now
+          obj.update_attribute(:title, 'New title')
+
+          expect(obj.updated_at.to_i).to eql(time_now.to_i)
+        end
+      end
+
+      it 'uses provided value updated_at if Config.timestamps=true', config: { timestamps: true } do
+        obj = klass.create(title: 'Old title')
+
+        travel 1.hour do
+          updated_at = Time.now
+          obj.update_attribute(:updated_at, updated_at)
+
+          expect(obj.updated_at.to_i).to eql(updated_at.to_i)
+        end
+      end
+
+      it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
+        obj = klass.create(title: 'Old title')
+        obj.update_attribute(:title, 'New title')
+
+        expect(obj.updated_at).to eql(nil)
+      end
+    end
   end
 
   describe '#update_attributes' do
@@ -389,6 +426,43 @@ describe Dynamoid::Fields do
         obj.update_attributes(count: '101')
         expect(obj.attributes[:count]).to eql(101)
         expect(raw_attributes(obj)[:count]).to eql(101)
+      end
+    end
+
+    describe 'timestamps' do
+      let(:klass) do
+        new_class do
+          field :title
+        end
+      end
+
+      it 'sets updated_at if Config.timestamps=true', config: { timestamps: true } do
+        obj = klass.create(title: 'Old title')
+
+        travel 1.hour do
+          time_now = Time.now
+          obj.update_attributes(title: 'New title')
+
+          expect(obj.updated_at.to_i).to eql(time_now.to_i)
+        end
+      end
+
+      it 'uses provided value updated_at if Config.timestamps=true', config: { timestamps: true } do
+        obj = klass.create(title: 'Old title')
+
+        travel 1.hour do
+          updated_at = Time.now
+          obj.update_attributes(updated_at: updated_at, title: 'New title')
+
+          expect(obj.updated_at.to_i).to eql(updated_at.to_i)
+        end
+      end
+
+      it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
+        obj = klass.create(title: 'Old title')
+        obj.update_attributes(title: 'New title')
+
+        expect(obj.updated_at).to eql(nil)
       end
     end
   end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -108,45 +108,6 @@ describe Dynamoid::Fields do
       expect(address.id).to eq original_id
     end
 
-    it 'should update only updated_at when no params are passed' do
-      initial_updated_at = address.updated_at
-      address.update_attributes([])
-      expect(address.updated_at).to_not eq initial_updated_at
-    end
-
-    context 'when timestamps are specified' do
-      it 'uses specified created_at at creation' do
-        time = Time.now - 1.day
-        address = Address.create!(created_at: time)
-        expect(address.created_at).to eq(time)
-      end
-
-      it 'uses specified updated_at at creation' do
-        time = Time.now - 1.day
-        address = Address.create!(updated_at: time)
-        expect(address.updated_at).to eq(time)
-      end
-
-      it 'uses specified updated_at at updating' do
-        time = Time.now - 1.day
-
-        expect do
-          address.city = 'foobar'
-          address.updated_at = time
-          address.save!
-        end.to change { address.updated_at }.to(time)
-      end
-
-      it 'changes updated_at at updating' do
-        expect do
-          address.city = 'foobar'
-          address.save!
-        end.to change { address.updated_at }
-
-        expect(address.updated_at).to be_present
-      end
-    end
-
     it 'adds in dirty methods for attributes' do
       address.city = 'Chicago'
       address.save

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -824,6 +824,44 @@ describe Dynamoid::Persistence do
       expect(user.todo_list).to eq nil
     end
 
+    describe 'timestamps' do
+      let(:klass) do
+        new_class
+      end
+
+      before do
+        klass.create_table
+      end
+
+      it 'sets created_at and updated_at if Config.timestamps=true', config: { timestamps: true } do
+        travel 1.hour do
+          time_now = Time.now
+          obj, = klass.import([{}])
+
+          expect(obj.created_at.to_i).to eql(time_now.to_i)
+          expect(obj.updated_at.to_i).to eql(time_now.to_i)
+        end
+      end
+
+      it 'uses provided values of created_at and updated_at if Config.timestamps=true', config: { timestamps: true } do
+        travel 1.hour do
+          created_at = updated_at = Time.now
+          obj, = klass.import([{ created_at: created_at, updated_at: updated_at }])
+
+          expect(obj.created_at.to_i).to eql(created_at.to_i)
+          expect(obj.updated_at.to_i).to eql(updated_at.to_i)
+        end
+      end
+
+      it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
+        created_at = updated_at = Time.now
+        obj, = klass.import([{}])
+
+        expect(obj.created_at).to eql(nil)
+        expect(obj.updated_at).to eql(nil)
+      end
+    end
+
     it 'dumps attribute values' do
       klass = new_class do
         field :active, :boolean

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -457,35 +457,6 @@ describe Dynamoid::Persistence do
     end
   end
 
-  context 'with timestamps set to false' do
-    def reload_address
-      Object.send(:remove_const, 'Address')
-      load 'app/models/address.rb'
-    end
-
-    timestamps = Dynamoid::Config.timestamps
-
-    before do
-      reload_address
-      Dynamoid.configure do |config|
-        config.timestamps = false
-      end
-    end
-
-    after do
-      reload_address
-      Dynamoid.configure do |config|
-        config.timestamps = timestamps
-      end
-    end
-
-    it 'sets nil to created_at and updated_at' do
-      address = Address.create
-      expect(address.created_at).to be_nil
-      expect(address.updated_at).to be_nil
-    end
-  end
-
   it 'deletes an item completely' do
     @user = User.create(name: 'Josh')
     @user.destroy

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'coveralls'
+require 'active_support/testing/time_helpers.rb'
+
 Coveralls.wear!
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
@@ -47,6 +49,7 @@ RSpec.configure do |config|
   config.include NewClassHelper
   config.include DumpingHelper
   config.include PersictenseHelper
+  config.include ActiveSupport::Testing::TimeHelpers
 
   config.before(:each) do
     DynamoDBLocal.delete_all_specified_tables!


### PR DESCRIPTION
Related issue https://github.com/Dynamoid/dynamoid/issues/284

Set timestamps (`created_at`/`updated_at`) in:
- upsert
- update_fields
- import
- update