### PR TITLE
Add warnings about nonexistent fields in 'where' conditions

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -42,7 +42,7 @@ module Dynamoid #:nodoc:
       #
       # @since 0.2.0
       def where(args)
-        query.update(args.dup.symbolize_keys)
+        query.update(args.symbolize_keys)
 
         nonexistent_fields = NonexistentFieldsDetector.new(args, @source).fields
 

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'keys_detector'
+require_relative 'key_fields_detector'
 require_relative 'nonexistent_fields_detector'
 
 module Dynamoid #:nodoc:
@@ -8,7 +8,7 @@ module Dynamoid #:nodoc:
     # The criteria chain is equivalent to an ActiveRecord relation (and realistically I should change the name from
     # chain to relation). It is a chainable object that builds up a query and eventually executes it by a Query or Scan.
     class Chain
-      attr_reader :query, :source, :consistent_read, :keys_detector
+      attr_reader :query, :source, :consistent_read, :key_fields_detector
 
       include Enumerable
       # Create a new criteria chain.
@@ -27,7 +27,7 @@ module Dynamoid #:nodoc:
         end
 
         # we should re-initialize keys detector every time we change query
-        @keys_detector = KeysDetector.new(@query, @source)
+        @key_fields_detector = KeyFieldsDetector.new(@query, @source)
       end
 
       # The workhorse method of the criteria chain. Each key in the passed in hash will become another criteria that the
@@ -57,7 +57,7 @@ module Dynamoid #:nodoc:
         end
 
         # we should re-initialize keys detector every time we change query
-        @keys_detector = KeysDetector.new(@query, @source)
+        @key_fields_detector = KeyFieldsDetector.new(@query, @source)
 
         self
       end
@@ -75,7 +75,7 @@ module Dynamoid #:nodoc:
       end
 
       def count
-        if @keys_detector.key_present?
+        if @key_fields_detector.key_present?
           count_via_query
         else
           count_via_scan
@@ -96,7 +96,7 @@ module Dynamoid #:nodoc:
         ids = []
         ranges = []
 
-        if @keys_detector.key_present?
+        if @key_fields_detector.key_present?
           Dynamoid.adapter.query(source.table_name, range_query).flat_map{ |i| i }.collect do |hash|
             ids << hash[source.hash_key.to_sym]
             ranges << hash[source.range_key.to_sym] if source.range_key
@@ -171,7 +171,7 @@ module Dynamoid #:nodoc:
       #
       # @since 3.1.0
       def pages
-        if @keys_detector.key_present?
+        if @key_fields_detector.key_present?
           pages_via_query
         else
           issue_scan_warning if Dynamoid::Config.warn_on_scan && query.present?
@@ -279,24 +279,24 @@ module Dynamoid #:nodoc:
         opts = {}
 
         # Add hash key
-        opts[:hash_key] = @keys_detector.hash_key
-        opts[:hash_value] = type_cast_condition_parameter(@keys_detector.hash_key, query[@keys_detector.hash_key])
+        opts[:hash_key] = @key_fields_detector.hash_key
+        opts[:hash_value] = type_cast_condition_parameter(@key_fields_detector.hash_key, query[@key_fields_detector.hash_key])
 
         # Add range key
-        if @keys_detector.range_key
-          opts[:range_key] = @keys_detector.range_key
-          if query[@keys_detector.range_key].present?
-            value = type_cast_condition_parameter(@keys_detector.range_key, query[@keys_detector.range_key])
+        if @key_fields_detector.range_key
+          opts[:range_key] = @key_fields_detector.range_key
+          if query[@key_fields_detector.range_key].present?
+            value = type_cast_condition_parameter(@key_fields_detector.range_key, query[@key_fields_detector.range_key])
             opts.update(range_eq: value)
           end
 
