### PR TITLE
Add smart count

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -536,6 +536,15 @@ module Dynamoid
         end
       end
 
+      def query_count(table_name, opts = {})
+        table = describe_table(table_name)
+        opts[:select] = 'COUNT'
+
+        Query.new.call(client, table, opts)
+          .map(&:count)
+          .reduce(:+)
+      end
+
       # Scan the DynamoDB table. This is usually a very slow operation as it naively filters all data on
       # the DynamoDB servers.
       #
@@ -555,6 +564,15 @@ module Dynamoid
             page.items.each { |row| yielder << result_item_to_hash(row) }
           end
         end
+      end
+
+      def scan_count(table_name, scan_hash = {}, select_opts = {})
+        table = describe_table(table_name)
+        select_opts[:select] = 'COUNT'
+
+        Scan.new.call(client, table, scan_hash, select_opts)
+          .map(&:count)
+          .reduce(:+)
       end
 
       #

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -605,7 +605,7 @@ module Dynamoid
             results = client.query(q)
             results.items.each { |row| y << result_item_to_hash(row) }
 
-            record_count += results.items.size
+            record_count += results.count
             break if record_limit && record_count >= record_limit
 
             scan_count += results.scanned_count
@@ -685,7 +685,7 @@ module Dynamoid
             results = client.scan(request)
             results.items.each { |row| y << result_item_to_hash(row) }
 
-            record_count += results.items.size
+            record_count += results.count
             break if record_limit && record_count >= record_limit
 
             scan_count += results.scanned_count

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -513,34 +513,34 @@ module Dynamoid
       # one range key to the hash.
       #
       # @param [String] table_name the name of the table
-      # @param [Hash] opts the options to query the table with
-      # @option opts [String] :hash_value the value of the hash key to find
-      # @option opts [Number, Number] :range_between find the range key within this range
-      # @option opts [Number] :range_greater_than find range keys greater than this
-      # @option opts [Number] :range_less_than find range keys less than this
-      # @option opts [Number] :range_gte find range keys greater than or equal to this
-      # @option opts [Number] :range_lte find range keys less than or equal to this
+      # @param [Hash] options the options to query the table with
+      # @option options [String] :hash_value the value of the hash key to find
+      # @option options [Number, Number] :range_between find the range key within this range
+      # @option options [Number] :range_greater_than find range keys greater than this
+      # @option options [Number] :range_less_than find range keys less than this
+      # @option options [Number] :range_gte find range keys greater than or equal to this
+      # @option options [Number] :range_lte find range keys less than or equal to this
       #
       # @return [Enumerable] matching items
       #
       # @since 1.0.0
       #
       # @todo Provide support for various other options http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#query-instance_method
-      def query(table_name, opts = {})
+      def query(table_name, options = {})
         table = describe_table(table_name)
 
         Enumerator.new do |yielder|
-          Query.new.call(client, table, opts).each do |page|
+          Query.new(client, table, options).call.each do |page|
             page.items.each { |row| yielder << result_item_to_hash(row) }
           end
         end
       end
 
-      def query_count(table_name, opts = {})
+      def query_count(table_name, options = {})
         table = describe_table(table_name)
-        opts[:select] = 'COUNT'
+        options[:select] = 'COUNT'
 
-        Query.new.call(client, table, opts)
+        Query.new(client, table, options).call
           .map(&:count)
           .reduce(:+)
       end
@@ -549,28 +549,28 @@ module Dynamoid
       # the DynamoDB servers.
       #
       # @param [String] table_name the name of the table
-      # @param [Hash] scan_hash a hash of attributes: matching records will be returned by the scan
+      # @param [Hash] conditions a hash of attributes: matching records will be returned by the scan
       #
       # @return [Enumerable] matching items
       #
       # @since 1.0.0
       #
       # @todo: Provide support for various options http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#scan-instance_method
-      def scan(table_name, scan_hash = {}, select_opts = {})
+      def scan(table_name, conditions = {}, options = {})
         table = describe_table(table_name)
 
         Enumerator.new do |yielder|
