### PR TITLE
Adding metadata to page iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,8 +590,27 @@ Access to the native DynamoDB pages can be obtained via the `find_by_pages`
 method, which yields arrays of records.
 
 ```ruby
-Address.find_by_pages do |addresses|
+Address.find_by_pages do |addresses, metadata|
   # have an array of pages
+end
+```
+
+Each yielded pages returns metadata as the second argument, which is a hash
+including a key `:last_evaluated_key`. The value of this key can be used for
+the `start` method to fetch the next page of records.
+
+```ruby
+class UserController < ApplicationController
+  def index
+    next_page = params[:next_page_token] ? JSON.parse(Base64.decode64(params[:next_page_token])) : ''
+
+    records, metadata = User.start(next_page).find_by_pages.first
+
+    render json: {
+      records: records,
+      next_page_token: Base64.encode64(metadata[:last_evaluated_key].to_json)
+    }
+  end
 end
 ```
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -536,7 +536,8 @@ module Dynamoid
         table = describe_table(table_name)
 
         Query.new(client, table, options).call.each do |page|
-          yield page.items.map{ |row| result_item_to_hash(row) }
+          yield page.items.map { |row| result_item_to_hash(row) },
+            { last_evaluated_key: page.last_evaluated_key }
         end
       end
 
@@ -562,10 +563,12 @@ module Dynamoid
       # @todo: Provide support for various options http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#scan-instance_method
       def scan(table_name, conditions = {}, options = {})
         return enum_for(:scan, table_name, conditions, options) unless block_given?
+
         table = describe_table(table_name)
 
         Scan.new(client, table, conditions, options).call.each do |page|
-          yield page.items.map{ |row| result_item_to_hash(row) }
+          yield page.items.map { |row| result_item_to_hash(row) },
+            { last_evaluated_key: page.last_evaluated_key }
         end
       end
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -532,12 +532,15 @@ module Dynamoid
       #
       # @todo Provide support for various other options http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#query-instance_method
       def query(table_name, options = {})
-        return enum_for(:query, table_name, options) unless block_given?
-        table = describe_table(table_name)
+        Enumerator.new do |yielder|
+          table = describe_table(table_name)
 
-        Query.new(client, table, options).call.each do |page|
-          yield page.items.map { |row| result_item_to_hash(row) },
-            { last_evaluated_key: page.last_evaluated_key }
+          Query.new(client, table, options).call.each do |page|
+            yielder.yield(
+              page.items.map { |row| result_item_to_hash(row) },
+              last_evaluated_key: page.last_evaluated_key
+            )
+          end
         end
       end
 
@@ -562,13 +565,15 @@ module Dynamoid
       #
       # @todo: Provide support for various options http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#scan-instance_method
       def scan(table_name, conditions = {}, options = {})
-        return enum_for(:scan, table_name, conditions, options) unless block_given?
+        Enumerator.new do |yielder|
+          table = describe_table(table_name)
 
-        table = describe_table(table_name)
-
-        Scan.new(client, table, conditions, options).call.each do |page|
-          yield page.items.map { |row| result_item_to_hash(row) },
-            { last_evaluated_key: page.last_evaluated_key }
+          Scan.new(client, table, conditions, options).call.each do |page|
+            yielder.yield(
+              page.items.map { |row| result_item_to_hash(row) },
+              last_evaluated_key: page.last_evaluated_key
+            )
+          end
         end
       end
 

--- a/lib/dynamoid/criteria.rb
+++ b/lib/dynamoid/criteria.rb
@@ -13,12 +13,12 @@ module Dynamoid
         # see Dynamoid::Criteria::Chain.
         #
         # @since 0.2.0
-        define_method(meth) do |*args|
+        define_method(meth) do |*args, &blk|
           chain = Dynamoid::Criteria::Chain.new(self)
           if args
-            chain.send(meth, *args)
+            chain.send(meth, *args, &blk)
           else
-            chain.send(meth)
+            chain.send(meth, &blk)
           end
         end
       end

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -163,10 +163,10 @@ module Dynamoid #:nodoc:
       #
       # @since 3.1.0
       def pages_via_query
-        return enum_for(:pages_via_query) unless block_given?
-
-        Dynamoid.adapter.query(source.table_name, range_query).each do |items, metadata|
-          yield items.map { |hash| source.from_database(hash) }, metadata
+        Enumerator.new do |yielder|
+          Dynamoid.adapter.query(source.table_name, range_query).each do |items, metadata|
+            yielder.yield items.map { |hash| source.from_database(hash) }, metadata.slice(:last_evaluated_key)
+          end
         end
       end
 
