### PR TITLE
Add attribute methods "before type casting"

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,40 @@ animal.class
 #=>  Cat
 ```
 
+### Type casting
+
+Dynamid supports type casting and tryes to do it in the most convinient way.
+Values for all fields (except custom type) are coerced to declared field types.
+
+Some obvious rules are used, e.g.:
+
+for boolean field:
+```ruby
+document.boolean_field = 'off'
+# => false
+document.boolean_field = 'false'
+# => false
+document.boolean_field = 'some string'
+# => true
+```
+
+or for integer field:
+```ruby
+document.integer_field = 42.3
+# => 42
+document.integer_field = '42.3'
+# => 42
+document.integer_field = true
+# => 1
+```
+
+If time zone isn't specified for `datetime` value - application time zone is used.
+
+To access field value before type casting following method could be
+used: `attributes_before_type_cast` and `read_attribute_before_type_cast`.
+
+There is `<name>_before_type_cast` method for every field in a model as well.
+
 ## Usage
 
 ### Object Creation

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -281,6 +281,7 @@ module Dynamoid #:nodoc:
         @new_record = true
         @attributes ||= {}
         @associations ||= {}
+        @attributes_before_type_cast ||= {}
 
         self.class.attributes.each do |_, options|
           if options[:type].is_a?(Class) && options[:default]

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -64,6 +64,7 @@ module Dynamoid #:nodoc:
             end
           end
           define_method("#{named}=") { |value| write_attribute(named, value) }
+          define_method("#{named}_before_type_cast") { read_attribute_before_type_cast(named) }
         end
       end
 
@@ -88,6 +89,7 @@ module Dynamoid #:nodoc:
           remove_method field
           remove_method :"#{field}="
           remove_method :"#{field}?"
+          remove_method:"#{field}_before_type_cast"
         end
       end
 
@@ -118,6 +120,8 @@ module Dynamoid #:nodoc:
       if association = @associations[name]
         association.reset
       end
+
+      @attributes_before_type_cast[name] = value
 
       value_casted = TypeCasting.cast_field(value, self.class.attributes[name])
       attributes[name] = value_casted
@@ -153,6 +157,19 @@ module Dynamoid #:nodoc:
     def update_attribute(attribute, value)
       write_attribute(attribute, value)
       save
+    end
+
+    # Returns a hash of attributes before typecasting
+    def attributes_before_type_cast
+      @attributes_before_type_cast
+    end
+
+    # Returns the value of the attribute identified by name before typecasting
+    #
+    # @param [Symbol] attribute name
+    def read_attribute_before_type_cast(name)
+      return nil unless name.respond_to?(:to_sym)
+      @attributes_before_type_cast[name.to_sym]
     end
 
     private

--- a/spec/dynamoid/before_type_cast_spec.rb
+++ b/spec/dynamoid/before_type_cast_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Before type cast' do
+  describe '#attributes_before_type_cast', config: { timestamps: false } do
+    let(:klass) do
+      new_class do
+        field :admin, :boolean
+      end
+    end
+
+    it 'returns original attributes value' do
+      obj = klass.new(admin: 0)
+
+      expect(obj.attributes_before_type_cast).to eql(
+        id: nil,
+        admin: 0,
+        created_at: nil,
+        updated_at: nil
+      )
+    end
+
+    it 'returns values for all the attributes even not assigned' do
+      klass_with_many_fields = new_class do
+        field :first_name
+        field :last_name
+        field :email
+      end
+      obj = klass_with_many_fields.new(first_name: 'John')
+
+      expect(obj.attributes_before_type_cast).to eql(
+        id: nil,
+        first_name: 'John',
+        last_name: nil,
+        email: nil,
+        created_at: nil,
+        updated_at: nil
+      )
+    end
+
+    it 'returns original default value if field has default value' do
+      klass_with_default_value = new_class do
+        field :activated_on, :date, default: '2018-09-27'
+      end
+      obj = klass_with_default_value.new
+
+      expect(obj.attributes_before_type_cast).to eql(
+        id: nil,
+        activated_on: '2018-09-27',
+        created_at: nil,
+        updated_at: nil
+      )
+    end
+
+    it 'returns nil if field does not have default value' do
+      obj = klass.new
+
+      expect(obj.attributes_before_type_cast).to eql(
+        id: nil,
+        admin: nil,
+        created_at: nil,
+        updated_at: nil
+      )
+    end
+
+    it 'returns values loaded from the storage before type casting' do
+      obj = klass.create!(admin: false)
+      obj2 = klass.find(obj.id)
+
+      expect(obj2.attributes_before_type_cast).to eql(
+        id: obj.id,
+        admin: false,
+        created_at: nil,
+        updated_at: nil
+      )
+    end
+  end
+
+  describe '#read_attribute_before_type_cast' do
+    let(:klass) do
+      new_class do
+        field :admin, :boolean
+      end
+    end
+
+    it 'returns attribute original value' do
+      obj = klass.new(admin: 1)
+
+      expect(obj.read_attribute_before_type_cast(:admin)).to eql(1)
+    end
+
+    it 'accepts string as well as symbol argument' do
+      obj = klass.new(admin: 1)
+
+      expect(obj.read_attribute_before_type_cast('admin')).to eql(1)
+    end
+
+    it 'returns nil if there is no such attribute' do
+      obj = klass.new
+
+      expect(obj.read_attribute_before_type_cast(:first_name)).to eql(nil)
+    end
+  end
+
+  describe '#<name>_before_type_cast' do
+    let(:klass) do
+      new_class do
+        field :first_name
+        field :last_name
+        field :admin, :boolean
+      end
+    end
+
+    it 'exists for every model attribute' do
+      obj = klass.new
+
+      expect(obj).to respond_to(:id)
+      expect(obj).to respond_to(:first_name_before_type_cast)
+      expect(obj).to respond_to(:last_name_before_type_cast)
+      expect(obj).to respond_to(:admin)
+      expect(obj).to respond_to(:created_at)
+      expect(obj).to respond_to(:updated_at)
+    end
+
+    it 'returns attribute original value' do
+      obj = klass.new(admin: 0)
+
+      expect(obj.admin_before_type_cast).to eql(0)
+    end
+  end
+end


### PR DESCRIPTION
Added:
- method `attributes_before_type_cast`
- method `read_attribte_before_type_cast`
- methods `<name>_before_type_cast`

Implemented Rails' [Active Record Attribute Methods Before Type Cast](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/BeforeTypeCast.html) interface.

It's reasonable as far as we have type casting and models could be used like form objects in view templates.