-          Scan.new.call(client, table, scan_hash, select_opts).each do |page|
+          Scan.new(client, table, conditions, options).call.each do |page|
             page.items.each { |row| yielder << result_item_to_hash(row) }
           end
         end
       end
 
-      def scan_count(table_name, scan_hash = {}, select_opts = {})
+      def scan_count(table_name, conditions = {}, options = {})
         table = describe_table(table_name)
-        select_opts[:select] = 'COUNT'
+        options[:select] = 'COUNT'
 
-        Scan.new.call(client, table, scan_hash, select_opts)
+        Scan.new(client, table, conditions, options).call
           .map(&:count)
           .reduce(:+)
       end

--- a/lib/dynamoid/adapter_plugin/query.rb
+++ b/lib/dynamoid/adapter_plugin/query.rb
@@ -1,58 +1,26 @@
 module Dynamoid
   module AdapterPlugin
     class Query
-      def call(client, table, opts = {})
-        hk    = (opts[:hash_key].present? ? opts.delete(:hash_key) : table.hash_key).to_s
-        rng   = (opts[:range_key].present? ? opts.delete(:range_key) : table.range_key).to_s
-        q     = opts.slice(
-          :consistent_read,
-          :scan_index_forward,
-          :select,
-          :index_name
-        )
+      OPTIONS_KEYS = [
+        :limit, :hash_key, :hash_value, :range_key, :consistent_read, :scan_index_forward,
+        :select, :index_name, :batch_size, :exclusive_start_key, :record_limit, :scan_limit
+      ]
 
-        opts.delete(:consistent_read)
-        opts.delete(:scan_index_forward)
-        opts.delete(:select)
-        opts.delete(:index_name)
+      attr_reader :client, :table, :options, :conditions
 
-        # Deal with various limits and batching
-        record_limit = opts.delete(:record_limit)
-        scan_limit = opts.delete(:scan_limit)
-        batch_size = opts.delete(:batch_size)
-        exclusive_start_key = opts.delete(:exclusive_start_key)
-        limit = [record_limit, scan_limit, batch_size].compact.min
+      def initialize(client, table, opts = {})
+        @client = client
+        @table = table
 
-        key_conditions = {
-          hk => {
-            comparison_operator: AwsSdkV3::EQ,
-            attribute_value_list: AwsSdkV3.attribute_value_list(AwsSdkV3::EQ, opts.delete(:hash_value).freeze)
-          }
-        }
+        opts = opts.symbolize_keys
+        @options = opts.slice(*OPTIONS_KEYS)
+        @conditions = opts.except(*OPTIONS_KEYS)
+      end
 
-        opts.each_pair do |k, _v|
-          next unless (op = AwsSdkV3::RANGE_MAP[k])
-          key_conditions[rng] = {
-            comparison_operator: op,
-            attribute_value_list: AwsSdkV3.attribute_value_list(op, opts.delete(k).freeze)
-          }
-        end
+      def call
+        request = build_request
 
-        query_filter = {}
-        opts.reject { |k, _| k.in? AwsSdkV3::RANGE_MAP.keys }.each do |attr, hash|
-          query_filter[attr] = {
-            comparison_operator: AwsSdkV3::FIELD_MAP[hash.keys[0]],
-            attribute_value_list: AwsSdkV3.attribute_value_list(AwsSdkV3::FIELD_MAP[hash.keys[0]], hash.values[0].freeze)
-          }
-        end
-
-        q[:limit] = limit if limit
-        q[:exclusive_start_key] = exclusive_start_key if exclusive_start_key
-        q[:table_name]     = table.name
-        q[:key_conditions] = key_conditions
-        q[:query_filter]   = query_filter
-
-        Enumerator.new do |y|
+        Enumerator.new do |yielder|
           record_count = 0
           scan_count = 0
 
@@ -74,30 +42,101 @@ module Dynamoid
             # The underlying implementation will have 1 page for records 1-999
             # then will request with limit 1 for records 1000-2000 (making 1000
             # requests of limit 1) until hit record 2001.
