### PR TITLE
Add collection element types

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,15 @@ You have two options if you need to use a `datetime` field as a range key:
 
 #### Note on set type
 
-DynamoDB supports only set of strings, numbers and binary.
+`Dynamoid`'s type `set` is stored as DynamoDB's Set attribute type.
+DynamoDB supports only Set of strings, numbers and binary.
+Moreover Set *must* contain elements of the same type only.
+
 In order to use some other `Dynamoid`'s types you can specify `of` option
 to declare the type of set elements.
 
-Only scalar types are supported (except `boolean`):
+As a result of that DynamoDB limitation, in Dynamoid only the following
+scalar types are supported (note: does not support `boolean`):
 `integer`, `number`, `date`, `datetime`, `serializable` and custom types.
 
 ```ruby
@@ -206,23 +210,30 @@ class Document
 end
 ```
 
-Some type declaration have options like `store_as_string` for `datetime`
-or `serializer` for `serializable`. It's possible to specify them for elements type:
+It's possible to specify field options like `store_as_string` for `datetime` field
+or `serializer` for `serializable` field for `set` elements type:
 
 ```ruby
 class Document
   include DynamoId::Document
 
   field :values, :set, of: { serialized: { serializer: JSON } }
+  field :dates, :set, of: { date: { store_as_string: true } }
+  field :datetimes, :set, of: { datetime: { store_as_string: false } }
 end
 ```
 
-As far as DynamoDB doesn't allow storing empty strings in Set
-when `Dynamoid` saves a document it removes all empty strings in `set` fields.
+DynamoDB doesn't allow empty strings in fields configured as `set`.
+Abiding by this restriction, when `Dynamoid` saves a document it removes all empty strings in set fields.
 
 #### Note on array type
 
-`array` field declaration supports `of` option as well:
+`Dynamoid`'s type `array` is stored as DynamoDB's List attribute type.
+It can contain elements of different types (in contrast to Set attribute type).
+
+If you need to store in array field elements of `datetime`, `date`,
+`serializable` or some custom type, which DynamoDB doesn't support
+natively, you should specify element type with `of` option:
 
 ```ruby
 class Document

--- a/README.md
+++ b/README.md
@@ -191,8 +191,12 @@ You have two options if you need to use a `datetime` field as a range key:
 
 #### Note on set type
 
-There is `of` option to declare the type of set elements. You can use
-`:integer` value only
+DynamoDB supports only set of strings, numbers and binary.
+In order to use some other `Dynamoid`'s types you can specify `of` option
+to declare the type of set elements.
+
+Only scalar types are supported (except `boolean`):
+`integer`, `number`, `date`, `datetime`, `serializable` and custom types.
 
 ```ruby
 class Document
