### PR TITLE
fix consistent_read option of Finders#find

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -429,9 +429,11 @@ module Dynamoid
         options ||= {}
         table = describe_table(table_name)
         range_key = options.delete(:range_key)
+        consistent_read = options.delete(:consistent_read)
 
         item = client.get_item(table_name: table_name,
-                               key: key_stanza(table, key, range_key))[:item]
+                               key: key_stanza(table, key, range_key),
+                               consistent_read: consistent_read)[:item]
         item ? result_item_to_hash(item) : nil
       end
 

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -406,6 +406,11 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
 
   context 'with a preexisting table' do
     # GetItem, PutItem and DeleteItem
+    it 'passes options to underlying GetItem call' do
+      expect(Dynamoid.adapter.client).to receive(:get_item).with(hash_including(consistent_read: true)).and_call_original
+      expect(Dynamoid.adapter.get_item(test_table1, '1', consistent_read: true)).to be_nil
+    end
+
     it 'performs GetItem for an item that does not exist' do
       expect(Dynamoid.adapter.get_item(test_table1, '1')).to be_nil
     end

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -288,12 +288,12 @@ describe Dynamoid::Finders do
     end
   end
 
-
-  # TODO: ATM, adapter sets consistent read to be true for all query. Provide option for setting consistent_read option
-  # it 'sends consistent option to the adapter' do
-  #  expects(Dynamoid::Adapter).to receive(:get_item).with { |table_name, key, options| options[:consistent_read] == true }
-  #  Address.find('x', :consistent_read => true)
-  # end
+  it 'sends consistent option to the adapter' do
+    expect(Dynamoid.adapter).to receive(:get_item)
+      .with(anything, anything, hash_including(consistent_read: true))
+      .and_call_original
+    Address.find(address.id, consistent_read: true)
+  end
 
   context 'with users' do
     it 'finds using method_missing for attributes' do


### PR DESCRIPTION
In [README.md#Consistent Reads](https://github.com/Dynamoid/dynamoid/tree/v2.2.0#consistent-reads), `Model#find` provides `consistent_read` option.

> Address.find(address.id, consistent_read: true)  # Find an address, ensure the read is consistent.

But it does not work.

I fix this by passing `consistent_read` option to client in `AwsSdkV3#get_item`.