### PR TITLE
Add warning about skipped conditions

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -54,15 +54,9 @@ module Dynamoid
           Dynamoid.logger.warn(detector.warning_message)
         end
 
-        nonexistent_fields = NonexistentFieldsDetector.new(args, @source).fields
-        if nonexistent_fields.present?
-          fields_list = nonexistent_fields.map { |s| "`#{s}`" }.join(', ')
-          fields_count = nonexistent_fields.size
-
-          Dynamoid.logger.warn(
-            "where conditions contain nonexistent" \
-            " field #{ 'name'.pluralize(fields_count) } #{ fields_list }"
-          )
+        detector = NonexistentFieldsDetector.new(args, @source)
+        if detector.found?
+          Dynamoid.logger.warn(detector.warning_message)
         end
 
         query.update(args.symbolize_keys)

--- a/lib/dynamoid/criteria/ignored_conditions_detector.rb
+++ b/lib/dynamoid/criteria/ignored_conditions_detector.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module Criteria
+    class IgnoredConditionsDetector
+      def initialize(conditions)
+        @conditions = conditions
+        @ignored_keys = ignored_keys
+      end
+
+      def found?
+        @ignored_keys.present?
+      end
+
+      def warning_message
+        return unless found?
+
+        'Where conditions may contain only one condition for an attribute. ' \
+          "Following conditions are ignored: #{ignored_conditions}"
+      end
+
+      private
+
+      def ignored_keys
+        @conditions.keys
+          .group_by(&method(:key_to_field))
+          .select { |field, ary| ary.size > 1 }
+          .flat_map { |field, ary| ary[0 .. -2] }
+      end
+
+      def key_to_field(key)
+        key.to_s.split('.')[0]
+      end
+
+      def ignored_conditions
+        @conditions.slice(*@ignored_keys)
+      end
+    end
+  end
+end
+

--- a/lib/dynamoid/criteria/nonexistent_fields_detector.rb
+++ b/lib/dynamoid/criteria/nonexistent_fields_detector.rb
@@ -6,19 +6,31 @@ module Dynamoid
       def initialize(conditions, source)
         @conditions = conditions
         @source = source
+        @nonexistent_fields = nonexistent_fields
       end
 
-      def fields
-        fields_from_conditions - fields_existent
+      def found?
+        @nonexistent_fields.present?
+      end
+
+      def warning_message
+        return unless found?
+
+        fields_list = @nonexistent_fields.map { |s| "`#{s}`" }.join(', ')
+        count = @nonexistent_fields.size
+
+        "where conditions contain nonexistent" \
+          " field #{ 'name'.pluralize(count) } #{ fields_list }"
       end
 
       private
 
+      def nonexistent_fields
+        fields_from_conditions - fields_existent
+      end
+
       def fields_from_conditions
-        @conditions.keys.map do |s|
-          name, _ = s.to_s.split('.')
-          name
-        end.map(&:to_sym)
+        @conditions.keys.map { |s| s.to_s.split('.')[0].to_sym }
       end
 
       def fields_existent

--- a/lib/dynamoid/criteria/overwritten_conditions_detector.rb
+++ b/lib/dynamoid/criteria/overwritten_conditions_detector.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module Criteria
+    class OverwrittenConditionsDetector
+      def initialize(conditions, conditions_new)
+        @conditions = conditions
+        @new_conditions = conditions_new
+        @overwritten_keys = overwritten_keys
+      end
+
+      def found?
+        @overwritten_keys.present?
+      end
+
+      def warning_message
+        return unless found?
+
+        'Where conditions may contain only one condition for an attribute. ' \
+          "Following conditions are ignored: #{ignored_conditions}"
+      end
+
+      private
+
+      def overwritten_keys
+        new_fields = @new_conditions.keys.map(&method(:key_to_field))
+        @conditions.keys.select { |key| key_to_field(key).in?(new_fields) }
+      end
+
+      def key_to_field(key)
+        key.to_s.split('.')[0]
+      end
+
+      def ignored_conditions
+        @conditions.slice(*@overwritten_keys.map(&:to_sym))
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
The issue - both `Query` and `Scan` operations support only one condition for an attribute. Actually they support more than one Dynamoid uses deprecated options `QueryFilter` and `ScanFilter` to specify conditions and they don't support.

So here I added warning messages when user mistakenly specifies several conditions for the one field in the `where` method and only the last condition wins - other are ignored.

Following cases are handled:
* `where('age.gt': 10, 'age.lt': 20)`
* `where('age.gt': 10).where('age.lt': 2)`

The warning message looks like: 
<pre>
Where conditions may contain only one condition for an attribute.
Following conditions are ignored: {:"age.gt"=>2}`
</pre>