@@ -176,10 +176,10 @@ module Dynamoid #:nodoc:
       #
       # @since 3.1.0
       def pages_via_scan
-        return enum_for(:pages_via_scan) unless block_given?
-
-        Dynamoid.adapter.scan(source.table_name, scan_query, scan_opts).each do |items, metadata|
-          yield items.map { |hash| source.from_database(hash) }, metadata
+        Enumerator.new do |yielder|
+          Dynamoid.adapter.scan(source.table_name, scan_query, scan_opts).each do |items, metadata|
+            yielder.yield(items.map { |hash| source.from_database(hash) }, metadata.slice(:last_evaluated_key))
+          end
         end
       end
 

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -165,8 +165,8 @@ module Dynamoid #:nodoc:
       def pages_via_query
         return enum_for(:pages_via_query) unless block_given?
 
-        Dynamoid.adapter.query(source.table_name, range_query).each do |items|
-          yield items.map { |hash| source.from_database(hash) }
+        Dynamoid.adapter.query(source.table_name, range_query).each do |items, metadata|
+          yield items.map { |hash| source.from_database(hash) }, metadata
         end
       end
 
@@ -178,8 +178,8 @@ module Dynamoid #:nodoc:
       def pages_via_scan
         return enum_for(:pages_via_scan) unless block_given?
 
-        Dynamoid.adapter.scan(source.table_name, scan_query, scan_opts).each do |items|
-          yield items.map { |hash| source.from_database(hash) }
+        Dynamoid.adapter.scan(source.table_name, scan_query, scan_opts).each do |items, metadata|
+          yield items.map { |hash| source.from_database(hash) }, metadata
         end
       end
 

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -936,6 +936,36 @@ describe Dynamoid::Criteria::Chain do
     end
   end
 
+  describe '#find_by_pages' do
+    let(:model) do
+      new_class do
+        self.range_key = :range
+        field :city
+        field :age, :number
+        field :range, :number
+        field :data
+      end
+    end
+
+    before do
+      120.times do |i|
+        model.create(
+          id: '1',
+          range: i.to_f,
+          age: i.to_f,
+          data: 'A' * 1024 * 16
+        )
+      end
+    end
+
+    it 'yields one page at a time' do
+      expect { |b| model.where(id: '1').find_by_pages(&b) }.to yield_successive_args(
+        [all(be_kind_of(model)), {last_evaluated_key: an_instance_of(Hash)}],
+        [all(be_kind_of(model)), {last_evaluated_key: nil}],
+      )
+    end
+  end
+
   describe '#start' do
     let(:model) do
       new_class(partition_key: :name) do

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -131,7 +131,7 @@ describe Dynamoid::Criteria::Chain do
       customer2 = model.create(name: 'Bob', age: 30)
 
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:pages_via_query).twice.and_call_original
+      expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', age: 10).all).to contain_exactly(customer1)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to eq(:age)
@@ -208,7 +208,7 @@ describe Dynamoid::Criteria::Chain do
       customer2 = model.create(name: 'a', last_name: 'b', age: 30)
 
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:pages_via_query).twice.and_call_original
+      expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'a', age: 10).all).to contain_exactly(customer1)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to be_nil
@@ -225,7 +225,7 @@ describe Dynamoid::Criteria::Chain do
       document2 = klass.create(id: '1', last_name: 'b', set: [3, 4].to_set)
 
       chain = Dynamoid::Criteria::Chain.new(klass)
-      expect(chain).to receive(:pages_via_query).twice.and_call_original
+      expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(id: '1', set: [1, 2].to_set).all).to contain_exactly(document1)
     end
 
@@ -239,7 +239,7 @@ describe Dynamoid::Criteria::Chain do
       document2 = klass.create(id: '1', last_name: 'b', array: [3, 4])
 
       chain = Dynamoid::Criteria::Chain.new(klass)
-      expect(chain).to receive(:pages_via_query).twice.and_call_original
+      expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(id: '1', array: [1, 2]).all).to contain_exactly(document1)
     end
 
@@ -356,7 +356,7 @@ describe Dynamoid::Criteria::Chain do
       customer2 = model.create(age: 30)
 
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:pages_via_scan).twice.and_call_original
+      expect(chain).to receive(:pages_via_scan).and_call_original
       expect(chain.where(age: 10).all).to contain_exactly(customer1)
       expect(chain.hash_key).to be_nil
       expect(chain.range_key).to be_nil
