### PR TITLE
Ignore not declared attributes

### DIFF
--- a/lib/dynamoid/undumping.rb
+++ b/lib/dynamoid/undumping.rb
@@ -4,8 +4,11 @@ module Dynamoid
   module Undumping
     def self.undump_attributes(attributes, attributes_options)
       {}.tap do |h|
-        attributes.symbolize_keys.each do |attribute, value|
-          h[attribute] = undump_field(value, attributes_options[attribute])
+        # ignore existing attributes not declared in document class
+        attributes.symbolize_keys
+          .select { |attribute| attributes_options.key?(attribute) }
+          .each do |attribute, value|
+            h[attribute] = undump_field(value, attributes_options[attribute])
         end
       end
     end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -937,6 +937,46 @@ describe Dynamoid::Criteria::Chain do
     end
   end
 
+  context 'field is not declared in document' do
+    context 'Query' do
+      let(:class_with_not_declared_field) do
+        new_class do
+          field :name
+        end
+      end
+
+      before do
+        class_with_not_declared_field.create_table
+      end
+
+      it 'ignores it without exceptions' do
+        Dynamoid.adapter.put_item(class_with_not_declared_field.table_name, id: '1', name: 'Mike', bod: '1996-12-21')
+        objects = class_with_not_declared_field.where(id: '1', name: 'Mike').to_a
+
+        expect(objects.map(&:id)).to eql(['1'])
+      end
+    end
+
+    context 'Scan' do
+      let(:class_with_not_declared_field) do
+        new_class do
+          range :name
+        end
+      end
+
+      before do
+        class_with_not_declared_field.create_table
+      end
+
+      it 'ignores it without exceptions' do
+        Dynamoid.adapter.put_item(class_with_not_declared_field.table_name, id: '1', name: 'Mike', bod: '1996-12-21')
+        objects = class_with_not_declared_field.where(id: '1', name: 'Mike').to_a
+
+        expect(objects.map(&:id)).to eql(['1'])
+      end
+    end
+  end
+
   describe '#delete_all' do
     it 'deletes in batch' do
       klass = new_class

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -64,6 +64,25 @@ describe Dynamoid::Finders do
         obj = klass.create
         expect(klass.find(obj.id)).to be_persisted
       end
+
+      context 'field is not declared in document' do
+        let(:class_with_not_declared_field) do
+          new_class do
+            field :name
+          end
+        end
+
+        before do
+          class_with_not_declared_field.create_table
+        end
+
+        it 'ignores it without exceptions' do
+          Dynamoid.adapter.put_item(class_with_not_declared_field.table_name, id: '1', bod: '1996-12-21')
+          obj = class_with_not_declared_field.find('1')
+
+          expect(obj.id).to eql('1')
+        end
+      end
     end
 
     context 'multiple primary keys provided' do
@@ -187,6 +206,28 @@ describe Dynamoid::Finders do
 
         expect(obj1).to be_persisted
         expect(obj2).to be_persisted
+      end
+
+      context 'field is not declared in document' do
+        let(:class_with_not_declared_field) do
+          new_class do
+            field :name
+          end
+        end
+
+        before do
+          class_with_not_declared_field.create_table
+        end
+
+        it 'ignores it without exceptions' do
+          Dynamoid.adapter.put_item(class_with_not_declared_field.table_name, id: '1', dob: '1996-12-21')
+          Dynamoid.adapter.put_item(class_with_not_declared_field.table_name, id: '2', dob: '2001-03-14')
+
+          objects = class_with_not_declared_field.find(['1', '2'])
+
+          expect(objects.size).to eql 2
+          expect(objects.map(&:id)).to contain_exactly('1', '2')
+        end
       end
 
       context 'backoff is specified' do


### PR DESCRIPTION
Fix exception while Dynamoid loads a document with attribute not declared as field in model.

Related issue https://github.com/Dynamoid/dynamoid/issues/308