### PR TITLE
Disable scan warning when intentionally loading all items from a collection

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -148,7 +148,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def records_via_scan
-        if Dynamoid::Config.warn_on_scan
+        if Dynamoid::Config.warn_on_scan && query.present?
           Dynamoid.logger.warn 'Queries without an index are forced to use scan and are generally much slower than indexed queries!'
           Dynamoid.logger.warn "You can index this query by adding index declaration to #{source.to_s.downcase}.rb:"
           Dynamoid.logger.warn "* global_secondary_index hash_key: 'some-name', range_key: 'some-another-name'"

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -77,7 +77,7 @@ describe Dynamoid::Criteria do
     end.not_to raise_error(Dynamoid::Errors::InvalidQuery)
   end
 
-  context 'when scans and warn_on_scan config option is true' do
+  context 'when scans using non-indexed fields and warn_on_scan config option is true' do
     before do
       @warn_on_scan = Dynamoid::Config.warn_on_scan
       Dynamoid::Config.warn_on_scan = true
@@ -94,6 +94,21 @@ describe Dynamoid::Criteria do
       expect(Dynamoid.logger).to receive(:warn).with('Not indexed attributes: :name, :password')
 
       User.where(name: 'x', password: 'password').all
+    end
+  end
+  context 'when doing intentional, full-table scan (query is empty) and warn_on_scan config option is true' do
+    before do
+      @warn_on_scan = Dynamoid::Config.warn_on_scan
+      Dynamoid::Config.warn_on_scan = true
+    end
+    after do
+      Dynamoid::Config.warn_on_scan = @warn_on_scan
+    end
+
+    it 'does not log any warnings' do
+      expect(Dynamoid.logger).not_to receive(:warn)
+
+      User.all
     end
   end
 end


### PR DESCRIPTION
This is a fix/improvement discussed in #273. The change modified scan warning not to show if user is intentionally loading full collection into memory (that is, when there is not query/criteria).