### PR TITLE
Add increment methods

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -224,6 +224,13 @@ module Dynamoid
       self
     end
 
+    # Wrapper around increment that saves the record.
+    # Returns true if the record could be saved.
+    def increment!(attribute, by = 1)
+      increment(attribute, by)
+      save
+    end
+
     # Delete this object, but only after running callbacks for it.
     #
     # @since 0.2.0

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -216,6 +216,14 @@ module Dynamoid
       false
     end
 
+    # Initializes attribute to zero if nil and adds the value passed as by (default is 1).
+    # Only makes sense for number-based attributes. Returns self.
+    def increment(attribute, by = 1)
+      self[attribute] ||= 0
+      self[attribute] += by
+      self
+    end
+
     # Delete this object, but only after running callbacks for it.
     #
     # @since 0.2.0

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -231,6 +231,14 @@ module Dynamoid
       save
     end
 
+    # Initializes attribute to zero if nil and subtracts the value passed as by (default is 1).
+    # Only makes sense for number-based attributes. Returns self.
+    def decrement(attribute, by = 1)
+      self[attribute] ||= 0
+      self[attribute] -= by
+      self
+    end
+
     # Delete this object, but only after running callbacks for it.
     #
     # @since 0.2.0

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -239,6 +239,13 @@ module Dynamoid
       self
     end
 
+    # Wrapper around decrement that saves the record.
+    # Returns true if the record could be saved.
+    def decrement!(attribute, by = 1)
+      decrement(attribute, by)
+      save
+    end
+
     # Delete this object, but only after running callbacks for it.
     #
     # @since 0.2.0

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -621,6 +621,104 @@ describe Dynamoid::Document do
     end
   end
 
+  describe '.inc' do
+    let(:document_class) do
+      new_class do
+        field :links_count, :integer
+        field :mentions_count, :integer
+      end
+    end
+
+    it 'adds specified value' do
+      obj = document_class.create!(links_count: 2)
+
+      expect {
+        document_class.inc(obj.id, links_count: 5)
+      }.to change { document_class.find(obj.id).links_count }.from(2).to(7)
+    end
+
+    it 'accepts negative value' do
+      obj = document_class.create!(links_count: 10)
+
+      expect {
+        document_class.inc(obj.id, links_count: -2)
+      }.to change { document_class.find(obj.id).links_count }.from(10).to(8)
+    end
+
+    it 'traits nil value as zero' do
+      obj = document_class.create!(links_count: nil)
+
+      expect {
+        document_class.inc(obj.id, links_count: 5)
+      }.to change { document_class.find(obj.id).links_count }.from(nil).to(5)
+    end
+
+    it 'supports passing several attributes at once' do
+      obj = document_class.create!(links_count: 2, mentions_count: 31)
+      document_class.inc(obj.id, links_count: 5, mentions_count: 9)
+
+      expect(document_class.find(obj.id).links_count).to eql(7)
+      expect(document_class.find(obj.id).mentions_count).to eql(40)
+    end
+
+    it 'accepts sort key if it is declared' do
+      class_with_sort_key = new_class do
+        range :author_name
+        field :links_count, :integer
+      end
+
+      obj = class_with_sort_key.create!(author_name: 'Mike', links_count: 2)
+      class_with_sort_key.inc(obj.id, 'Mike', links_count: 5)
+
+      expect(obj.reload.links_count).to eql(7)
+    end
+
+    it 'uses dumped value of sort key to call UpdateItem' do
+      class_with_sort_key = new_class do
+        range :published_on, :date
+        field :links_count, :integer
+      end
+
+      obj = class_with_sort_key.create!(published_on: '2018-10-07'.to_date, links_count: 2)
+      class_with_sort_key.inc(obj.id, '2018-10-07'.to_date, links_count: 5)
+
+      expect(obj.reload.links_count).to eql(7)
+    end
+
+    describe 'timestamps' do
+      it 'does not change updated_at', config: { timestamps: true } do
+        obj = document_class.create!
+        expect(obj.updated_at).to be_present
+
+        expect {
+          document_class.inc(obj.id, links_count: 5)
+        }.not_to change { document_class.find(obj.id).updated_at }
+      end
+    end
+
+    describe 'type casting' do
+      it 'uses casted value of sort key to call UpdateItem' do
+        class_with_sort_key = new_class do
+          range :published_on, :date
+          field :links_count, :integer
+        end
+
+        obj = class_with_sort_key.create!(published_on: '2018-10-07'.to_date, links_count: 2)
+        class_with_sort_key.inc(obj.id, '2018-10-07', links_count: 5)
+
+        expect(obj.reload.links_count).to eql(7)
+      end
+
+      it 'type casts attributes' do
+        obj = document_class.create!(links_count: 2)
+
+        expect {
+          document_class.inc(obj.id, links_count: '5.12345')
+        }.to change { document_class.find(obj.id).links_count }.from(2).to(7)
+      end
+    end
+  end
+
   context '.reload' do
     let(:address) { Address.create }
     let(:message) { Message.create(text: 'Nice, supporting datetime range!', time: Time.now.to_datetime) }

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -958,6 +958,45 @@ describe Dynamoid::Persistence do
     end
   end
 