-            if q[:limit] && record_limit && record_limit - record_count < q[:limit]
-              q[:limit] = record_limit - record_count
+            if request[:limit] && record_limit && record_limit - record_count < request[:limit]
+              request[:limit] = record_limit - record_count
             end
-            if q[:limit] && scan_limit && scan_limit - scan_count < q[:limit]
-              q[:limit] = scan_limit - scan_count
+            if request[:limit] && scan_limit && scan_limit - scan_count < request[:limit]
+              request[:limit] = scan_limit - scan_count
             end
 
-            results = client.query(q)
-            y << results
+            response = client.query(request)
 
-            record_count += results.count
+            yielder << response
+
+            record_count += response.count
             break if record_limit && record_count >= record_limit
 
-            scan_count += results.scanned_count
+            scan_count += response.scanned_count
             break if scan_limit && scan_count >= scan_limit
 
-            if (lk = results.last_evaluated_key)
-              q[:exclusive_start_key] = lk
+            if response.last_evaluated_key
+              request[:exclusive_start_key] = response.last_evaluated_key
             else
               break
             end
 
             backoff.call if backoff
           end
+        end
+      end
+
+      private
+
+      def build_request
+        request = options.slice(
+          :consistent_read,
+          :scan_index_forward,
+          :select,
+          :index_name,
+          :exclusive_start_key
+        ).compact
+
+        # Deal with various limits and batching
+        batch_size = options[:batch_size]
+        limit = [record_limit, scan_limit, batch_size].compact.min
+
+        request[:limit]          = limit if limit
+        request[:table_name]     = table.name
+        request[:key_conditions] = key_conditions
+        request[:query_filter]   = query_filter
+
+        request
+      end
+
+      def record_limit
+        options[:record_limit]
+      end
+
+      def scan_limit
+        options[:scan_limit]
+      end
+
+      def hash_key_name
+        (options[:hash_key] || table.hash_key)
+      end
+
+      def range_key_name
+        (options[:range_key] || table.range_key)
+      end
+
+      def key_conditions
+        result = {
+          hash_key_name => {
+            comparison_operator: AwsSdkV3::EQ,
+            attribute_value_list: AwsSdkV3.attribute_value_list(AwsSdkV3::EQ, options[:hash_value].freeze)
+          }
+        }
+
+        conditions.slice(*AwsSdkV3::RANGE_MAP.keys).each do |k, _v|
+          op = AwsSdkV3::RANGE_MAP[k]
+
+          result[range_key_name] = {
+            comparison_operator: op,
+            attribute_value_list: AwsSdkV3.attribute_value_list(op, conditions[k].freeze)
+          }
+        end
+
+        result
+      end
+
+      def query_filter
+        conditions.except(*AwsSdkV3::RANGE_MAP.keys).reduce({}) do |result, (attr, cond)|
+          condition = {
+            comparison_operator: AwsSdkV3::FIELD_MAP[cond.keys[0]],
+            attribute_value_list: AwsSdkV3.attribute_value_list(AwsSdkV3::FIELD_MAP[cond.keys[0]], cond.values[0].freeze)
+          }
+          result[attr] = condition
+          result
         end
       end
     end

