### PR TITLE
Fix `create_tables` rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,7 +877,7 @@ module DynamoidReset
     end
     Dynamoid.adapter.tables.clear
     # Recreate all tables to avoid unexpected errors
-    Dynamoid.included_models.each(&:create_table)
+    Dynamoid.included_models.each { |m| m.create_table(sync: true) }
   end
 end
 

--- a/lib/dynamoid/tasks/database.rake
+++ b/lib/dynamoid/tasks/database.rake
@@ -7,7 +7,7 @@ namespace :dynamoid do
   desc 'Creates DynamoDB tables, one for each of your Dynamoid models - does not modify pre-existing tables'
   task create_tables: :environment do
     # Load models so Dynamoid will be able to discover tables expected.
-    Dir[File.join(Dynamoid::Config.models_dir, '*.rb')].sort.each { |file| require file }
+    Dir[File.join(Dynamoid::Config.models_dir, '**/*.rb')].sort.each { |file| require file }
     if Dynamoid.included_models.any?
       tables = Dynamoid::Tasks::Database.create_tables
       result = tables[:created].map { |c| "#{c} created" } + tables[:existing].map { |e| "#{e} already exists" }

--- a/lib/dynamoid/tasks/database.rb
+++ b/lib/dynamoid/tasks/database.rb
@@ -14,7 +14,7 @@ module Dynamoid
           if Dynamoid.adapter.list_tables.include? model.table_name
             results[:existing] << model.table_name
           else
-            model.create_table
+            model.create_table(sync: true)
             results[:created] << model.table_name
           end
         end


### PR DESCRIPTION
Updates:
* creates tables for models in nested directories (in `Config.models_dir`)
* create tables synchronously

Related issue https://github.com/Dynamoid/Dynamoid/issues/270