### PR TITLE
Make Dynamoid::Tasks::Database a Rake::TaskLib object.

### DIFF
--- a/lib/dynamoid/tasks/database.rake
+++ b/lib/dynamoid/tasks/database.rake
@@ -1,41 +1,4 @@
 # frozen_string_literal: true
 
-require 'dynamoid'
 require 'dynamoid/tasks/database'
-
-namespace :dynamoid do
-  desc 'Creates DynamoDB tables, one for each of your Dynamoid models - does not modify pre-existing tables'
-  task create_tables: :environment do
-    # Load models so Dynamoid will be able to discover tables expected.
-    Dir[File.join(Dynamoid::Config.models_dir, '**/*.rb')].sort.each { |file| require file }
-    if Dynamoid.included_models.any?
-      tables = Dynamoid::Tasks::Database.create_tables
-      result = tables[:created].map { |c| "#{c} created" } + tables[:existing].map { |e| "#{e} already exists" }
-      result.sort.each { |r| puts r }
-    else
-      puts 'Dynamoid models are not loaded, or you have no Dynamoid models.'
-    end
-  end
-
-  desc 'Tests if the DynamoDB instance can be contacted using your configuration'
-  task ping: :environment do
-    success = false
-    failure_reason = nil
-
-    begin
-      Dynamoid::Tasks::Database.ping
-      success = true
-    rescue StandardError => e
-      failure_reason = e.message
-    end
-
-    msg = "Connection to DynamoDB #{success ? 'OK' : 'FAILED'}"
-    msg << if Dynamoid.config.endpoint
-             " at local endpoint '#{Dynamoid.config.endpoint}'"
-           else
-             ' at remote AWS endpoint'
-           end
-    msg << ", reason being '#{failure_reason}'" unless success
-    puts msg
-  end
-end
+Dynamoid::Tasks::Database.new

--- a/lib/dynamoid/tasks/database.rb
+++ b/lib/dynamoid/tasks/database.rb
@@ -1,9 +1,56 @@
 # frozen_string_literal: true
 
+require 'dynamoid'
+require 'rake/tasklib'
+
 module Dynamoid
   module Tasks
-    module Database
-      module_function
+    class Database < Rake::TaskLib
+
+      # Initializes the database rake tasks.
+      def initialize
+        define
+      end
+
+      # Defines the database rake tasks.
+      def define
+        namespace :dynamoid do
+          desc 'Creates DynamoDB tables, one for each of your Dynamoid models - does not modify pre-existing tables'
+          task create_tables: :environment do
+            # Load models so Dynamoid will be able to discover tables expected.
+            Dir[File.join(Dynamoid::Config.models_dir, '**/*.rb')].sort.each { |file| require file }
+            if Dynamoid.included_models.any?
+              tables = create_tables
+              result = tables[:created].map { |c| "#{c} created" } + tables[:existing].map { |e| "#{e} already exists" }
+              result.sort.each { |r| puts r }
+            else
+              puts 'Dynamoid models are not loaded, or you have no Dynamoid models.'
+            end
+          end
+
+          desc 'Tests if the DynamoDB instance can be contacted using your configuration'
+          task ping: :environment do
+            success = false
+            failure_reason = nil
+
+            begin
+              ping
+              success = true
+            rescue StandardError => e
+              failure_reason = e.message
+            end
+
+            msg = "Connection to DynamoDB #{success ? 'OK' : 'FAILED'}"
+            msg << if Dynamoid.config.endpoint
+                     " at local endpoint '#{Dynamoid.config.endpoint}'"
+            else
+              ' at remote AWS endpoint'
+            end
+            msg << ", reason being '#{failure_reason}'" unless success
+            puts msg
+          end
+        end
+      end
 
       # Create any new tables for the models. Existing tables are not
       # modified.

--- a/spec/dynamoid/tasks/database_spec.rb
+++ b/spec/dynamoid/tasks/database_spec.rb
@@ -6,7 +6,7 @@ describe Dynamoid::Tasks::Database do
   describe '#ping' do
     context 'when the database is reachable' do
       it 'should be able to ping (connect to) DynamoDB' do
-        expect { Dynamoid::Tasks::Database.ping }.not_to raise_exception
+        expect { subject.ping }.not_to raise_exception
       end
     end
   end
@@ -19,14 +19,14 @@ describe Dynamoid::Tasks::Database do
     context "when the tables don't exist yet" do
       it 'should create tables' do
         expect {
-          Dynamoid::Tasks::Database.create_tables
+          subject.create_tables
         }.to change {
           Dynamoid.adapter.list_tables.include?(@klass.table_name)
         }.from(false).to(true)
       end
 
       it 'returns created table names' do
-        results = Dynamoid::Tasks::Database.create_tables
+        results = subject.create_tables
         expect(results[:existing]).not_to include(@klass.table_name)
         expect(results[:created]).to include(@klass.table_name)
       end
@@ -36,7 +36,7 @@ describe Dynamoid::Tasks::Database do
       it 'should not attempt to re-create the table' do
         @klass.create_table
 
-        results = Dynamoid::Tasks::Database.create_tables
+        results = subject.create_tables
         expect(results[:existing]).to include(@klass.table_name)
         expect(results[:created]).not_to include(@klass.table_name)
       end


### PR DESCRIPTION
* This allows non-Rails users to require `dynamoid/tasks/database` and
  manually initializing the rake task via `Dynamoid::Tasks::Database.new`.
* This also allows for the rake task to become configurable via it's `#initialize` method.