### PR TITLE
Choose the best global secondary index which consider range key

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -312,16 +312,19 @@ module Dynamoid #:nodoc:
         # Chooses the first GSI found that can be utilized for the query
         # But only do so if projects ALL attributes otherwise we won't
         # get back full data
+        result = false
         source.global_secondary_indexes.each do |_, gsi|
           next unless query.keys.map(&:to_s).include?(gsi.hash_key.to_s) && gsi.projected_attributes == :all
+          next if @range_key.present? && !query_keys.include?(gsi.range_key.to_s)
+
           @hash_key = gsi.hash_key
           @range_key = gsi.range_key
           @index_name = gsi.name
-          return true
+          result = true
         end
 
         # Could not utilize any indices so we'll have to scan
-        false
+        result
       end
 
       # Start key needs to be set up based on the index utilized

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -598,6 +598,7 @@ describe Dynamoid::Criteria::Chain do
           field :gender
 
           global_secondary_index hash_key: :city, range_key: :age, name: :cityage, projected_attributes: :all
+          global_secondary_index hash_key: :city, range_key: :gender, name: :citygender, projected_attributes: :all
           global_secondary_index hash_key: :email, range_key: :age, name: :emailage, projected_attributes: :all
         end
       end
@@ -682,6 +683,22 @@ describe Dynamoid::Criteria::Chain do
         expect(chain.hash_key).to be_nil
         expect(chain.range_key).to be_nil
         expect(chain.index_name).to be_nil
+      end
+
+      it 'chooses the best global secondary index which consider range key' do
+        chain = Dynamoid::Criteria::Chain.new(model)
+        expect(chain).to receive(:records_via_query).and_call_original
+        expect(chain.where(city: 'San Francisco', 'age.lte': 15).to_a.size).to eq(2)
+        expect(chain.hash_key).to eq(:city)
+        expect(chain.range_key).to eq(:age)
+        expect(chain.index_name).to eq(:cityage)
+
+        chain = Dynamoid::Criteria::Chain.new(model)
+        expect(chain).to receive(:records_via_query).and_call_original
+        expect(chain.where(city: 'San Francisco', gender: 'male').to_a.size).to eq(3)
+        expect(chain.hash_key).to eq(:city)
+        expect(chain.range_key).to eq(:gender)
+        expect(chain.index_name).to eq(:citygender)
       end
     end
 


### PR DESCRIPTION
I use dynamoid in my model as following:

```rb
class User
  include Dynamoid::Document

  table name: :line_users, key: :id

  field :parent_id, :string
  field :some_value, :string
  field :some_date_at, :datetime

  global_secondary_index hash_key: :parent_id, range_key: :some_value, projected_attributes: :all
  global_secondary_index hash_key: :parent_id, range_key: :some_date_at, projected_attributes: :all
end
```

So I would like to search via query like a following code:

```rb
User.where(parent_id: parent_id, 'some_date_at.lte': 1.day.ago)
```

But dynamoid chooses the first finding GSI because it is not consider range key in the GSI selection processing.

https://github.com/Dynamoid/dynamoid/blob/48d167dc06cdb6b9a223ffbc56681f9901c48066/lib/dynamoid/criteria/chain.rb#L315-L321

I modified it to consider the range key.