### PR TITLE
Technically {**/}*.rb is more correct/flexible.

### DIFF
--- a/lib/dynamoid/tasks/database.rake
+++ b/lib/dynamoid/tasks/database.rake
@@ -7,7 +7,7 @@ namespace :dynamoid do
   desc 'Creates DynamoDB tables, one for each of your Dynamoid models - does not modify pre-existing tables'
   task create_tables: :environment do
     # Load models so Dynamoid will be able to discover tables expected.
-    Dir[File.join(Dynamoid::Config.models_dir, '**/*.rb')].sort.each { |file| require file }
+    Dir[File.join(Dynamoid::Config.models_dir, '{**/}*.rb')].sort.each { |file| require file }
     if Dynamoid.included_models.any?
       tables = Dynamoid::Tasks::Database.create_tables
       result = tables[:created].map { |c| "#{c} created" } + tables[:existing].map { |e| "#{e} already exists" }


### PR DESCRIPTION
Require models within the models directory, and any sub-directories.