@@ -532,7 +532,7 @@ describe Dynamoid::Criteria::Chain do
 
     it 'supports query on local secondary index but always defaults to table range key' do
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:pages_via_query).twice.and_call_original
+      expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', 'range.lt': 3, 'range2.gt': 15).to_a.size).to eq(1)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to eq(:range)
@@ -541,14 +541,14 @@ describe Dynamoid::Criteria::Chain do
 
     it 'supports query on local secondary index' do
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:pages_via_query).twice.and_call_original
+      expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', 'range2.gt': 15).to_a.size).to eq(2)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to eq(:range2)
       expect(chain.index_name).to eq(:range2index)
 
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:pages_via_query).twice.and_call_original
+      expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', 'range3.lt': 200).to_a.size).to eq(1)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to eq(:range3)
@@ -557,14 +557,14 @@ describe Dynamoid::Criteria::Chain do
 
     it 'supports query on local secondary index with start' do
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:pages_via_query).twice.and_call_original
+      expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', 'range2.gt': 15).to_a.size).to eq(2)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to eq(:range2)
       expect(chain.index_name).to eq(:range2index)
 
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:pages_via_query).twice.and_call_original
+      expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', 'range2.gt': 15).start(@customer2).all).to contain_exactly(@customer3)
       expect(chain.hash_key).to eq(:name)
       expect(chain.range_key).to eq(:range2)
@@ -588,7 +588,7 @@ describe Dynamoid::Criteria::Chain do
       customer2 = model.create(name: 'Jeff', city: 'San Francisco', age: 15, gender: 'male', customerid: 2)
 
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:pages_via_scan).twice.and_call_original
+      expect(chain).to receive(:pages_via_scan).and_call_original
       expect(chain.where(city: 'San Francisco').to_a.size).to eq(2)
       # Does not use GSI since not projecting all attributes
       expect(chain.hash_key).to be_nil
@@ -625,7 +625,7 @@ describe Dynamoid::Criteria::Chain do
 
       it 'supports query on global secondary index but always defaults to table hash key' do
         chain = Dynamoid::Criteria::Chain.new(model)
-        expect(chain).to receive(:pages_via_query).twice.and_call_original
+        expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(name: 'Bob').to_a.size).to eq(1)
         expect(chain.hash_key).to eq(:name)
         expect(chain.range_key).to be_nil
@@ -634,28 +634,28 @@ describe Dynamoid::Criteria::Chain do
 
       it 'supports query on global secondary index' do
         chain = Dynamoid::Criteria::Chain.new(model)
-        expect(chain).to receive(:pages_via_query).twice.and_call_original
+        expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(city: 'San Francisco').to_a.size).to eq(3)
         expect(chain.hash_key).to eq(:city)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:cityage)
 
         chain = Dynamoid::Criteria::Chain.new(model)
-        expect(chain).to receive(:pages_via_query).twice.and_call_original
+        expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(city: 'San Francisco', 'age.gt': 12).to_a.size).to eq(2)
         expect(chain.hash_key).to eq(:city)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:cityage)
 
         chain = Dynamoid::Criteria::Chain.new(model)
-        expect(chain).to receive(:pages_via_query).twice.and_call_original
+        expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(email: 'greg@test.com').to_a.size).to eq(1)
         expect(chain.hash_key).to eq(:email)
         expect(chain.range_key).to eq(:age)
         expect(chain.index_name).to eq(:emailage)
 
         chain = Dynamoid::Criteria::Chain.new(model)
-        expect(chain).to receive(:pages_via_query).twice.and_call_original
+        expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(email: 'greg@test.com', 'age.gt': 12).to_a.size).to eq(1)
         expect(chain.hash_key).to eq(:email)
         expect(chain.range_key).to eq(:age)
@@ -664,7 +664,7 @@ describe Dynamoid::Criteria::Chain do
 
       it 'supports scan when no global secondary index available' do
         chain = Dynamoid::Criteria::Chain.new(model)
-        expect(chain).to receive(:pages_via_scan).twice.and_call_original
+        expect(chain).to receive(:pages_via_scan).and_call_original
         expect(chain.where(gender: 'male').to_a.size).to eq(4)
         expect(chain.hash_key).to be_nil
         expect(chain.range_key).to be_nil
@@ -673,7 +673,7 @@ describe Dynamoid::Criteria::Chain do
 
       it 'supports query on global secondary index with start' do
         chain = Dynamoid::Criteria::Chain.new(model)
-        expect(chain).to receive(:pages_via_query).twice.and_call_original
+        expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(city: 'San Francisco').to_a.size).to eq(3)
         expect(chain.hash_key).to eq(:city)
         expect(chain.range_key).to eq(:age)