--- a/lib/dynamoid/adapter_plugin/query.rb
+++ b/lib/dynamoid/adapter_plugin/query.rb
@@ -1,0 +1,105 @@
+module Dynamoid
+  module AdapterPlugin
+    class Query
+      def call(client, table, opts = {})
+        hk    = (opts[:hash_key].present? ? opts.delete(:hash_key) : table.hash_key).to_s
+        rng   = (opts[:range_key].present? ? opts.delete(:range_key) : table.range_key).to_s
+        q     = opts.slice(
+          :consistent_read,
+          :scan_index_forward,
+          :select,
+          :index_name
+        )
+
+        opts.delete(:consistent_read)
+        opts.delete(:scan_index_forward)
+        opts.delete(:select)
+        opts.delete(:index_name)
+
+        # Deal with various limits and batching
+        record_limit = opts.delete(:record_limit)
+        scan_limit = opts.delete(:scan_limit)
+        batch_size = opts.delete(:batch_size)
+        exclusive_start_key = opts.delete(:exclusive_start_key)
+        limit = [record_limit, scan_limit, batch_size].compact.min
+
+        key_conditions = {
+          hk => {
+            comparison_operator: AwsSdkV3::EQ,
+            attribute_value_list: AwsSdkV3.attribute_value_list(AwsSdkV3::EQ, opts.delete(:hash_value).freeze)
+          }
+        }
+
+        opts.each_pair do |k, _v|
+          next unless (op = AwsSdkV3::RANGE_MAP[k])
+          key_conditions[rng] = {
+            comparison_operator: op,
+            attribute_value_list: AwsSdkV3.attribute_value_list(op, opts.delete(k).freeze)
+          }
+        end
+
+        query_filter = {}
+        opts.reject { |k, _| k.in? AwsSdkV3::RANGE_MAP.keys }.each do |attr, hash|
+          query_filter[attr] = {
+            comparison_operator: AwsSdkV3::FIELD_MAP[hash.keys[0]],
+            attribute_value_list: AwsSdkV3.attribute_value_list(AwsSdkV3::FIELD_MAP[hash.keys[0]], hash.values[0].freeze)
+          }
+        end
+
+        q[:limit] = limit if limit
+        q[:exclusive_start_key] = exclusive_start_key if exclusive_start_key
+        q[:table_name]     = table.name
+        q[:key_conditions] = key_conditions
+        q[:query_filter]   = query_filter
+
+        Enumerator.new do |y|
+          record_count = 0
+          scan_count = 0
+
+          backoff = Dynamoid.config.backoff ? Dynamoid.config.build_backoff : nil
+
+          loop do
+            # Adjust the limit down if the remaining record and/or scan limit are
+            # lower to obey limits. We can assume the difference won't be
+            # negative due to break statements below but choose smaller limit
+            # which is why we have 2 separate if statements.
+            # NOTE: Adjusting based on record_limit can cause many HTTP requests
+            # being made. We may want to change this behavior, but it affects
+            # filtering on data with potentially large gaps.
+            # Example:
+            #    User.where('created_at.gte' => 1.day.ago).record_limit(1000)
+            #    Records 1-999 User's that fit criteria
+            #    Records 1000-2000 Users's that do not fit criteria
+            #    Record 2001 fits criteria
+            # The underlying implementation will have 1 page for records 1-999
+            # then will request with limit 1 for records 1000-2000 (making 1000
+            # requests of limit 1) until hit record 2001.
+            if q[:limit] && record_limit && record_limit - record_count < q[:limit]
+              q[:limit] = record_limit - record_count
+            end
+            if q[:limit] && scan_limit && scan_limit - scan_count < q[:limit]
+              q[:limit] = scan_limit - scan_count
+            end
+
+            results = client.query(q)
+            y << results
+
+            record_count += results.count
+            break if record_limit && record_count >= record_limit
+
+            scan_count += results.scanned_count
+            break if scan_limit && scan_count >= scan_limit
+
+            if (lk = results.last_evaluated_key)
+              q[:exclusive_start_key] = lk
+            else
+              break
+            end
+
+            backoff.call if backoff
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dynamoid/adapter_plugin/scan.rb
+++ b/lib/dynamoid/adapter_plugin/scan.rb
@@ -1,0 +1,77 @@
+module Dynamoid
+  module AdapterPlugin
+    class Scan
+      def call(client, table, scan_hash = {}, select_opts = {})
+        request = { table_name: table.name }
+        request[:consistent_read] = true if select_opts.delete(:consistent_read)
+
+        # Deal with various limits and batching
+        record_limit = select_opts.delete(:record_limit)
+        scan_limit = select_opts.delete(:scan_limit)
+        batch_size = select_opts.delete(:batch_size)
+        exclusive_start_key = select_opts.delete(:exclusive_start_key)
+        request_limit = [record_limit, scan_limit, batch_size].compact.min
+        request[:limit] = request_limit if request_limit
+        request[:exclusive_start_key] = exclusive_start_key if exclusive_start_key
+
+        if scan_hash.present?
+          request[:scan_filter] = scan_hash.reduce({}) do |memo, (attr, cond)|
+            memo.merge(attr.to_s => {
+            comparison_operator: AwsSdkV3::FIELD_MAP[cond.keys[0]],
+            attribute_value_list: AwsSdkV3.attribute_value_list(AwsSdkV3::FIELD_MAP[cond.keys[0]], cond.values[0].freeze)
+          })
+          end
+        end
+
+        Enumerator.new do |y|
+          record_count = 0
+          scan_count = 0
+
+          backoff = Dynamoid.config.backoff ? Dynamoid.config.build_backoff : nil
+
+          loop do
+            # Adjust the limit down if the remaining record and/or scan limit are
+            # lower to obey limits. We can assume the difference won't be
+            # negative due to break statements below but choose smaller limit
+            # which is why we have 2 separate if statements.
+            # NOTE: Adjusting based on record_limit can cause many HTTP requests
+            # being made. We may want to change this behavior, but it affects
+            # filtering on data with potentially large gaps.
+            # Example:
+            #    User.where('created_at.gte' => 1.day.ago).record_limit(1000)
+            #    Records 1-999 User's that fit criteria
+            #    Records 1000-2000 Users's that do not fit criteria
+            #    Record 2001 fits criteria
+            # The underlying implementation will have 1 page for records 1-999
+            # then will request with limit 1 for records 1000-2000 (making 1000
+            # requests of limit 1) until hit record 2001.
+            if request[:limit] && record_limit && record_limit - record_count < request[:limit]
+              request[:limit] = record_limit - record_count
+            end
+            if request[:limit] && scan_limit && scan_limit - scan_count < request[:limit]
+              request[:limit] = scan_limit - scan_count
+            end
+
+            results = client.scan(request)
+            y << results
+
+            record_count += results.count
+            break if record_limit && record_count >= record_limit
+
+            scan_count += results.scanned_count
+            break if scan_limit && scan_count >= scan_limit
+
+            # Keep pulling if we haven't finished paging in all data
+            if (lk = results[:last_evaluated_key])
+              request[:exclusive_start_key] = lk
+            else
+              break
+            end
+
+            backoff.call if backoff
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dynamoid/adapter_plugin/scan.rb
+++ b/lib/dynamoid/adapter_plugin/scan.rb
@@ -9,10 +9,12 @@ module Dynamoid
         record_limit = select_opts.delete(:record_limit)
         scan_limit = select_opts.delete(:scan_limit)
         batch_size = select_opts.delete(:batch_size)
