### PR TITLE
Add support for backoff in scan and query

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -578,6 +578,7 @@ module Dynamoid
         Enumerator.new do |y|
           record_count = 0
           scan_count = 0
+          backoff = Dynamoid.config.backoff ? Dynamoid.config.build_backoff : nil
           loop do
             # Adjust the limit down if the remaining record and/or scan limit are
             # lower to obey limits. We can assume the difference won't be
@@ -615,6 +616,8 @@ module Dynamoid
             else
               break
             end
+
+            backoff.call if backoff
           end
         end
       end
@@ -655,6 +658,7 @@ module Dynamoid
         Enumerator.new do |y|
           record_count = 0
           scan_count = 0
+          backoff = Dynamoid.config.backoff ? Dynamoid.config.build_backoff : nil
           loop do
             # Adjust the limit down if the remaining record and/or scan limit are
             # lower to obey limits. We can assume the difference won't be
@@ -693,6 +697,8 @@ module Dynamoid
             else
               break
             end
+
+            backoff.call if backoff
           end
         end
       end


### PR DESCRIPTION
Add backoff support in scan and query operations.
Backoff functions were implemented in https://github.com/Dynamoid/dynamoid/pull/246