### PR TITLE
Add store_boolean_as_native global config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,16 +144,16 @@ The primary use case for using a custom field type is to represent your business
 
 #### Note on boolean type
 
-The boolean fields are stored as `'t'` and `'f'` strings by default. DynamoDB
-supports boolean type natively. So if you want to use native boolean
-type or already have table with native boolean attribute you can easily
-achieve this with `store_as_native_boolean` option:
+The boolean fields are stored as DynamoDB boolean values by default.
+Dynamoid can store boolean values as strings as well - `'t'` and `'f'`.
+So if you want to change default format of boolean field you can easily
+achieve this with `store_as_native_boolean` field option:
 
 ```ruby
 class Document
   include DynamoId::Document
 
-  field :active, :boolean, store_as_native_boolean: true
+  field :active, :boolean, store_as_native_boolean: false
 end
 ```
 
@@ -685,6 +685,9 @@ Listed below are all configuration options.
   Acceptable values - `utc`, `local` (to use system time zone) and time zone name e.g. `Eastern Time (US & Canada)`. Default is `utc`
 * `store_datetime_as_string` - if `true` then Dynamoid stores :datetime fields in ISO 8601 string format. Default is `false`
 * `store_date_as_string` - if `true` then Dynamoid stores :date fields in ISO 8601 string format. Default is `false`
+* `store_boolean_as_native` - if `true` Dynamoid stores boolean fields as native DynamoDB
+  boolean values. Otherwise boolean fields are stored as string values
+`'t'` and `'f'`. Default is true
 * `backoff` - is a hash: key is a backoff strategy (symbol), value is parameters for the strategy. Is used in batch operations. Default id `nil`
 * `backoff_strategies`: is a hash and contains all available strategies. Default is { constant: ..., exponential: ...}
 

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -33,7 +33,7 @@ module Dynamoid
     option :application_timezone, default: :utc # available values - :utc, :local, time zone name like "Hawaii"
     option :store_datetime_as_string, default: false # store Time fields in ISO 8601 string format
     option :store_date_as_string, default: false # store Date fields in ISO 8601 string format
