### PR TITLE
Fix flaky specs related to numeric datetime format

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ end
 
 #### Note on datetime type
 
-By default datetime fields are persisted as UNIX timestamps with millisecond precission in DynamoDB. If you prefer datetimes to be stored as ISO-8601 formatted strings instead then set `store_as_string` to `true`
+By default datetime fields are persisted as UNIX timestamps with millisecond precision in DynamoDB. If you prefer datetimes to be stored as ISO-8601 formatted strings instead then set `store_as_string` to `true`
 
 ```ruby
 class Document

--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ By default date fields are persisted as days count since 1 January 1970 like UNI
 class Document
   include DynamoId::Document
 
-  field :sent_at, :datetime, store_as_string: true
+  field :sent_on, :date, store_as_string: true
 end
 ```
 
 #### Note on datetime type
 
-By default datetime fields are persisted as UNIX timestamps with milisecond precission in DynamoDB. If you prefer datetimes to be stored as ISO-8601 formatted strings instead then set `store_as_string` to `true`
+By default datetime fields are persisted as UNIX timestamps with millisecond precission in DynamoDB. If you prefer datetimes to be stored as ISO-8601 formatted strings instead then set `store_as_string` to `true`
 
 ```ruby
 class Document
@@ -180,6 +180,14 @@ class Document
   field :sent_at, :datetime, store_as_string: true
 end
 ```
+
+WARNING: Fiels in numeric format are stored with nanoseconds as a fraction part and precision could be lost.
+That's why `datetime` field in numeric format shouldn't be used as a range key.
+
+There are following options if you need to use `datetime` field as a range key:
+* to use string format
+* to store `datetime` values without milliseconds e.g. cut them
+  manually with `change` method - `Time.now.change(usec: 0)`
 
 #### Note on set type
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ class Document
 end
 ```
 
-WARNING: Fiels in numeric format are stored with nanoseconds as a fraction part and precision could be lost.
+WARNING: Fields in numeric format are stored with nanoseconds as a fraction part and precision could be lost.
 That's why `datetime` field in numeric format shouldn't be used as a range key.
 
 There are following options if you need to use `datetime` field as a range key:

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ end
 WARNING: Fields in numeric format are stored with nanoseconds as a fraction part and precision could be lost.
 That's why `datetime` field in numeric format shouldn't be used as a range key.
 
-There are following options if you need to use `datetime` field as a range key:
-* to use string format
-* to store `datetime` values without milliseconds e.g. cut them
+You have two options if you need to use a `datetime` field as a range key:
+* string format
+* store `datetime` values without milliseconds e.g. cut them
   manually with `change` method - `Time.now.change(usec: 0)`
 
 #### Note on set type

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -75,6 +75,13 @@ module Dynamoid
           @connection_hash[:region] = Dynamoid::Config.region
         end
 
+        # https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb
+        # https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/log/formatter.rb
+        formatter = Aws::Log::Formatter.new(':operation | Request :http_request_body | Response :http_response_body')
+        @connection_hash[:logger] = Dynamoid::Config.logger
+        @connection_hash[:log_level] = :debug
+        @connection_hash[:log_formatter] = formatter
+
         @connection_hash
       end
 

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -606,12 +606,12 @@ describe Dynamoid::Document do
 
     it 'uses dumped value of sort key to load document' do
       klass = new_class do
-        range :activated_at, :datetime
+        range :activated_on, :date
         field :name
       end
 
-      obj = klass.create!(activated_at: Time.now, name: 'Old value')
-      obj2 = klass.where(id: obj.id, activated_at: obj.activated_at).first
+      obj = klass.create!(activated_on: Date.today, name: 'Old value')
+      obj2 = klass.where(id: obj.id, activated_on: obj.activated_on).first
       obj2.update_attributes(name: 'New value')
 
       expect { obj.reload }.to change {

--- a/spec/dynamoid/dumping_spec.rb
+++ b/spec/dynamoid/dumping_spec.rb
@@ -174,19 +174,6 @@ describe 'Dumping' do
         expect(raw_attributes(obj)[:sent_at]).to eql(BigDecimal('1532131200.0'))
       end
 
-      it 'does not loose precision and can be used as sort key', :bugfix do
-        klass = new_class do
-          range :expired_at, :datetime
-        end
-
-        models = (1..100).map { klass.create(expired_at: Time.now) }
-        loaded_models = models.map { |m| klass.find(m.id, range_key: m.expired_at) }
-
-        expect do
-          loaded_models.map { |m| klass.find(m.id, range_key: m.expired_at) }
-        end.not_to raise_error
-      end
-
       it 'stores nil value' do
         obj = klass.create(sent_at: nil)
         expect(reload(obj).sent_at).to eql(nil)

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -680,12 +680,12 @@ describe Dynamoid::Persistence do
 
     it 'uses dumped value of sort key to call UpdateItem' do
       klass = new_class do
-        range :activated_at, :datetime
+        range :activated_on, :date
         field :name
       end
       klass.create_table
 
-      obj = klass.create!(activated_at: Time.now, name: 'Old value')
+      obj = klass.create!(activated_on: Date.today, name: 'Old value')
       obj.update! { |d| d.set(name: 'New value') }
 
       expect(obj.reload.name).to eql('New value')
@@ -738,13 +738,13 @@ describe Dynamoid::Persistence do
   context 'delete' do
     it 'uses dumped value of sort key to call DeleteItem' do
       klass = new_class do
-        range :activated_at, :datetime
+        range :activated_on, :date
       end
 
-      obj = klass.create!(activated_at: Time.now)
+      obj = klass.create!(activated_on: Date.today)
 
       expect { obj.delete }.to change {
-        klass.where(id: obj.id, activated_at: obj.activated_at).first
+        klass.where(id: obj.id, activated_on: obj.activated_on).first
       }.to(nil)
     end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -568,14 +568,13 @@ describe Dynamoid::Persistence do
 
       context 'persisted record' do
         it 'does not change created_at if Config.timestamps=true', config: { timestamps: true } do
-          time_now_old = DateTime.now
           obj = klass.create(title: 'Old title')
 
           travel 1.hour do
-            obj.title = 'New title'
-            obj.save
-
-            expect(obj.created_at.to_s).to eql(time_now_old.to_s)
+            expect do
+              obj.title = 'New title'
+              obj.save
+            end.not_to change { obj.created_at.to_s }
           end
         end
 

--- a/spec/support/log_level.rb
+++ b/spec/support/log_level.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.around :each, :log_level do |example|
+    level_old = Dynamoid::Config.logger.level
+
+    Dynamoid::Config.logger.level = example.metadata[:log_level]
+    example.run
+    Dynamoid::Config.logger.level = level_old
+  end
+end


### PR DESCRIPTION
There is an issue with numeric format of `datetime` fields.

Dynamoid stores `datetime` field as a float number and may lose precision while convert it to needed time zone etc e.g stored value `1536429694.118027` may be loaded as `1536429694.118026999`.

So I added warning to not to use `datetime` as a range key, because when precision is lost user cannot load a document with hash key/range key.

Later we can store `datetime` without float part by default - just seconds - and add config option to preserve current behavior.