-          query.keys.select { |k| k.to_s =~ /^#{@keys_detector.range_key}\./ }.each do |key|
+          query.keys.select { |k| k.to_s =~ /^#{@key_fields_detector.range_key}\./ }.each do |key|
             opts.merge!(range_hash(key))
           end
         end
 
-        (query.keys.map(&:to_sym) - [@keys_detector.hash_key.to_sym, @keys_detector.range_key.try(:to_sym)])
-          .reject { |k, _| k.to_s =~ /^#{@keys_detector.range_key}\./ }
+        (query.keys.map(&:to_sym) - [@key_fields_detector.hash_key.to_sym, @key_fields_detector.range_key.try(:to_sym)])
+          .reject { |k, _| k.to_s =~ /^#{@key_fields_detector.range_key}\./ }
           .each do |key|
           if key.to_s.include?('.')
             opts.update(field_hash(key))
@@ -331,8 +331,8 @@ module Dynamoid #:nodoc:
       def start_key
         return @start if @start.is_a?(Hash)
 
-        hash_key = @keys_detector.hash_key || source.hash_key
-        range_key = @keys_detector.range_key || source.range_key
+        hash_key = @key_fields_detector.hash_key || source.hash_key
+        range_key = @key_fields_detector.range_key || source.range_key
 
         key = {}
         key[hash_key] = type_cast_condition_parameter(hash_key, @start.send(hash_key))
@@ -351,7 +351,7 @@ module Dynamoid #:nodoc:
 
       def query_opts
         opts = {}
-        opts[:index_name] = @keys_detector.index_name if @keys_detector.index_name
+        opts[:index_name] = @key_fields_detector.index_name if @key_fields_detector.index_name
         opts[:select] = 'ALL_ATTRIBUTES'
         opts[:record_limit] = @record_limit if @record_limit
         opts[:scan_limit] = @scan_limit if @scan_limit

--- a/lib/dynamoid/criteria/key_fields_detector.rb
+++ b/lib/dynamoid/criteria/key_fields_detector.rb
@@ -2,7 +2,7 @@
 
 module Dynamoid #:nodoc:
   module Criteria
-    class KeysDetector
+    class KeyFieldsDetector
       attr_reader :hash_key, :range_key, :index_name
 
       def initialize(query, source)

--- a/lib/dynamoid/criteria/nonexistent_fields_detector.rb
+++ b/lib/dynamoid/criteria/nonexistent_fields_detector.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module Criteria
+    class NonexistentFieldsDetector
+      def initialize(conditions, source)
+        @conditions = conditions
+        @source = source
+      end
+
+      def fields
+        fields_from_conditions - fields_existent
+      end
+
+      private
+
+      def fields_from_conditions
+        @conditions.keys.map do |s|
+          name, _ = s.to_s.split('.')
+          name
+        end.map(&:to_sym)
+      end
+
+      def fields_existent
+        @source.attributes.keys.map(&:to_sym)
+      end
+    end
+  end
+end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -937,6 +937,41 @@ describe Dynamoid::Criteria::Chain do
     end
   end
 
+  describe '#where' do
+    context 'passed condition for nonexistent attribute' do
+      let(:model) do
+        new_class do
+          field :city
+        end
+      end
+
+      before do
+        model.create_table
+      end
+
+      it 'writes warning message' do
+        expect(Dynamoid.logger).to receive(:warn)
+          .with('where conditions contain nonexistent field name `town`')
+
+        model.where(town: 'New York')
+      end
+
+      it 'writes warning message for condition with operator' do
+        expect(Dynamoid.logger).to receive(:warn)
+          .with('where conditions contain nonexistent field name `town`')
+
+        model.where('town.contain': 'New York')
+      end
+
+      it 'writes warning message with a list of attributes' do
+        expect(Dynamoid.logger).to receive(:warn)
+          .with('where conditions contain nonexistent field names `town`, `street1`')
+
+        model.where(town: 'New York', street1: 'Allen Street')
+      end
+    end
+  end
+
   describe '#find_by_pages' do
     let(:model) do
       new_class do

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -134,9 +134,9 @@ describe Dynamoid::Criteria::Chain do
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', age: 10).all).to contain_exactly(customer1)
-      expect(chain.keys_detector.hash_key).to eq(:name)
-      expect(chain.keys_detector.range_key).to eq(:age)
-      expect(chain.keys_detector.index_name).to be_nil
+      expect(chain.key_fields_detector.hash_key).to eq(:name)
+      expect(chain.key_fields_detector.range_key).to eq(:age)
+      expect(chain.key_fields_detector.index_name).to be_nil
     end
 
     it 'supports lt' do
@@ -211,9 +211,9 @@ describe Dynamoid::Criteria::Chain do
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'a', age: 10).all).to contain_exactly(customer1)
-      expect(chain.keys_detector.hash_key).to eq(:name)
-      expect(chain.keys_detector.range_key).to be_nil
-      expect(chain.keys_detector.index_name).to be_nil
+      expect(chain.key_fields_detector.hash_key).to eq(:name)
+      expect(chain.key_fields_detector.range_key).to be_nil
+      expect(chain.key_fields_detector.index_name).to be_nil
     end
 
     it 'supports eq for set' do
@@ -359,9 +359,9 @@ describe Dynamoid::Criteria::Chain do
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:pages_via_scan).and_call_original
       expect(chain.where(age: 10).all).to contain_exactly(customer1)
-      expect(chain.keys_detector.hash_key).to be_nil
-      expect(chain.keys_detector.range_key).to be_nil
-      expect(chain.keys_detector.index_name).to be_nil
+      expect(chain.key_fields_detector.hash_key).to be_nil
+      expect(chain.key_fields_detector.range_key).to be_nil
+      expect(chain.key_fields_detector.index_name).to be_nil
     end
 
     it 'supports eq for set' do
@@ -535,41 +535,41 @@ describe Dynamoid::Criteria::Chain do
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', 'range.lt': 3, 'range2.gt': 15).to_a.size).to eq(1)
-      expect(chain.keys_detector.hash_key).to eq(:name)
-      expect(chain.keys_detector.range_key).to eq(:range)
-      expect(chain.keys_detector.index_name).to be_nil
+      expect(chain.key_fields_detector.hash_key).to eq(:name)
+      expect(chain.key_fields_detector.range_key).to eq(:range)
+      expect(chain.key_fields_detector.index_name).to be_nil
     end
 
     it 'supports query on local secondary index' do
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', 'range2.gt': 15).to_a.size).to eq(2)
-      expect(chain.keys_detector.hash_key).to eq(:name)
-      expect(chain.keys_detector.range_key).to eq(:range2)
-      expect(chain.keys_detector.index_name).to eq(:range2index)
+      expect(chain.key_fields_detector.hash_key).to eq(:name)
+      expect(chain.key_fields_detector.range_key).to eq(:range2)
+      expect(chain.key_fields_detector.index_name).to eq(:range2index)
 
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', 'range3.lt': 200).to_a.size).to eq(1)
-      expect(chain.keys_detector.hash_key).to eq(:name)
-      expect(chain.keys_detector.range_key).to eq(:range3)
-      expect(chain.keys_detector.index_name).to eq(:range3index)
+      expect(chain.key_fields_detector.hash_key).to eq(:name)
+      expect(chain.key_fields_detector.range_key).to eq(:range3)
+      expect(chain.key_fields_detector.index_name).to eq(:range3index)
     end
 
     it 'supports query on local secondary index with start' do
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', 'range2.gt': 15).to_a.size).to eq(2)
-      expect(chain.keys_detector.hash_key).to eq(:name)
-      expect(chain.keys_detector.range_key).to eq(:range2)
-      expect(chain.keys_detector.index_name).to eq(:range2index)
+      expect(chain.key_fields_detector.hash_key).to eq(:name)
+      expect(chain.key_fields_detector.range_key).to eq(:range2)
+      expect(chain.key_fields_detector.index_name).to eq(:range2index)
 
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:pages_via_query).and_call_original
       expect(chain.where(name: 'Bob', 'range2.gt': 15).start(@customer2).all).to contain_exactly(@customer3)
