### PR TITLE
Add inheritance field option

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,23 @@ animal.class
 #=>  Cat
 ```
 
+If you already have DynamoDB tables and `type` field already exists and has its own semantic it leads to conflict.
+It's possible to tell Dynamoid to use another field (even not existing)
+instead of `type` one with `inheritance_field` table option:
+
+```ruby
+class Car
+  include Dynamoid::Document
+  table inheritance_field: :my_new_type
+
+  field :my_new_type
+end
+
+c = Car.create
+c.my_new_type
+#=> "Car"
+```
+
 ### Type casting
 
 Dynamid supports type casting and tryes to do it in the most convinient way.

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -14,7 +14,7 @@ module Dynamoid
 
       before_create :set_created_at
       before_save :set_updated_at
-      after_initialize :set_type
+      after_initialize :set_inheritance_field
     end
 
     include ActiveModel::AttributeMethods

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -18,8 +18,9 @@ module Dynamoid #:nodoc:
         @scan_index_forward = true
 
         # Honor STI and :type field if it presents
-        if @source.attributes.key?(:type)
-          @query[:'type.in'] = @source.deep_subclasses.map(&:name) << @source.name
+        type = @source.inheritance_field
+        if @source.attributes.key?(type)
+          @query[:"#{type}.in"] = @source.deep_subclasses.map(&:name) << @source.name
         end
       end
 

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -50,6 +50,11 @@ module Dynamoid #:nodoc:
         options[:write_capacity] || Dynamoid::Config.write_capacity
       end
 
+      # Returns the field name used to support STI for this table.
+      def inheritance_field
+        options[:inheritance_field] || :type
+      end
+
       # Returns the id field for this class.
       #
       # @since 0.4.0
@@ -265,7 +270,7 @@ module Dynamoid #:nodoc:
       end
 
       def choose_right_class(attrs)
-        attrs[:type] ? attrs[:type].constantize : self
+        attrs[inheritance_field] ? attrs[inheritance_field].constantize : self
       end
     end
 

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -102,7 +102,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def build(attrs = {})
-        attrs[:type] ? attrs[:type].constantize.new(attrs) : new(attrs)
+        choose_right_class(attrs).new(attrs)
       end
 
       # Does this object exist?
@@ -262,6 +262,10 @@ module Dynamoid #:nodoc:
 
       def deep_subclasses
         subclasses + subclasses.map(&:deep_subclasses).flatten
+      end
+
+      def choose_right_class(attrs)
+        attrs[:type] ? attrs[:type].constantize : self
       end
     end
 

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -169,8 +169,14 @@ module Dynamoid #:nodoc:
       end
     end
 
-    def set_type
-      self.type ||= self.class.name if self.class.attributes[:type]
+    def set_inheritance_field
+      # actually it does only following logic:
+      # self.type ||= self.class.name if self.class.attributes[:type]
+
+      type = self.class.inheritance_field
+      if self.class.attributes[type] && self.send(type).nil?
+        self.send("#{type}=", self.class.name)
+      end
     end
   end
 end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -59,7 +59,7 @@ module Dynamoid
       end
 
       def from_database(attrs = {})
-        clazz = attrs[:type] ? obj = attrs[:type].constantize : self
+        clazz = choose_right_class(attrs)
         attrs_undumped = Undumping.undump_attributes(attrs, clazz.attributes)
         clazz.new(attrs_undumped).tap { |r| r.new_record = false }
       end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -937,26 +937,6 @@ describe Dynamoid::Criteria::Chain do
     end
   end
 
-  context 'single table inheritance' do
-    describe 'where' do
-      it 'honors STI' do
-        Vehicle.create(description: 'Description')
-        car = Car.create(description: 'Description')
-
-        expect(Car.where(description: 'Description').all.to_a).to eq [car]
-      end
-    end
-
-    describe 'all' do
-      it 'honors STI' do
-        Vehicle.create(description: 'Description')
-        car = Car.create
-
-        expect(Car.all.to_a).to eq [car]
-      end
-    end
-  end
-
   describe '#delete_all' do
     it 'deletes in batch' do
       klass = new_class

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -726,17 +726,6 @@ describe Dynamoid::Document do
     end
   end
 
-  context 'single table inheritance' do
-    it 'should have a type' do
-      expect(Vehicle.new.type).to eq 'Vehicle'
-    end
-
-    it 'reports the same table name for both base and derived classes' do
-      expect(Vehicle.table_name).to eq Car.table_name
-      expect(Vehicle.table_name).to eq NuclearSubmarine.table_name
-    end
-  end
-
   context '#count' do
     it 'returns the number of documents in the table' do
       document = Tweet.create(tweet_id: 'x', group: 'abc')

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -664,6 +664,7 @@ describe Dynamoid::Document do
     expect(Address.hash_key).to eq :id
     expect(Address.read_capacity).to eq 100
     expect(Address.write_capacity).to eq 20
+    expect(Address.inheritance_field).to eq :type
   end
 
   it 'follows any table options provided to it' do

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -239,37 +239,6 @@ describe Dynamoid::Fields do
     end
   end
 
-  context 'single table inheritance (STI)' do
-    let!(:class_a) do
-      new_class do
-        field :type
-        field :a
-      end
-    end
-
-    let!(:class_b) do
-      Class.new(class_a) do
-        field :b
-      end
-    end
-
-    let!(:class_c) do
-      Class.new(class_a) do
-        field :c
-      end
-    end
-
-    it 'enables only own attributes in a base class ' do
-      expect(class_a.attributes.keys).to match_array(%i[id type a created_at updated_at])
-    end
-
-    it 'enabled only own attributes and inherited in a child class' do
-      expect(class_b.attributes.keys).to include(:a)
-      expect(class_b.attributes.keys).to include(:b)
-      expect(class_b.attributes.keys).not_to include(:c)
-    end
-  end
-
   context 'extention overides field accessors' do
     let(:klass) do
       extention = Module.new do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -1045,58 +1045,6 @@ describe Dynamoid::Persistence do
     end
   end
 
-  context 'single table inheritance (STI)' do
-    before do
-      A = new_class class_name: 'A' do
-        field :type
-      end
-      B = Class.new(A) do
-        def self.name; 'B'; end
-      end
-      C = Class.new(A) do
-        def self.name; 'C'; end
-      end
-      D = Class.new(B) do
-        def self.name; 'D'; end
-      end
-    end
-
-    after do
-      Object.send(:remove_const, :A)
-      Object.send(:remove_const, :B)
-      Object.send(:remove_const, :C)
-      Object.send(:remove_const, :D)
-    end
-
-    it 'saves subclass objects in the parent table' do
-      b = B.create
-      expect(A.find(b.id)).to eql b
-    end
-
-    it 'loads subclass item when querying the parent table' do
-      b = B.create!
-      c = C.create!
-      d = D.create!
-
-      expect(A.all.to_a).to contain_exactly(b, c, d)
-    end
-
-    it 'does not load parent item when quering the child table' do
-      a = A.create!
-      b = B.create!
-
-      expect(B.all.to_a).to eql([b])
-    end
-
-    it 'does not load items of sibling class' do
-      b = B.create!
-      c = C.create!
-
-      expect(B.all.to_a).to eql([b])
-      expect(C.all.to_a).to eql([c])
-    end
-  end
-
   describe '.import' do
     before do
       Address.create_table

--- a/spec/dynamoid/sti_spec.rb
+++ b/spec/dynamoid/sti_spec.rb
@@ -114,4 +114,40 @@ RSpec.describe 'STI' do
       end
     end
   end
+
+  describe '`inheritance_field` document option' do
+    before do
+      A = new_class class_name: 'A' do
+        table inheritance_field: :type_new
+
+        field :type
+        field :type_new
+      end
+
+      B = Class.new(A) do
+        def self.name; 'B'; end
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :A)
+      Object.send(:remove_const, :B)
+    end
+
+    it 'allows to switch from `type` field to another one to store class name' do
+      b = B.create!
+
+      expect(A.find(b.id)).to eql b
+      expect(b.type_new).to eql('B')
+    end
+
+    it 'ignores `type` field at all' do
+      b = B.create!
+      expect(b.type).to eql(nil)
+
+      b = B.create!(type: 'Integer')
+      expect(A.find(b.id)).to eql b
+      expect(b.type).to eql('Integer')
+    end
+  end
 end

--- a/spec/dynamoid/sti_spec.rb
+++ b/spec/dynamoid/sti_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+RSpec.describe 'STI' do
+  describe 'fields' do
+    let!(:class_a) do
+      new_class do
+        field :type
+        field :a
+      end
+    end
+
+    let!(:class_b) do
+      Class.new(class_a) do
+        field :b
+      end
+    end
+
+    let!(:class_c) do
+      Class.new(class_a) do
+        field :c
+      end
+    end
+
+    it 'enables only own attributes in a base class ' do
+      expect(class_a.attributes.keys).to match_array(%i[id type a created_at updated_at])
+    end
+
+    it 'enabled only own attributes and inherited in a child class' do
+      expect(class_b.attributes.keys).to include(:a)
+      expect(class_b.attributes.keys).to include(:b)
+      expect(class_b.attributes.keys).not_to include(:c)
+    end
+  end
+
+  describe 'document' do
+    it 'fills `type` field with class name' do
+      expect(Vehicle.new.type).to eq 'Vehicle'
+    end
+
+    it 'reports the same table name for both base and derived classes' do
+      expect(Vehicle.table_name).to eq Car.table_name
+      expect(Vehicle.table_name).to eq NuclearSubmarine.table_name
+    end
+  end
+
+  describe 'persistence' do
+    before do
+      A = new_class class_name: 'A' do
+        field :type
+      end
+      B = Class.new(A) do
+        def self.name; 'B'; end
+      end
+      C = Class.new(A) do
+        def self.name; 'C'; end
+      end
+      D = Class.new(B) do
+        def self.name; 'D'; end
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :A)
+      Object.send(:remove_const, :B)
+      Object.send(:remove_const, :C)
+      Object.send(:remove_const, :D)
+    end
+
+    it 'saves subclass objects in the parent table' do
+      b = B.create
+      expect(A.find(b.id)).to eql b
+    end
+
+    it 'loads subclass item when querying the parent table' do
+      b = B.create!
+      c = C.create!
+      d = D.create!
+
+      expect(A.all.to_a).to contain_exactly(b, c, d)
+    end
+
+    it 'does not load parent item when quering the child table' do
+      a = A.create!
+      b = B.create!
+
+      expect(B.all.to_a).to eql([b])
+    end
+
+    it 'does not load items of sibling class' do
+      b = B.create!
+      c = C.create!
+
+      expect(B.all.to_a).to eql([b])
+      expect(C.all.to_a).to eql([c])
+    end
+  end
+
+  describe 'quering' do
+    describe 'where' do
+      it 'honors STI' do
+        Vehicle.create(description: 'Description')
+        car = Car.create(description: 'Description')
+
+        expect(Car.where(description: 'Description').all.to_a).to eq [car]
+      end
+    end
+
+    describe 'all' do
+      it 'honors STI' do
+        Vehicle.create(description: 'Description')
+        car = Car.create
+
+        expect(Car.all.to_a).to eq [car]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related issue https://github.com/Dynamoid/dynamoid/issues/297#issuecomment-423536619

Added new document option `inheritance_field` to allow using another field instead of `type` to support STI.

It's similar to Rails' [inheritance_column](https://apidock.com/rails/ActiveRecord/Base/inheritance_column/class) method

So there is an example:

```ruby
class Car
  include Dynamoid::Document
  table inheritance_field: :my_new_type

  field :my_new_type
end

c = Car.create
c.my_new_type
#=> "Car"
```