@@ -681,13 +681,13 @@ describe Dynamoid::Criteria::Chain do
 
         # Now query with start at customer2 and we should only see customer3
         chain = Dynamoid::Criteria::Chain.new(model)
-        expect(chain).to receive(:pages_via_query).twice.and_call_original
+        expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(city: 'San Francisco').start(@customer2).all).to contain_exactly(@customer3)
       end
 
       it "does not use index if a condition for index hash key is other than 'equal'" do
         chain = Dynamoid::Criteria::Chain.new(model)
-        expect(chain).to receive(:pages_via_scan).twice.and_call_original
+        expect(chain).to receive(:pages_via_scan).and_call_original
         expect(chain.where('city.begins_with': 'San').to_a.size).to eq(3)
         expect(chain.hash_key).to be_nil
         expect(chain.range_key).to be_nil
@@ -723,7 +723,7 @@ describe Dynamoid::Criteria::Chain do
       customer2 = model.create(name: 'Jeff', city: 'San Francisco', age: 15)
 
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:pages_via_query).twice.and_call_original
+      expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(city: 'San Francisco').start(customer1).all).to contain_exactly(customer2)
     end
   end
@@ -1028,7 +1028,7 @@ describe Dynamoid::Criteria::Chain do
       it 'return query result from the specified item' do
         chain = Dynamoid::Criteria::Chain.new(model)
 
-        expect(chain).to receive(:pages_via_query).twice.and_call_original
+        expect(chain).to receive(:pages_via_query).and_call_original
         customers = chain.where(version: 'v1', 'age.gt': 10).start(@customer2).all.to_a
 
         expect(customers).to contain_exactly(@customer3, @customer4)
@@ -1037,7 +1037,7 @@ describe Dynamoid::Criteria::Chain do
       it 'return scan result from the specified item' do
         chain = Dynamoid::Criteria::Chain.new(model)
 
-        expect(chain).to receive(:pages_via_scan).twice.and_call_original
+        expect(chain).to receive(:pages_via_scan).and_call_original
         customers = chain.where(gender: 'male').start(@customer1).all.to_a
 
         expect(customers).to contain_exactly(@customer3)
@@ -1061,7 +1061,7 @@ describe Dynamoid::Criteria::Chain do
       it 'return scan result from the specified item' do
         chain = Dynamoid::Criteria::Chain.new(model)
 
-        expect(chain).to receive(:pages_via_scan).twice.and_call_original
+        expect(chain).to receive(:pages_via_scan).and_call_original
         customers = chain.where('age.gt': 10).start(@customer2).all.to_a
 
         expect(customers).to contain_exactly(@customer3, @customer4)

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -50,6 +50,16 @@ describe Dynamoid::Criteria do
     )
   end
 
+  it 'returns a last_evaluated_key which may be used to restart iteration' do
+    # Creates exactly 2 full pages
+    58.times { User.create(name: SecureRandom.uuid * 1024) }
+
+    first_page, first_page_meta = User.find_by_pages.first
+    second_page, = User.start(first_page_meta[:last_evaluated_key]).find_by_pages.first
+
+    expect(first_page & second_page).to be_empty
+  end
+
   it 'returns N records' do
     5.times { |i| User.create(name: 'Josh', email: "josh_#{i}@joshsymonds.com") }
     expect(User.record_limit(2).all.count).to eq(2)

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -38,14 +38,16 @@ describe Dynamoid::Criteria do
   end
 
   it 'passes each to all members' do
-    User.each do |u|
-      expect(u.id == user1.id || u.id == user2.id).to be_truthy
-      expect(u.new_record).to be_falsey
-    end
+    expect { |b| User.each(&b)}.to yield_successive_args(
+      be_kind_of(User).and(have_attributes('new_record' => false)),
+      be_kind_of(User).and(have_attributes('new_record' => false))
+    )
   end
 
   it 'passes find_by_pages to all members' do
-    expect(User.find_by_pages).to match([contain_exactly(user1, user2)])
+    expect {|b| User.find_by_pages(&b)}.to yield_successive_args(
+      [all(be_kind_of(User)), {last_evaluated_key: nil}],
+    )
   end
 
   it 'returns N records' do


### PR DESCRIPTION
Adds the metadata for each pages as a second parameter `find_by_pages`.

While I was testing I also found a bug with all of the criteria delegation such as `Model.each`, and the `Model.find_by_pages` method I added. The specs didn't catch it with mine because `match_array` coerces it to an array. The test for criteria `.each` method had a false positive because no `expect` was ever called.