-      expect(chain.keys_detector.hash_key).to eq(:name)
-      expect(chain.keys_detector.range_key).to eq(:range2)
-      expect(chain.keys_detector.index_name).to eq(:range2index)
+      expect(chain.key_fields_detector.hash_key).to eq(:name)
+      expect(chain.key_fields_detector.range_key).to eq(:range2)
+      expect(chain.key_fields_detector.index_name).to eq(:range2index)
     end
   end
 
@@ -592,9 +592,9 @@ describe Dynamoid::Criteria::Chain do
       expect(chain).to receive(:pages_via_scan).and_call_original
       expect(chain.where(city: 'San Francisco').to_a.size).to eq(2)
       # Does not use GSI since not projecting all attributes
-      expect(chain.keys_detector.hash_key).to be_nil
-      expect(chain.keys_detector.range_key).to be_nil
-      expect(chain.keys_detector.index_name).to be_nil
+      expect(chain.key_fields_detector.hash_key).to be_nil
+      expect(chain.key_fields_detector.range_key).to be_nil
+      expect(chain.key_fields_detector.index_name).to be_nil
     end
 
     context 'with full composite key for table' do
@@ -628,57 +628,57 @@ describe Dynamoid::Criteria::Chain do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(name: 'Bob').to_a.size).to eq(1)
-        expect(chain.keys_detector.hash_key).to eq(:name)
-        expect(chain.keys_detector.range_key).to be_nil
-        expect(chain.keys_detector.index_name).to be_nil
+        expect(chain.key_fields_detector.hash_key).to eq(:name)
+        expect(chain.key_fields_detector.range_key).to be_nil
+        expect(chain.key_fields_detector.index_name).to be_nil
       end
 
       it 'supports query on global secondary index' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(city: 'San Francisco').to_a.size).to eq(3)
