### PR TITLE
Add NullLogger

### DIFF
--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activemodel', '>=4'
   spec.add_runtime_dependency 'aws-sdk-dynamodb', '~> 1'
   spec.add_runtime_dependency 'concurrent-ruby', '>= 1.0'
+  spec.add_runtime_dependency 'null-logger'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -2,6 +2,7 @@
 
 require 'uri'
 require 'logger'
+require 'null_logger'
 require 'dynamoid/config/options'
 require 'dynamoid/config/backoff_strategies/constant_backoff'
 require 'dynamoid/config/backoff_strategies/exponential_backoff'
@@ -61,7 +62,7 @@ module Dynamoid
     # @since 0.2.0
     def logger=(logger)
       case logger
-      when false, nil then @logger = Logger.new('/dev/null')
+      when false, nil then @logger = NullLogger.new
       when true then @logger = default_logger
       else
         @logger = logger if logger.respond_to?(:info)


### PR DESCRIPTION
Use fake logger (`NullLogger`) instead of writing to `/dev/null` if logging is disabled.

I consider using `/dev/null` to be smell and it shouldn't work on Windows.

Related PR https://github.com/Dynamoid/dynamoid/pull/287