+        select = select_opts.delete(:select)
         exclusive_start_key = select_opts.delete(:exclusive_start_key)
         request_limit = [record_limit, scan_limit, batch_size].compact.min
         request[:limit] = request_limit if request_limit
         request[:exclusive_start_key] = exclusive_start_key if exclusive_start_key
+        request[:select] = select if select
 
         if scan_hash.present?
           request[:scan_filter] = scan_hash.reduce({}) do |memo, (attr, cond)|

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -52,6 +52,14 @@ module Dynamoid #:nodoc:
         records
       end
 
+      def count
+        if key_present?
+          count_via_query
+        else
+          count_via_scan
+        end
+      end
+
       # Returns the last fetched record matched the criteria
       # Enumerable doesn't implement `last`, only `first`
       # So we have to implement it ourselves
@@ -162,6 +170,14 @@ module Dynamoid #:nodoc:
             yielder.yield source.from_database(hash)
           end
         end
+      end
+
+      def count_via_query
+        Dynamoid.adapter.query_count(source.table_name, range_query)
+      end
+
+      def count_via_scan
+        Dynamoid.adapter.scan_count(source.table_name, scan_query, scan_opts)
       end
 
       def range_hash(key)

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -539,7 +539,7 @@ describe Dynamoid::Criteria::Chain do
     it 'supports query on local secondary index but always defaults to table range key' do
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:records_via_query).and_call_original
-      expect(chain.where(name: 'Bob', 'range.lt': 3, 'range2.gt': 15).count).to eq(1)
+      expect(chain.where(name: 'Bob', 'range.lt': 3, 'range2.gt': 15).to_a.size).to eq(1)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to eq(:range)
       expect(chain.index_name).to be_nil
