### PR TITLE
Add range key to RecordNotFound exception

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -428,7 +428,9 @@ module Dynamoid
       #
       # @todo Provide support for various options http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#get_item-instance_method
       def get_item(table_name, key, options = {})
+        options = options.dup
         options ||= {}
+
         table = describe_table(table_name)
         range_key = options.delete(:range_key)
         consistent_read = options.delete(:consistent_read)
@@ -449,6 +451,8 @@ module Dynamoid
       #
       # @todo Provide support for various options http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#update_item-instance_method
       def update_item(table_name, key, options = {})
+        options = options.dup
+
         range_key = options.delete(:range_key)
         conditions = options.delete(:conditions)
         table = describe_table(table_name)

--- a/lib/dynamoid/adapter_plugin/scan.rb
+++ b/lib/dynamoid/adapter_plugin/scan.rb
@@ -74,7 +74,7 @@ module Dynamoid
         ).compact
 
         # Deal with various limits and batching
-        batch_size = options.delete(:batch_size)
+        batch_size = options[:batch_size]
         limit = [record_limit, scan_limit, batch_size].compact.min
 
         request[:limit]       = limit if limit

--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -117,7 +117,8 @@ module Dynamoid
         if items.size == ids.size || !options[:raise_error]
           items ? items.map { |i| from_database(i) } : []
         else
-          message = "Couldn't find all #{name.pluralize} with '#{hash_key}': (#{ids.join(', ')}) "
+          ids_list = range_key ? ids.map { |pk, sk| "(#{pk},#{sk})" } : ids.map(&:to_s)
+          message = "Couldn't find all #{name.pluralize} with primary keys [#{ids_list.join(', ')}] "
           message += "(found #{items.size} results, but was looking for #{ids.size})"
           raise Errors::RecordNotFound, message
         end
@@ -131,11 +132,11 @@ module Dynamoid
 
           options[:range_key] = key_dumped
         end
-
         if item = Dynamoid.adapter.read(table_name, id, options)
           from_database(item)
         elsif options[:raise_error]
-          message = "Couldn't find #{name} with '#{hash_key}'=#{id}"
+          primary_key = range_key ? "(#{id},#{options[:range_key]})" : id
+          message = "Couldn't find #{name} with primary key #{primary_key}"
           raise Errors::RecordNotFound, message
         end
       end

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -27,7 +27,7 @@ describe Dynamoid::Finders do
           klass.create_table
           expect {
             klass.find('wrong-id')
-          }.to raise_error(Dynamoid::Errors::RecordNotFound, "Couldn't find Document with 'id'=wrong-id")
+          }.to raise_error(Dynamoid::Errors::RecordNotFound, "Couldn't find Document with primary key wrong-id")
         end
       end
 
@@ -41,7 +41,7 @@ describe Dynamoid::Finders do
           klass_with_composite_key.create_table
           expect {
             klass_with_composite_key.find('wrong-id', range_key: 100500)
-          }.to raise_error(Dynamoid::Errors::RecordNotFound, "Couldn't find Document with 'id'=wrong-id")
+          }.to raise_error(Dynamoid::Errors::RecordNotFound, "Couldn't find Document with primary key (wrong-id,100500)")
         end
 
         it 'type casts a sort key value' do
@@ -111,7 +111,7 @@ describe Dynamoid::Finders do
             klass.find([obj1.id, obj2.id, 'wrong-id'])
           }.to raise_error(
             Dynamoid::Errors::RecordNotFound,
-            "Couldn't find all Documents with 'id': (#{obj1.id}, #{obj2.id}, wrong-id) " \
+            "Couldn't find all Documents with primary keys [#{obj1.id}, #{obj2.id}, wrong-id] " \
             '(found 2 results, but was looking for 3)'
           )
         end
@@ -122,7 +122,7 @@ describe Dynamoid::Finders do
             klass.find(['wrong-id'])
           }.to raise_error(
             Dynamoid::Errors::RecordNotFound,
-            "Couldn't find all Documents with 'id': (wrong-id) (found 0 results, but was looking for 1)"
+            "Couldn't find all Documents with primary keys [wrong-id] (found 0 results, but was looking for 1)"
           )
         end
 
@@ -156,7 +156,7 @@ describe Dynamoid::Finders do
             klass_with_composite_key.find([[obj.id, obj.age], ['wrong-id', 100500]])
           }.to raise_error(
             Dynamoid::Errors::RecordNotFound,
-            "Couldn't find all Documents with 'id': (#{obj.id}, 12, wrong-id, 100500) (found 1 results, but was looking for 2)")
+            "Couldn't find all Documents with primary keys [(#{obj.id},12), (wrong-id,100500)] (found 1 results, but was looking for 2)")
         end
 
         it 'raises RecordNotFound if only one primary key provided and no result found' do
@@ -165,7 +165,7 @@ describe Dynamoid::Finders do
             klass_with_composite_key.find([['wrong-id', 100500]])
           }.to raise_error(
             Dynamoid::Errors::RecordNotFound,
-            "Couldn't find all Documents with 'id': (wrong-id, 100500) (found 0 results, but was looking for 1)"
+            "Couldn't find all Documents with primary keys [(wrong-id,100500)] (found 0 results, but was looking for 1)"
           )
         end
 


### PR DESCRIPTION
Updated:
* add range key to error message for `find_by_id`
* change wording slightly for other cases

Error message when single document (with composite key) is searching: `"Couldn't find Document with primary key (wrong-id,100500)"`

Error message when multiple documents (with composite key) are searching: `"Couldn't find all Documents with primary keys [(aaa,12), (wrong-id,100500)] (found 1 results, but was looking for 2)"`