-    option :store_boolean_as_native, default: false
+    option :store_boolean_as_native, default: true
     option :backoff, default: nil # callable object to handle exceeding of table throughput limit
     option :backoff_strategies, default: {
       constant: BackoffStrategies::ConstantBackoff,

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -33,6 +33,7 @@ module Dynamoid
     option :application_timezone, default: :utc # available values - :utc, :local, time zone name like "Hawaii"
     option :store_datetime_as_string, default: false # store Time fields in ISO 8601 string format
     option :store_date_as_string, default: false # store Date fields in ISO 8601 string format
+    option :store_boolean_as_native, default: false
     option :backoff, default: nil # callable object to handle exceeding of table throughput limit
     option :backoff_strategies, default: {
       constant: BackoffStrategies::ConstantBackoff,

--- a/lib/dynamoid/dumping.rb
+++ b/lib/dynamoid/dumping.rb
@@ -134,8 +134,13 @@ module Dynamoid
     class BooleanDumper < Base
       def process(value)
         unless value.nil?
-          if @options[:store_as_native_boolean]
-            !!value # native boolean type
+          store_as_boolean = if @options[:store_as_native_boolean].nil?
+                               Dynamoid.config.store_boolean_as_native
+                             else
+                               @options[:store_as_native_boolean]
+                             end
+          if store_as_boolean
+            !!value
           else
             value.to_s[0] # => "f" or "t"
           end

--- a/lib/dynamoid/undumping.rb
+++ b/lib/dynamoid/undumping.rb
@@ -156,10 +156,15 @@ module Dynamoid
 
     class BooleanUndumper < Base
       def process(value)
-        if ['t', true].include? value
-          true
-        elsif ['f', false].include? value
-          false
+        store_as_boolean = if @options[:store_as_native_boolean].nil?
+                             Dynamoid.config.store_boolean_as_native
+                           else
+                             @options[:store_as_native_boolean]
+                           end
+        if store_as_boolean
+          !!value
+        elsif ['t', 'f'].include?(value)
+          value == 't'
         else
           raise ArgumentError, 'Boolean column neither true nor false'
         end

--- a/lib/dynamoid/undumping.rb
+++ b/lib/dynamoid/undumping.rb
@@ -155,6 +155,8 @@ module Dynamoid
     end
 
     class BooleanUndumper < Base
+      STRING_VALUES = ['t', 'f']
+
       def process(value)
         store_as_boolean = if @options[:store_as_native_boolean].nil?
                              Dynamoid.config.store_boolean_as_native
@@ -163,7 +165,7 @@ module Dynamoid
                            end
         if store_as_boolean
           !!value
-        elsif ['t', 'f'].include?(value)
+        elsif STRING_VALUES.include?(value)
           value == 't'
         else
           raise ArgumentError, 'Boolean column neither true nor false'

--- a/spec/dynamoid/dumping_spec.rb
+++ b/spec/dynamoid/dumping_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'Dumping' do
   describe 'Boolean field' do
-    context 'stored in string format' do
+    context 'string format' do
       let(:klass) do
         new_class do
           field :active, :boolean
@@ -30,7 +30,7 @@ describe 'Dumping' do
       end
     end
 
-    context 'stored in boolean format' do
+    context 'boolean format' do
       let(:klass) do
         new_class do
           field :active, :boolean, store_as_native_boolean: true
@@ -61,6 +61,94 @@ describe 'Dumping' do
         obj = klass.create(active: nil)
         expect(reload(obj).active).to eql(nil)
         expect(raw_attributes(obj)[:active]).to eql(nil)
+      end
+    end
+
+    describe '"store_boolean_as_native" global config option' do
+      it 'is stored as boolean by default' do
+        klass = new_class do
+          field :active, :boolean
+        end
+        obj = klass.create(active: true)
+
+        expect(raw_attributes(obj)[:active]).to eql(true)
+        expect(reload(obj).active).to eql(true)
+      end
+
+      context 'store_boolean_as_native=true' do
+        it 'is stored as boolean if field option store_as_native_boolean is not set',
+          config: { store_boolean_as_native: true } do
+
+          klass = new_class do
+            field :active, :boolean
+          end
+          obj = klass.create(active: true)
+
+          expect(raw_attributes(obj)[:active]).to eql(true)
+          expect(reload(obj).active).to eql(true)
+        end
+
+        it 'is stored as boolean if field option store_as_native_boolean=true',
+          config: { store_boolean_as_native: true } do
+
+          klass = new_class do
+            field :active, :boolean, store_as_native_boolean: true
+          end
+          obj = klass.create(active: true)
+
+          expect(raw_attributes(obj)[:active]).to eql(true)
+          expect(reload(obj).active).to eql(true)
+        end
+
+        it 'is stored as string if field option store_as_native_boolean=false',
+          config: { store_boolean_as_native: true } do
+
+          klass = new_class do
+            field :active, :boolean, store_as_native_boolean: false
+          end
+          obj = klass.create(active: true)
+
+          expect(raw_attributes(obj)[:active]).to eql('t')
+          expect(reload(obj).active).to eql(true)
+        end
+      end
+
+      context 'store_boolean_as_native=false' do
+        it 'is stored as string if field option store_as_native_boolean is not set',
+          config: { store_boolean_as_native: false } do
+
+          klass = new_class do
+            field :active, :boolean
+          end
+          obj = klass.create(active: true)
+
+          expect(raw_attributes(obj)[:active]).to eql('t')
+          expect(reload(obj).active).to eql(true)
+        end
+
+        it 'is stored as boolean if field option store_as_native_boolean=true',
+          config: { store_boolean_as_native: false } do
+
+          klass = new_class do
+            field :active, :boolean, store_as_native_boolean: true
+          end
+          obj = klass.create(active: true)
+
+          expect(raw_attributes(obj)[:active]).to eql(true)
+          expect(reload(obj).active).to eql(true)
+        end
+
+        it 'is stored as string if field option store_as_native_boolean=false',
+          config: { store_boolean_as_native: false } do
+
+          klass = new_class do
+            field :active, :boolean, store_as_native_boolean: false
+          end
+          obj = klass.create(active: true)
+
+          expect(raw_attributes(obj)[:active]).to eql('t')
+          expect(reload(obj).active).to eql(true)
+        end
       end
     end
   end

--- a/spec/dynamoid/dumping_spec.rb
+++ b/spec/dynamoid/dumping_spec.rb
@@ -7,7 +7,7 @@ describe 'Dumping' do
     context 'string format' do
       let(:klass) do
         new_class do
-          field :active, :boolean
+          field :active, :boolean, store_as_native_boolean: false
         end
       end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -518,7 +518,7 @@ describe Dynamoid::Persistence do
 
     it 'dumps attribute values' do
       klass = new_class do
-        field :active, :boolean
+        field :active, :boolean, store_as_native_boolean: false
       end
 
       obj = klass.new(active: false)
@@ -966,7 +966,7 @@ describe Dynamoid::Persistence do
 
     it 'dumps attribute values' do
       klass = new_class do
-        field :active, :boolean
+        field :active, :boolean, store_as_native_boolean: false
       end
       klass.create_table
 


### PR DESCRIPTION
The option is similar to the `store_as_native_boolean` field option and means the same.

By default the option is true so any boolean field will be stored as native DynamoDB's boolean value.