+  describe '#decrement' do
+    let(:document_class) do
+      new_class do
+        field :age, :integer
+      end
+    end
+
+    it 'decrements specified attribute' do
+      obj = document_class.new(age: 21)
+
+      expect { obj.decrement(:age) }.to change { obj.age }.from(21).to(20)
+    end
+
+    it 'initializes the attribute with zero if nil' do
+      obj = document_class.new(age: nil)
+
+      expect { obj.decrement(:age) }.to change { obj.age }.from(nil).to(-1)
+    end
+
+    it 'adds specified optional value' do
+      obj = document_class.new(age: 21)
+
+      expect { obj.decrement(:age, 10) }.to change { obj.age }.from(21).to(11)
+    end
+
+    it 'returns self' do
+      obj = document_class.new(age: 21)
+
+      expect(obj.decrement(:age)).to eql(obj)
+    end
+
+    it 'does not save changes' do
+      obj = document_class.new(age: 21)
+      obj.decrement(:age)
+
+      expect(obj).to be_new_record
+    end
+  end
+
   context 'update' do
     before :each do
       @tweet = Tweet.create(tweet_id: 1, group: 'abc', count: 5, tags: Set.new(%w[db sql]), user_name: 'john')

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -905,6 +905,59 @@ describe Dynamoid::Persistence do
     end
   end
 
+  describe '#increment!' do
+    let(:document_class) do
+      new_class do
+        field :age, :integer
+      end
+    end
+
+    it 'increments specified attribute' do
+      obj = document_class.new(age: 21)
+
+      expect { obj.increment!(:age) }.to change { obj.age }.from(21).to(22)
+    end
+
+    it 'initializes the attribute with zero if nil' do
+      obj = document_class.new(age: nil)
+
+      expect { obj.increment!(:age) }.to change { obj.age }.from(nil).to(1)
+    end
+
+    it 'adds specified optional value' do
+      obj = document_class.new(age: 21)
+
+      expect { obj.increment!(:age, 10) }.to change { obj.age }.from(21).to(31)
+    end
+
+    it 'returns true if document is valid' do
+      class_with_validation = new_class do
+        field :age, :integer
+        validates :age, numericality: { less_than: 16 }
+      end
+      obj = class_with_validation.new(age: 10)
+
+      expect(obj.increment!(:age, 1)).to eql(true)
+    end
+
+    it 'returns false if document is invalid' do
+      class_with_validation = new_class do
+        field :age, :integer
+        validates :age, numericality: { less_than: 16 }
+      end
+      obj = class_with_validation.new(age: 10)
+
+      expect(obj.increment!(:age, 10)).to eql(false)
+    end
+
+    it 'saves changes' do
+      obj = document_class.new(age: 21)
+      obj.increment!(:age)
+
+      expect(obj).to be_persisted
+    end
+  end
+
   context 'update' do
     before :each do
       @tweet = Tweet.create(tweet_id: 1, group: 'abc', count: 5, tags: Set.new(%w[db sql]), user_name: 'john')

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -997,6 +997,59 @@ describe Dynamoid::Persistence do
     end
   end
 