-        expect(chain.keys_detector.hash_key).to eq(:city)
-        expect(chain.keys_detector.range_key).to eq(:age)
-        expect(chain.keys_detector.index_name).to eq(:cityage)
+        expect(chain.key_fields_detector.hash_key).to eq(:city)
+        expect(chain.key_fields_detector.range_key).to eq(:age)
+        expect(chain.key_fields_detector.index_name).to eq(:cityage)
 
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(city: 'San Francisco', 'age.gt': 12).to_a.size).to eq(2)
-        expect(chain.keys_detector.hash_key).to eq(:city)
-        expect(chain.keys_detector.range_key).to eq(:age)
-        expect(chain.keys_detector.index_name).to eq(:cityage)
+        expect(chain.key_fields_detector.hash_key).to eq(:city)
+        expect(chain.key_fields_detector.range_key).to eq(:age)
+        expect(chain.key_fields_detector.index_name).to eq(:cityage)
 
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(email: 'greg@test.com').to_a.size).to eq(1)
-        expect(chain.keys_detector.hash_key).to eq(:email)
-        expect(chain.keys_detector.range_key).to eq(:age)
-        expect(chain.keys_detector.index_name).to eq(:emailage)
+        expect(chain.key_fields_detector.hash_key).to eq(:email)
+        expect(chain.key_fields_detector.range_key).to eq(:age)
+        expect(chain.key_fields_detector.index_name).to eq(:emailage)
 
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(email: 'greg@test.com', 'age.gt': 12).to_a.size).to eq(1)
-        expect(chain.keys_detector.hash_key).to eq(:email)
-        expect(chain.keys_detector.range_key).to eq(:age)
-        expect(chain.keys_detector.index_name).to eq(:emailage)
+        expect(chain.key_fields_detector.hash_key).to eq(:email)
+        expect(chain.key_fields_detector.range_key).to eq(:age)
+        expect(chain.key_fields_detector.index_name).to eq(:emailage)
       end
 
       it 'supports scan when no global secondary index available' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:pages_via_scan).and_call_original
         expect(chain.where(gender: 'male').to_a.size).to eq(4)
-        expect(chain.keys_detector.hash_key).to be_nil
-        expect(chain.keys_detector.range_key).to be_nil
-        expect(chain.keys_detector.index_name).to be_nil
+        expect(chain.key_fields_detector.hash_key).to be_nil
+        expect(chain.key_fields_detector.range_key).to be_nil
+        expect(chain.key_fields_detector.index_name).to be_nil
       end
 
       it 'supports query on global secondary index with start' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(city: 'San Francisco').to_a.size).to eq(3)
-        expect(chain.keys_detector.hash_key).to eq(:city)
-        expect(chain.keys_detector.range_key).to eq(:age)
-        expect(chain.keys_detector.index_name).to eq(:cityage)
+        expect(chain.key_fields_detector.hash_key).to eq(:city)
+        expect(chain.key_fields_detector.range_key).to eq(:age)
+        expect(chain.key_fields_detector.index_name).to eq(:cityage)
 
         # Now query with start at customer2 and we should only see customer3
         chain = Dynamoid::Criteria::Chain.new(model)
@@ -690,25 +690,25 @@ describe Dynamoid::Criteria::Chain do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:pages_via_scan).and_call_original
         expect(chain.where('city.begins_with': 'San').to_a.size).to eq(3)
-        expect(chain.keys_detector.hash_key).to be_nil
-        expect(chain.keys_detector.range_key).to be_nil
-        expect(chain.keys_detector.index_name).to be_nil
+        expect(chain.key_fields_detector.hash_key).to be_nil
+        expect(chain.key_fields_detector.range_key).to be_nil
+        expect(chain.key_fields_detector.index_name).to be_nil
       end
 
       it 'prefers global secondary index with range key used in conditions to index w/o such range key' do
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(city: 'San Francisco', 'age.lte': 15).to_a.size).to eq(2)
-        expect(chain.keys_detector.hash_key).to eq(:city)
-        expect(chain.keys_detector.range_key).to eq(:age)
-        expect(chain.keys_detector.index_name).to eq(:cityage)
+        expect(chain.key_fields_detector.hash_key).to eq(:city)
+        expect(chain.key_fields_detector.range_key).to eq(:age)
+        expect(chain.key_fields_detector.index_name).to eq(:cityage)
 
         chain = Dynamoid::Criteria::Chain.new(model)
         expect(chain).to receive(:pages_via_query).and_call_original
         expect(chain.where(city: 'San Francisco', gender: 'male').to_a.size).to eq(3)
-        expect(chain.keys_detector.hash_key).to eq(:city)
-        expect(chain.keys_detector.range_key).to eq(:gender)
-        expect(chain.keys_detector.index_name).to eq(:citygender)
+        expect(chain.key_fields_detector.hash_key).to eq(:city)
+        expect(chain.key_fields_detector.range_key).to eq(:gender)
+        expect(chain.key_fields_detector.index_name).to eq(:citygender)
       end
     end
 


### PR DESCRIPTION
There is a common mistake to use wrong attribute names in conditions hash. Now it will lead to warning:

```ruby
class User
  include Dynamoid::Document

  field :first_name
end

User.where(full_name: 'Alex')
#=> where conditions contain nonexistent field name `full_name`
```