@@ -548,14 +548,14 @@ describe Dynamoid::Criteria::Chain do
     it 'supports query on local secondary index' do
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:records_via_query).and_call_original
-      expect(chain.where(name: 'Bob', 'range2.gt': 15).count).to eq(2)
+      expect(chain.where(name: 'Bob', 'range2.gt': 15).to_a.size).to eq(2)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to eq(:range2)
       expect(chain.index_name).to eq(:range2index)
 
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:records_via_query).and_call_original
-      expect(chain.where(name: 'Bob', 'range3.lt': 200).count).to eq(1)
+      expect(chain.where(name: 'Bob', 'range3.lt': 200).to_a.size).to eq(1)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to eq(:range3)
       expect(chain.index_name).to eq(:range3index)
@@ -564,7 +564,7 @@ describe Dynamoid::Criteria::Chain do
     it 'supports query on local secondary index with start' do
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:records_via_query).and_call_original
-      expect(chain.where(name: 'Bob', 'range2.gt': 15).count).to eq(2)
+      expect(chain.where(name: 'Bob', 'range2.gt': 15).to_a.size).to eq(2)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to eq(:range2)
       expect(chain.index_name).to eq(:range2index)
@@ -596,7 +596,7 @@ describe Dynamoid::Criteria::Chain do
 
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:records_via_scan).and_call_original
-      expect(chain.where(city: 'San Francisco').count).to eq(2)
+      expect(chain.where(city: 'San Francisco').to_a.size).to eq(2)
       # Does not use GSI since not projecting all attributes
       expect(chain.hash_key).to be_nil
       expect(chain.range_key).to be_nil
@@ -633,7 +633,7 @@ describe Dynamoid::Criteria::Chain do
       it 'supports query on global secondary index but always defaults to table hash key' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(name: 'Bob').count).to eq(1)
+        expect(chain.where(name: 'Bob').to_a.size).to eq(1)
         expect(chain.hash_key).to eq(:name)
         expect(chain.range_key).to be_nil
         expect(chain.index_name).to be_nil
@@ -642,28 +642,28 @@ describe Dynamoid::Criteria::Chain do
       it 'supports query on global secondary index' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(city: 'San Francisco').count).to eq(3)
+        expect(chain.where(city: 'San Francisco').to_a.size).to eq(3)
         expect(chain.hash_key).to eq(:city)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:cityage)
 
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(city: 'San Francisco', 'age.gt': 12).count).to eq(2)
+        expect(chain.where(city: 'San Francisco', 'age.gt': 12).to_a.size).to eq(2)
         expect(chain.hash_key).to eq(:city)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:cityage)
 
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(email: 'greg@test.com').count).to eq(1)
+        expect(chain.where(email: 'greg@test.com').to_a.size).to eq(1)
         expect(chain.hash_key).to eq(:email)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:emailage)
 
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(email: 'greg@test.com', 'age.gt': 12).count).to eq(1)
+        expect(chain.where(email: 'greg@test.com', 'age.gt': 12).to_a.size).to eq(1)
         expect(chain.hash_key).to eq(:email)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:emailage)
@@ -672,7 +672,7 @@ describe Dynamoid::Criteria::Chain do
       it 'supports scan when no global secondary index available' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_scan).and_call_original
-        expect(chain.where(gender: 'male').count).to eq(4)
+        expect(chain.where(gender: 'male').to_a.size).to eq(4)
         expect(chain.hash_key).to be_nil
         expect(chain.range_key).to be_nil
         expect(chain.index_name).to be_nil
@@ -681,7 +681,7 @@ describe Dynamoid::Criteria::Chain do
       it 'supports query on global secondary index with start' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_query).and_call_original
-        expect(chain.where(city: 'San Francisco').count).to eq(3)
+        expect(chain.where(city: 'San Francisco').to_a.size).to eq(3)
         expect(chain.hash_key).to eq(:city)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:cityage)