+  describe '#decrement' do
+    let(:document_class) do
+      new_class do
+        field :age, :integer
+      end
+    end
+
+    it 'decrements specified attribute' do
+      obj = document_class.new(age: 21)
+
+      expect { obj.decrement!(:age) }.to change { obj.age }.from(21).to(20)
+    end
+
+    it 'initializes the attribute with zero if nil' do
+      obj = document_class.new(age: nil)
+
+      expect { obj.decrement!(:age) }.to change { obj.age }.from(nil).to(-1)
+    end
+
+    it 'adds specified optional value' do
+      obj = document_class.new(age: 21)
+
+      expect { obj.decrement!(:age, 10) }.to change { obj.age }.from(21).to(11)
+    end
+
+    it 'returns true if document is valid' do
+      class_with_validation = new_class do
+        field :age, :integer
+        validates :age, numericality: { greater_than: 16 }
+      end
+      obj = class_with_validation.new(age: 20)
+
+      expect(obj.decrement!(:age, 1)).to eql(true)
+    end
+
+    it 'returns false if document is invalid' do
+      class_with_validation = new_class do
+        field :age, :integer
+        validates :age, numericality: { greater_than: 16 }
+      end
+      obj = class_with_validation.new(age: 20)
+
+      expect(obj.decrement!(:age, 10)).to eql(false)
+    end
+
+    it 'saves changes' do
+      obj = document_class.new(age: 21)
+      obj.decrement!(:age)
+
+      expect(obj).to be_persisted
+    end
+  end
+
   context 'update' do
     before :each do
       @tweet = Tweet.create(tweet_id: 1, group: 'abc', count: 5, tags: Set.new(%w[db sql]), user_name: 'john')

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -866,6 +866,45 @@ describe Dynamoid::Persistence do
     end
   end
 
+  describe '#increment' do
+    let(:document_class) do
+      new_class do
+        field :age, :integer
+      end
+    end
+
+    it 'increments specified attribute' do
+      obj = document_class.new(age: 21)
+
+      expect { obj.increment(:age) }.to change { obj.age }.from(21).to(22)
+    end
+
+    it 'initializes the attribute with zero if nil' do
+      obj = document_class.new(age: nil)
+
+      expect { obj.increment(:age) }.to change { obj.age }.from(nil).to(1)
+    end
+
+    it 'adds specified optional value' do
+      obj = document_class.new(age: 21)
+
+      expect { obj.increment(:age, 10) }.to change { obj.age }.from(21).to(31)
+    end
+
+    it 'returns self' do
+      obj = document_class.new(age: 21)
+
+      expect(obj.increment(:age)).to eql(obj)
+    end
+
+    it 'does not save changes' do
+      obj = document_class.new(age: 21)
+      obj.increment(:age)
+
+      expect(obj).to be_new_record
+    end
+  end
+
   context 'update' do
     before :each do
       @tweet = Tweet.create(tweet_id: 1, group: 'abc', count: 5, tags: Set.new(%w[db sql]), user_name: 'john')


### PR DESCRIPTION
Changes:
- added `#increment`, `#increment!`, `#decrement` and `#decrement!` similar to model methods in Rails ([documentation](https://apidock.com/rails/v4.2.7/ActiveRecord/Persistence/increment))
- added `.inc` method for atomic changing numerical attributes like counters etc. Similar to [Model#inc](https://mongoid.github.io/old/en/mongoid/docs/persistence.html#atomic) in Mongoid and [.update_counters/.increment_counter](https://apidock.com/rails/ActiveRecord/CounterCache/ClassMethods/update_counters) in Rails

Inspired by abandoned PR https://github.com/Dynamoid/dynamoid/pull/266