### PR TITLE
Use the `{,**/}*.rb` dir glob which is technically more correct.

### DIFF
--- a/lib/dynamoid/tasks/database.rake
+++ b/lib/dynamoid/tasks/database.rake
@@ -7,7 +7,7 @@ namespace :dynamoid do
   desc 'Creates DynamoDB tables, one for each of your Dynamoid models - does not modify pre-existing tables'
   task create_tables: :environment do
     # Load models so Dynamoid will be able to discover tables expected.
-    Dir[File.join(Dynamoid::Config.models_dir, '**/*.rb')].sort.each { |file| require file }
+    Dir[File.join(Dynamoid::Config.models_dir, '{,**/}*.rb')].sort.each { |file| require file }
     if Dynamoid.included_models.any?
       tables = Dynamoid::Tasks::Database.create_tables
       result = tables[:created].map { |c| "#{c} created" } + tables[:existing].map { |e| "#{e} already exists" }


### PR DESCRIPTION
Technically, `**/*.rb` will match any `.rb` file in the directory, as well as any sub-directories. However, `{,**/}*.rb` is more explicit, as the `{,b}` pattern expands to "nothing OR `b`".
