### PR TITLE
Add Ability to specify timeout connection settings

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -74,6 +74,18 @@ module Dynamoid
         if Dynamoid::Config.region?
           @connection_hash[:region] = Dynamoid::Config.region
         end
+        if Dynamoid::Config.http_continue_timeout?
+          @connection_hash[:http_continue_timeout] = Dynamoid::Config.http_continue_timeout
+        end
+        if Dynamoid::Config.http_idle_timeout?
+          @connection_hash[:http_idle_timeout] = Dynamoid::Config.http_idle_timeout
+        end
+        if Dynamoid::Config.http_open_timeout?
+          @connection_hash[:http_open_timeout] = Dynamoid::Config.http_open_timeout
+        end
+        if Dynamoid::Config.http_read_timeout?
+          @connection_hash[:http_read_timeout] = Dynamoid::Config.http_read_timeout
+        end
 
         # https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb
         # https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/log/formatter.rb

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -49,6 +49,8 @@ module Dynamoid
       }
       BATCH_WRITE_ITEM_REQUESTS_LIMIT = 25
 
+      CONNECTION_CONFIG_OPTIONS = %i[endpoint region http_continue_timeout http_idle_timeout http_open_timeout http_read_timeout].freeze
+
       attr_reader :table_cache
 
       # Establish the connection to DynamoDB.
@@ -62,29 +64,14 @@ module Dynamoid
       def connection_config
         @connection_hash = {}
 
-        if Dynamoid::Config.endpoint?
-          @connection_hash[:endpoint] = Dynamoid::Config.endpoint
+        (Dynamoid::Config.settings.compact.keys & CONNECTION_CONFIG_OPTIONS).each do |option|
+          @connection_hash[option] = Dynamoid::Config.send(option)
         end
         if Dynamoid::Config.access_key?
           @connection_hash[:access_key_id] = Dynamoid::Config.access_key
         end
         if Dynamoid::Config.secret_key?
           @connection_hash[:secret_access_key] = Dynamoid::Config.secret_key
-        end
-        if Dynamoid::Config.region?
-          @connection_hash[:region] = Dynamoid::Config.region
-        end
-        if Dynamoid::Config.http_continue_timeout?
-          @connection_hash[:http_continue_timeout] = Dynamoid::Config.http_continue_timeout
-        end
-        if Dynamoid::Config.http_idle_timeout?
-          @connection_hash[:http_idle_timeout] = Dynamoid::Config.http_idle_timeout
-        end
-        if Dynamoid::Config.http_open_timeout?
-          @connection_hash[:http_open_timeout] = Dynamoid::Config.http_open_timeout
-        end
-        if Dynamoid::Config.http_read_timeout?
-          @connection_hash[:http_read_timeout] = Dynamoid::Config.http_read_timeout
         end
 
         # https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -42,6 +42,10 @@ module Dynamoid
       constant: BackoffStrategies::ConstantBackoff,
       exponential: BackoffStrategies::ExponentialBackoff
     }
+    option :http_continue_timeout, default: nil # specify if you'd like to overwrite Aws Configure - default: 1
+    option :http_idle_timeout, default: nil     #                                                  - default: 5
+    option :http_open_timeout, default: nil     #                                                  - default: 15
+    option :http_read_timeout, default: nil     #                                                  - default: 60
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.
     #

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -892,4 +892,18 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
   # UpdateItem
 
   # UpdateTable
+
+  # connection_config
+  context '#connectin_config' do
+    subject { described_class.new.connection_config }
+
+    before do
+      Dynamoid.configure.http_open_timeout = 30
+    end
+
+    it 'not nil options entried' do
+      expect(subject.keys).to contain_exactly(:endpoint, :log_formatter, :log_level, :logger, :http_open_timeout)
+      expect(subject[:http_open_timeout]).to eq 30
+    end
+  end
 end


### PR DESCRIPTION
We can use [Aws configuration](https://github.com/Dynamoid/dynamoid#aws-configuration) but it's not specified for Dynamoid.

This change adds ability to specify timeout connection settings specific to Dynamoid.

I referred default values to following URL.
https://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html
