### PR TITLE
Travis CI. Fix specific bundler version installation

### DIFF
--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -6,6 +6,6 @@ source 'https://rubygems.org'
 
 gem 'nokogiri', '~> 1.6.8'
 gem 'pry-byebug', platforms: :ruby
-gem 'rails', '~> 4.2.0'
+gem 'activemodel', '~> 4.2.0'
 
 gemspec path: '../'

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -5,6 +5,6 @@
 source 'https://rubygems.org'
 
 gem 'pry-byebug', platforms: :ruby
-gem 'rails', '~> 5.0.0'
+gem 'activemodel', '~> 5.0.0'
 
 gemspec path: '../'

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -5,6 +5,6 @@
 source 'https://rubygems.org'
 
 gem 'pry-byebug', platforms: :ruby
-gem 'rails', '~> 5.1.0'
+gem 'activemodel', '~> 5.1.0'
 
 gemspec path: '../'

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -5,6 +5,6 @@
 source 'https://rubygems.org'
 
 gem 'pry-byebug', platforms: :ruby
-gem 'rails', '~> 5.2.0'
+gem 'activemodel', '~> 5.2.0'
 
 gemspec path: '../'


### PR DESCRIPTION
Specify `activemodel` instead of `rails` in specs.

There is an issue with running specs against Rails 4.2 because this version requires `bundler < 2.0`. 

Travis CI provides Ruby with preinstalled Bundler and makes it `default` gem (so you cannot uninstall it). After releasing Bundler 2 TravisCI preinstalls it and it breaks our specs.

As far as only Rails limits bundler version but not `activemodel` and Dynamoid depends on `activemodel` only lets get rid of Rails in specs