@@ -707,7 +707,7 @@ describe Dynamoid::Criteria::Chain do
       it "does not use index if a condition for index hash key is other than 'equal'" do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:records_via_scan).and_call_original
-        expect(chain.where('city.begins_with': 'San').count).to eq(3)
+        expect(chain.where('city.begins_with': 'San').to_a.size).to eq(3)
         expect(chain.hash_key).to be_nil
         expect(chain.range_key).to be_nil
         expect(chain.index_name).to be_nil
@@ -1124,6 +1124,90 @@ describe Dynamoid::Criteria::Chain do
           chain = Dynamoid::Criteria::Chain.new(klass)
           expect { chain.delete_all }.to change { klass.count }.by(-1)
         end
+      end
+    end
+  end
+
+  describe '#count' do
+    describe 'Query vs Scan' do
+      it 'Scans when query is empty' do
+        chain = Dynamoid::Criteria::Chain.new(Address)
+        chain.query = {}
+        expect(chain).to receive(:count_via_scan)
+        chain.count
+      end
+
+      it 'Queries when query is only ID' do
+        chain = Dynamoid::Criteria::Chain.new(Address)
+        chain.query = { id: 'test' }
+        expect(chain).to receive(:count_via_query)
+        chain.count
+      end
+
+      it 'Queries when query contains ID' do
+        chain = Dynamoid::Criteria::Chain.new(Address)
+        chain.query = { id: 'test', city: 'Bucharest' }
+        expect(chain).to receive(:count_via_query)
+        chain.count
+      end
+
+      it 'Scans when query includes keys that are neither a hash nor a range' do
+        chain = Dynamoid::Criteria::Chain.new(Address)
+        chain.query = { city: 'Bucharest' }
+        expect(chain).to receive(:count_via_scan)
+        chain.count
+      end
+
+      it 'Scans when query is only a range' do
+        chain = Dynamoid::Criteria::Chain.new(Tweet)
+        chain.query = { group: 'xx' }
+        expect(chain).to receive(:count_via_scan)
+        chain.count
+      end
+
+      it 'Scans when there is only not-equal operator for hash key' do
+        chain = Dynamoid::Criteria::Chain.new(Address)
+        chain.query = { 'id.in': ['test'] }
+        expect(chain).to receive(:count_via_scan)
+        chain.count
+      end
+    end
+
+    context 'Query' do
+      let(:model) do
+        Class.new do
+          include Dynamoid::Document
+
+          table name: :customer, key: :name
+          range :age, :integer
+        end
+      end
+
+      it 'returns count of filtered documents' do
+        customer1 = model.create(name: 'Bob', age: 5)
+        customer2 = model.create(name: 'Bob', age: 9)
+        customer3 = model.create(name: 'Bob', age: 12)
+
+        expect(model.where(name: 'Bob', 'age.lt': 10).count).to eql(2)
+      end
+    end
+
+    context 'Scan' do
+      let(:model) do
+        Class.new do
+          include Dynamoid::Document
+
+          table name: :customer
+          field :age, :integer
+        end
+      end
+
+      it 'returns count of filtered documents' do
+        customer1 = model.create(age: 5)
+        customer2 = model.create(age: 9)
+        customer3 = model.create(age: 12)
+
+        expect(model.where('age.lt': 10).count).to eql(2)
       end
     end
   end


### PR DESCRIPTION
Implement `#count` method for `Query`/`Scan` chain in efficient way.

Current implementation downloads all the documents in order to calculate `Query`/`Scan` result's size.

Proposed implementation doesn't do it and uses `Select: "COUNT"` options to return only `count` and `scanned_count` in response [(API documentation).](https://docs.aws.amazon.com/en_us/amazondynamodb/latest/APIReference/API_Scan.html#DDB-Scan-response-Count)

So now `Document.where('age.gt': 10).count` works much more efficiently.

---

Related issues: https://github.com/Dynamoid/Dynamoid/issues/144 and https://github.com/Dynamoid/dynamoid/issues/301