@@ -202,6 +206,31 @@ class Document
 end
 ```
 
+Some type declaration have options like `store_as_string` for `datetime`
+or `serializer` for `serializable`. It's possible to specify them for elements type:
+
+```ruby
+class Document
+  include DynamoId::Document
+
+  field :values, :set, of: { serialized: { serializer: JSON } }
+end
+```
+
+As far as DynamoDB doesn't allow storing empty strings in Set
+when `Dynamoid` saves a document it removes all empty strings in `set` fields.
+
+#### Note on array type
+
+`array` field declaration supports `of` option as well:
+
+```ruby
+class Document
+  include DynamoId::Document
+
+  field :dates, :array, of: :date
+end
+```
 
 #### Magic Columns
 

--- a/lib/dynamoid/dumping.rb
+++ b/lib/dynamoid/dumping.rb
@@ -11,6 +11,8 @@ module Dynamoid
     end
 
     def self.dump_field(value, options)
+      return nil if value.nil?
+
       dumper = field_dumper(options)
 
       if dumper.nil?
@@ -64,6 +66,54 @@ module Dynamoid
 
     # set -> set
     class SetDumper < Base
+      ALLOWED_TYPES = [:string, :integer, :number, :date, :datetime, :serialized]
+
+      def process(set)
+        if @options.key?(:of)
+          process_typed_collection(set)
+        else
+          set
+        end
+      end
+
+      private
+
+      def process_typed_collection(set)
+        if allowed_type?
+          dumper = Dumping.field_dumper(element_options)
+          result = set.map { |el| dumper.process(el) }
+
+          if element_type == :string
+            result.reject!(&:empty?)
+          end
+
+          result.to_set
+        else
+          raise ArgumentError, "Set element type #{element_type} isn't supported"
+        end
+      end
+
+      def allowed_type?
+        ALLOWED_TYPES.include?(element_type) || element_type.is_a?(Class)
+      end
+
+      def element_type
+        unless @options[:of].is_a?(Hash)
+          @options[:of]
+        else
+          @options[:of].keys.first
+        end
+      end
+
+      def element_options
+        unless @options[:of].is_a?(Hash)
+          { type: element_type }
+        else
+          @options[:of][element_type].dup.tap do |options|
+            options[:type] = element_type
+          end
+        end
+      end
     end
 
     # array -> array

--- a/lib/dynamoid/dumping.rb
+++ b/lib/dynamoid/dumping.rb
@@ -13,7 +13,7 @@ module Dynamoid
     def self.dump_field(value, options)
       return nil if value.nil?
 
-      dumper = field_dumper(options)
+      dumper = find_dumper(options)
 
       if dumper.nil?
         raise ArgumentError, "Unknown type #{options[:type]}"
@@ -22,7 +22,7 @@ module Dynamoid
       dumper.process(value)
     end
 
-    def self.field_dumper(options)
+    def self.find_dumper(options)
       dumper_class = case options[:type]
                      when :string     then StringDumper
                      when :integer    then IntegerDumper
@@ -80,7 +80,7 @@ module Dynamoid
 
       def process_typed_collection(set)
         if allowed_type?
-          dumper = Dumping.field_dumper(element_options)
+          dumper = Dumping.find_dumper(element_options)
           result = set.map { |el| dumper.process(el) }
 
           if element_type == :string
@@ -132,7 +132,7 @@ module Dynamoid
 
       def process_typed_collection(array)
         if allowed_type?
-          dumper = Dumping.field_dumper(element_options)
+          dumper = Dumping.find_dumper(element_options)
           result = array.map { |el| dumper.process(el) }
 
           if element_type == :string

--- a/lib/dynamoid/type_casting.rb
+++ b/lib/dynamoid/type_casting.rb
@@ -158,12 +158,52 @@ module Dynamoid
 
     class ArrayTypeCaster < Base
       def process(value)
+        array = type_cast_to_array(value)
+
+        if array.present? && @options[:of].present?
+          process_typed_array(array)
+        else
+          array
+        end
+      end
+
+      private
+
+      def type_cast_to_array(value)
         if value.is_a?(Array)
           value.dup
         elsif value.respond_to?(:to_a)
           value.to_a
         else
           nil
+        end
+      end
+
+      def process_typed_array(array)
+        type_caster = TypeCasting.find_type_caster(element_options)
+
+        if type_caster.nil?
+          raise ArgumentError, "Set element type #{element_type} isn't supported"
+        end
+
+        array.map { |el| type_caster.process(el) }
+      end
+
+      def element_type
+        unless @options[:of].is_a?(Hash)
+          @options[:of]
+        else
+          @options[:of].keys.first
+        end
+      end
+
+      def element_options
+        unless @options[:of].is_a?(Hash)
+          { type: element_type }
+        else
+          @options[:of][element_type].dup.tap do |options|
+            options[:type] = element_type
+          end
         end
       end
     end

--- a/lib/dynamoid/undumping.rb
+++ b/lib/dynamoid/undumping.rb
@@ -11,13 +11,14 @@ module Dynamoid
     end
 
     def self.undump_field(value, options)
+      return nil if value.nil?
+
       undumper = find_undumper(options)
 
       if undumper.nil?
         raise ArgumentError, "Unknown type #{options[:type]}"
       end
 
-      return nil if value.nil?
       undumper.process(value)
     end
 
@@ -64,14 +65,46 @@ module Dynamoid
     end
 
     class SetUndumper < Base
-      def process(value)
-        case @options[:of]
-        when :integer
-          value.map { |v| Integer(v) }.to_set
-        when :number
-          value.map { |v| BigDecimal(v.to_s) }.to_set
+      ALLOWED_TYPES = [:string, :integer, :number, :date, :datetime, :serialized]
+
+      def process(set)
+        if @options.key?(:of)
+          process_typed_collection(set)
         else
-          value.is_a?(Set) ? value : Set.new(value)
+          set.is_a?(Set) ? set : Set.new(set)
+        end
+      end
+
+      private
+
+      def process_typed_collection(set)
+        if allowed_type?
+          undumper = Undumping.find_undumper(element_options)
+          set.map { |el| undumper.process(el) }.to_set
+        else
+          raise ArgumentError, "Set element type #{element_type} isn't supported"
+        end
+      end
+
+      def allowed_type?
+        ALLOWED_TYPES.include?(element_type) || element_type.is_a?(Class)
+      end
+
+      def element_type
+        unless @options[:of].is_a?(Hash)
+          @options[:of]
+        else
+          @options[:of].keys.first
+        end
+      end
+
+      def element_options
+        unless @options[:of].is_a?(Hash)
+          { type: element_type }
+        else
+          @options[:of][element_type].dup.tap do |options|
+            options[:type] = element_type
+          end
         end
       end
     end

--- a/spec/dynamoid/dumping_spec.rb
+++ b/spec/dynamoid/dumping_spec.rb
@@ -13,18 +13,21 @@ describe 'Dumping' do
 
       it "saves false as 'f'" do
         obj = klass.create(active: false)
+
         expect(reload(obj).active).to eql(false)
         expect(raw_attributes(obj)[:active]).to eql('f')
       end
 
       it "saves true as 't'" do
         obj = klass.create(active: true)
+
         expect(reload(obj).active).to eql(true)
         expect(raw_attributes(obj)[:active]).to eql('t')
       end
 
       it 'stores nil value' do
         obj = klass.create(active: nil)
+
         expect(reload(obj).active).to eql(nil)
         expect(raw_attributes(obj)[:active]).to eql(nil)
       end
@@ -39,12 +42,14 @@ describe 'Dumping' do
 
       it 'saves false as false' do
         obj = klass.create(active: false)
+
         expect(reload(obj).active).to eql(false)
         expect(raw_attributes(obj)[:active]).to eql(false)
       end
 
       it 'saves true as true' do
         obj = klass.create(active: true)
+
         expect(reload(obj).active).to eql(true)
         expect(raw_attributes(obj)[:active]).to eql(true)
       end
@@ -59,6 +64,7 @@ describe 'Dumping' do
 
       it 'stores nil value' do
         obj = klass.create(active: nil)
+
         expect(reload(obj).active).to eql(nil)
         expect(raw_attributes(obj)[:active]).to eql(nil)
       end
@@ -69,6 +75,7 @@ describe 'Dumping' do
         klass = new_class do
           field :active, :boolean
         end
+
         obj = klass.create(active: true)
 
         expect(raw_attributes(obj)[:active]).to eql(true)
@@ -82,6 +89,7 @@ describe 'Dumping' do
           klass = new_class do
             field :active, :boolean
           end
+
           obj = klass.create(active: true)
 
           expect(raw_attributes(obj)[:active]).to eql(true)
@@ -94,6 +102,7 @@ describe 'Dumping' do
           klass = new_class do
             field :active, :boolean, store_as_native_boolean: true
           end
+
           obj = klass.create(active: true)
 
           expect(raw_attributes(obj)[:active]).to eql(true)
@@ -106,6 +115,7 @@ describe 'Dumping' do
           klass = new_class do
             field :active, :boolean, store_as_native_boolean: false
           end
+
           obj = klass.create(active: true)
 
           expect(raw_attributes(obj)[:active]).to eql('t')
@@ -120,6 +130,7 @@ describe 'Dumping' do
           klass = new_class do
             field :active, :boolean
           end
+
           obj = klass.create(active: true)
 
           expect(raw_attributes(obj)[:active]).to eql('t')
@@ -132,6 +143,7 @@ describe 'Dumping' do
           klass = new_class do
             field :active, :boolean, store_as_native_boolean: true
           end
+
           obj = klass.create(active: true)
 
           expect(raw_attributes(obj)[:active]).to eql(true)
@@ -144,6 +156,7 @@ describe 'Dumping' do
           klass = new_class do
             field :active, :boolean, store_as_native_boolean: false
           end
+
           obj = klass.create(active: true)
 
           expect(raw_attributes(obj)[:active]).to eql('t')
@@ -164,18 +177,21 @@ describe 'Dumping' do
       it 'saves time as :number' do
         time = Time.utc(2018, 7, 24, 22, 4, 30, 1).to_datetime
         obj = klass.create(sent_at: time)
+
         expect(reload(obj).sent_at).to eql(time)
         expect(raw_attributes(obj)[:sent_at]).to eql(BigDecimal('1532469870.000001'))
       end
 
       it 'saves date as :number' do
         obj = klass.create(sent_at: Date.new(2018, 7, 21))
+
         expect(reload(obj).sent_at).to eq(DateTime.new(2018, 7, 21, 0, 0, 0))
         expect(raw_attributes(obj)[:sent_at]).to eql(BigDecimal('1532131200.0'))
       end
 
       it 'stores nil value' do
         obj = klass.create(sent_at: nil)
+
         expect(reload(obj).sent_at).to eql(nil)
         expect(raw_attributes(obj)[:sent_at]).to eql(nil)
       end
@@ -238,6 +254,7 @@ describe 'Dumping' do
 
       it 'stores nil value' do
         obj = klass.create(sent_at: nil)
+
         expect(reload(obj).sent_at).to eq(nil)
         expect(raw_attributes(obj)[:sent_at]).to eql(nil)
       end
@@ -252,6 +269,7 @@ describe 'Dumping' do
 
       it 'loads time in local time zone if config.application_timezone = :local',
         config: { application_timezone: :local } do
+
         time = DateTime.now
         obj = klass.create(last_logged_in_at: time)
         obj = klass.find(obj.id)
@@ -263,6 +281,7 @@ describe 'Dumping' do
 
       it 'loads time in specified time zone if config.application_timezone = time zone name',
         config: { application_timezone: 'Hawaii' } do
+
         # Hawaii UTC-10
         time = '2017-06-20 08:00:00 +0300'.to_datetime
         obj = klass.create(last_logged_in_at: time)
@@ -272,6 +291,7 @@ describe 'Dumping' do
 
       it 'loads time in UTC if config.application_timezone = :utc',
         config: { application_timezone: :utc } do
+
         time = '2017-06-20 08:00:00 +0300'.to_datetime
         obj = klass.create(last_logged_in_at: time)
 
@@ -288,6 +308,7 @@ describe 'Dumping' do
 
       it 'stores time in local time zone',
         config: { dynamodb_timezone: :local, store_datetime_as_string: true } do
+
         time = DateTime.now
         obj = klass.create(last_logged_in_at: time)
 
@@ -296,22 +317,21 @@ describe 'Dumping' do
 
       it 'stores time in specified time zone',
         config: { dynamodb_timezone: 'Hawaii', store_datetime_as_string: true } do
+
         time = '2017-06-20 08:00:00 +0300'.to_datetime
         obj = klass.create(last_logged_in_at: time)
 
         expect(raw_attributes(obj)[:last_logged_in_at]).to eql('2017-06-19T19:00:00-10:00')
       end
 
-      it 'stores time in UTC',
-        config: { dynamodb_timezone: :utc, store_datetime_as_string: true } do
+      it 'stores time in UTC', config: { dynamodb_timezone: :utc, store_datetime_as_string: true } do
         time = '2017-06-20 08:00:00 +0300'.to_datetime
         obj = klass.create(last_logged_in_at: time)
 
         expect(raw_attributes(obj)[:last_logged_in_at]).to eql('2017-06-20T05:00:00+00:00')
       end
 
-      it 'uses UTC by default',
-        config: { store_datetime_as_string: true } do
+      it 'uses UTC by default', config: { store_datetime_as_string: true } do
         time = '2017-06-20 08:00:00 +0300'.to_datetime
         obj = klass.create(last_logged_in_at: time)
 
@@ -319,7 +339,9 @@ describe 'Dumping' do
       end
 
       it 'converts time between application time zone and dynamodb time zone correctly',
-        config: { application_timezone: 'Hong Kong', dynamodb_timezone: 'Hawaii', store_datetime_as_string: true } do
+        config: { application_timezone: 'Hong Kong', dynamodb_timezone: 'Hawaii',
+                  store_datetime_as_string: true } do
+
         # Hong Kong +8
         # Hawaii -10
         time = '2017-06-20 08:00:00 +0300'.to_datetime
@@ -339,6 +361,7 @@ describe 'Dumping' do
         end
 
         obj = klass.create(signed_up_on: '2017-09-25'.to_date)
+
         expect(reload(obj).signed_up_on).to eql('2017-09-25'.to_date)
         expect(raw_attributes(obj)[:signed_up_on]).to eql('2017-09-25')
       end
@@ -377,6 +400,7 @@ describe 'Dumping' do
         end
 
         obj = klass.create(signed_up_on: nil)
+
         expect(reload(obj).signed_up_on).to eql(nil)
         expect(raw_attributes(obj)[:signed_up_on]).to eql(nil)
       end
@@ -389,6 +413,7 @@ describe 'Dumping' do
         end
 
         obj = klass.create(signed_up_on: '2017-09-25'.to_date)
+
         expect(reload(obj).signed_up_on).to eql('2017-09-25'.to_date)
         expect(raw_attributes(obj)[:signed_up_on]).to eql(17_434)
       end
@@ -427,6 +452,7 @@ describe 'Dumping' do
         end
 
         obj = klass.create(signed_up_on: nil)
+
         expect(reload(obj).signed_up_on).to eql(nil)
         expect(raw_attributes(obj)[:signed_up_on]).to eql(nil)
       end
@@ -451,24 +477,28 @@ describe 'Dumping' do
     it 'stores a set of integers' do
       set = Set.new([1, 2])
       obj = klass.create(set_value: Set.new([1, 2]))
+
       expect(reload(obj).set_value).to eql(Set.new(['1'.to_d, '2'.to_d]))
       expect(raw_attributes(obj)[:set_value]).to eql(Set.new(['1'.to_d, '2'.to_d]))
     end
 
     it 'stores a set of numbers' do
       obj = klass.create(set_value: Set.new([1.5, '2'.to_d]))
+
       expect(reload(obj).set_value).to eql(Set.new(['1.5'.to_d, '2'.to_d]))
       expect(raw_attributes(obj)[:set_value]).to eql(Set.new(['1.5'.to_d, '2'.to_d]))
     end
 
     it 'stores empty set as nil' do
       obj = klass.create(set_value: Set.new)
+
       expect(reload(obj).set_value).to eql(nil)
       expect(raw_attributes(obj)[:set_value]).to eql(nil)
     end
 
     it 'stores nil value' do
       obj = klass.create(set_value: nil)
+
       expect(reload(obj).set_value).to eql(nil)
       expect(raw_attributes(obj)[:set_value]).to eql(nil)
     end
@@ -707,6 +737,7 @@ describe 'Dumping' do
 
     it 'can store empty array' do
       obj = klass.create(tags: [])
+
       expect(reload(obj).tags).to eql([])
       expect(raw_attributes(obj)[:tags]).to eql([])
     end
@@ -721,11 +752,13 @@ describe 'Dumping' do
 
     it 'stores document as an array element' do
       obj = klass.create(tags: [{ foo: 'bar' }])
+
       expect(reload(obj).tags).to eql([{ 'foo' => 'bar' }])
       expect(raw_attributes(obj)[:tags]).to eql([{ 'foo' => 'bar' }])
 
       array = %w[foo bar]
       obj = klass.create(tags: [array])
+
       expect(reload(obj).tags).to eql([array])
       expect(raw_attributes(obj)[:tags]).to eql([array])
     end
@@ -748,6 +781,7 @@ describe 'Dumping' do
 
     it 'stores nil value' do
       obj = klass.create(tags: nil)
+
       expect(reload(obj).tags).to eql(nil)
       expect(raw_attributes(obj)[:tags]).to eql(nil)
     end
@@ -976,6 +1010,7 @@ describe 'Dumping' do
       end
 
       obj = klass.create(name: 'Matthew')
+
       expect(reload(obj).name).to eql('Matthew')
       expect(raw_attributes(obj)[:name]).to eql('Matthew')
     end
@@ -986,6 +1021,7 @@ describe 'Dumping' do
       end
 
       obj = klass.create(name: '')
+
       expect(reload(obj).name).to eql(nil)
       expect(raw_attributes(obj)[:name]).to eql(nil)
     end
@@ -996,6 +1032,7 @@ describe 'Dumping' do
       end
 
       obj = klass.create(name: 'Matthew')
+
       expect(reload(obj).name).to eql('Matthew')
       expect(raw_attributes(obj)[:name]).to eql('Matthew')
     end
@@ -1006,6 +1043,7 @@ describe 'Dumping' do
       end
 
       obj = klass.create(name: nil)
+
       expect(reload(obj).name).to eql(nil)
       expect(raw_attributes(obj)[:name]).to eql(nil)
     end
@@ -1064,6 +1102,7 @@ describe 'Dumping' do
 
     it 'stores nil value' do
       obj = klass.create(config: nil)
+
       expect(reload(obj).config).to eql(nil)
       expect(raw_attributes(obj)[:config]).to eql(nil)
     end
@@ -1073,9 +1112,7 @@ describe 'Dumping' do
         config = { 'foo' => { 'bar' => 1 }, 'baz' => [{ 'foobar' => 2 }] }
         obj = klass.create(config: config)
 
-        expect(reload(obj).config).to eql(
-          foo: { bar: 1 }, baz: [{ foobar: 2 }]
-        )
+        expect(reload(obj).config).to eql(foo: { bar: 1 }, baz: [{ foobar: 2 }])
       end
     end
 
@@ -1126,12 +1163,14 @@ describe 'Dumping' do
 
     it 'stores integer value as Integer' do
       obj = klass.create(count: 10)
+
       expect(reload(obj).count).to eql(10)
       expect(raw_attributes(obj)[:count]).to eql(10)
     end
 
     it 'stores nil value' do
       obj = klass.create(count: nil)
+
       expect(reload(obj).count).to eql(nil)
       expect(raw_attributes(obj)[:count]).to eql(nil)
     end
@@ -1146,24 +1185,28 @@ describe 'Dumping' do
 
     it 'stores integer value as Number' do
       obj = klass.create(count: 10)
+
       expect(reload(obj).count).to eql(BigDecimal(10))
       expect(raw_attributes(obj)[:count]).to eql(BigDecimal(10))
     end
 
     it 'stores float value Number' do
       obj = klass.create(count: 10.001)
+
       expect(reload(obj).count).to eql(BigDecimal('10.001'))
       expect(raw_attributes(obj)[:count]).to eql(BigDecimal('10.001'))
     end
 
     it 'stores BigDecimal value as Number' do
       obj = klass.create(count: BigDecimal('10.001'))
+
       expect(reload(obj).count).to eql(BigDecimal('10.001'))
       expect(raw_attributes(obj)[:count]).to eql(BigDecimal('10.001'))
     end
 
     it 'stores nil value' do
       obj = klass.create(count: nil)
+
       expect(reload(obj).count).to eql(nil)
       expect(raw_attributes(obj)[:count]).to eql(nil)
     end
@@ -1198,6 +1241,7 @@ describe 'Dumping' do
       end
 
       obj = klass.create(options: { foo: 'bar' })
+
       expect(reload(obj).options).to eql('foo' => 'bar')
       expect(raw_attributes(obj)[:options]).to eql('{"foo":"bar"}')
     end
@@ -1208,6 +1252,7 @@ describe 'Dumping' do
       end
 
       obj = klass.create(options: Set.new)
+
       expect(reload(obj).options).to eql(Set.new)
       expect(raw_attributes(obj)[:options]).to eql("--- !ruby/object:Set\nhash: {}\n")
     end
@@ -1218,6 +1263,7 @@ describe 'Dumping' do
       end
 
       obj = klass.create(options: nil)
+
       expect(reload(obj).options).to eql(nil)
       expect(raw_attributes(obj)[:options]).to eql(nil)
     end

--- a/spec/dynamoid/type_casting_spec.rb
+++ b/spec/dynamoid/type_casting_spec.rb
@@ -255,6 +255,61 @@ describe 'Type casting' do
       expect(obj.items).to eql(set)
       expect(obj.items).not_to equal(set)
     end
+
+    describe 'typed set' do
+      it 'type casts strings' do
+        klass = new_class do
+          field :values, :set, of: :string
+        end
+
+        obj = klass.new(values: Set.new([{ name: 'John' }]))
+
+        expect(obj.values).to eql(Set.new(['{:name=>"John"}']))
+      end
+
+      it 'type casts integers' do
+        klass = new_class do
+          field :values, :set, of: :integer
+        end
+
+        obj = klass.new(values: Set.new([1, 1.5, '2'.to_d]))
+
+        expect(obj.values).to eql(Set.new([1, 1, 2]))
+      end
+
+      it 'type casts numbers' do
+        klass = new_class do
+          field :values, :set, of: :number
+        end
+
+        obj = klass.new(values: Set.new([1, 1.5, '2'.to_d]))
+
+        expect(obj.values).to eql(Set.new(['1'.to_d, '1.5'.to_d, '2'.to_d]))
+      end
+
+      it 'type casts dates' do
+        klass = new_class do
+          field :values, :set, of: :date
+        end
+
+        obj = klass.new(values: Set.new(['2018-08-21']))
+
+        expect(obj.values).to eql(Set.new(['2018-08-21'.to_date]))
+      end
+
+      it 'type casts datetimes' do
+        klass = new_class do
+          field :values, :set, of: :datetime
+        end
+
+        obj = klass.new(values: Set.new(['2018-08-21T21:55:30+01:00']))
+
+        expect(obj.values).to eql(Set.new(['2018-08-21T21:55:30+01:00'.to_datetime]))
+      end
+
+      it 'does not change serialized'
+      it 'does not change custom types'
+    end
   end
 
   describe 'Array field' do

--- a/spec/dynamoid/type_casting_spec.rb
+++ b/spec/dynamoid/type_casting_spec.rb
@@ -349,6 +349,61 @@ describe 'Type casting' do
       expect(obj.items).to eql(array)
       expect(obj.items).not_to equal(array)
     end
+
+    describe 'typed array' do
+      it 'type casts strings' do
+        klass = new_class do
+          field :values, :array, of: :string
+        end
+
+        obj = klass.new(values: [{ name: 'John' }])
+
+        expect(obj.values).to eql(['{:name=>"John"}'])
+      end
+
+      it 'type casts integers' do
+        klass = new_class do
+          field :values, :array, of: :integer
+        end
+
+        obj = klass.new(values: [1, 1.5, '2'.to_d])
+
+        expect(obj.values).to eql([1, 1, 2])
+      end
+
+      it 'type casts numbers' do
+        klass = new_class do
+          field :values, :array, of: :number
+        end
+
+        obj = klass.new(values: [1, 1.5, '2'.to_d])
+
+        expect(obj.values).to eql(['1'.to_d, '1.5'.to_d, '2'.to_d])
+      end
+
+      it 'type casts dates' do
+        klass = new_class do
+          field :values, :array, of: :date
+        end
+
+        obj = klass.new(values: ['2018-08-21'])
+
+        expect(obj.values).to eql(['2018-08-21'.to_date])
+      end
+
+      it 'type casts datetimes' do
+        klass = new_class do
+          field :values, :array, of: :datetime
+        end
+
+        obj = klass.new(values: ['2018-08-21T21:55:30+01:00'])
+
+        expect(obj.values).to eql(['2018-08-21T21:55:30+01:00'.to_datetime])
+      end
+
+      it 'does not change serialized'
+      it 'does not change custom types'
+    end
   end
 
   describe 'String field' do


### PR DESCRIPTION
Updates:
- extended supported types list of `:of` option in field declaration for `set` field
- add `:of` option for `array` field

`of` option now supports all scalar types (except `boolean`) like `integer`, `number`, `date`, `datetime`, `serializable` and custom types.

Example:

```ruby
field :values, :set, of: :datetime
```

Some type declarations have options like `store_as_string` or `serializer`. It's possible to specify them for elements type:

```ruby
field :values, :array, of: { serialized: { serializer: JSON } }
```

Related Issue https://github.com/Dynamoid/Dynamoid/issues/272