### PR TITLE
Fix list_tables method to return names of all tables, not just first page

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -467,10 +467,16 @@ module Dynamoid
       # List all tables on DynamoDB.
       #
       # @since 1.0.0
-      #
-      # @todo Provide limit support http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#update_item-instance_method
       def list_tables
-        client.list_tables[:table_names]
+        [].tap do |result|
+          start_table_name = nil
+          loop do
+            result_page = client.list_tables exclusive_start_table_name: start_table_name
+            start_table_name = result_page.last_evaluated_table_name
+            result.concat result_page.table_names
+            break unless start_table_name
+          end
+        end
       end
 
       # Persists an item on DynamoDB.

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -762,6 +762,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
     end
 
     context 'when calling ListTables with more than 200 tables' do
+      let!(:count_before) { Dynamoid.adapter.list_tables.size }
       before do
         201.times do |n|
           Dynamoid.adapter.create_table("dynamoid_tests_ALotOfTables#{n}", [:id])
@@ -776,7 +777,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       it 'automatically pages through all results' do
         expect(Dynamoid.adapter.list_tables).to include "dynamoid_tests_ALotOfTables44"
         expect(Dynamoid.adapter.list_tables).to include "dynamoid_tests_ALotOfTables200"
-        expect(Dynamoid.adapter.list_tables.size).to eq 204
+        expect(Dynamoid.adapter.list_tables.size).to eq 201 + count_before
       end
     end
 

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -761,6 +761,25 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       expect(Dynamoid.adapter.list_tables).to include test_table2
     end
 
+    context 'when calling ListTables with more than 200 tables' do
+      before do
+        201.times do |n|
+          Dynamoid.adapter.create_table("dynamoid_tests_ALotOfTables#{n}", [:id])
+        end
+      end
+      after do
+        201.times do |n|
+          Dynamoid.adapter.delete_table("dynamoid_tests_ALotOfTables#{n}")
+        end
+      end
+
+      it 'automatically pages through all results' do
+        expect(Dynamoid.adapter.list_tables).to include "dynamoid_tests_ALotOfTables44"
+        expect(Dynamoid.adapter.list_tables).to include "dynamoid_tests_ALotOfTables200"
+        expect(Dynamoid.adapter.list_tables.size).to eq 204
+      end
+    end
+
     # Query
     it 'performs query on a table and returns items' do
       Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')


### PR DESCRIPTION
Old implementation returns only the first page of `list_tables` call. New implementation pages through the results to return all table names.