### PR TITLE
Add :map field type

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,32 @@ Dynamoid.configure do |config|
 end
 ```
 
+## Logging
+
+There is a config option `logger`. Dynamoid writes requests and
+responses to DynamoDB using this logger on the `debug` level. So in
+order to troubleshoot and debug issues just set it:
+
+```ruby
+class User
+  include Dynamoid::Document
+  field name
+end
+
+Dynamoid.config.logger.level = :debug
+Dynamoid.config.endpoint = 'localhost:8000'
+
+User.create(name: 'Alex')
+
+# => D, [2019-05-12T20:01:07.840051 #75059] DEBUG -- : put_item | Request "{\"TableName\":\"dynamoid_users\",\"Item\":{\"created_at\":{\"N\":\"1557680467.608749\"},\"updated_at\":{\"N\":\"1557680467.608809\"},\"id\":{\"S\":\"1227eea7-2c96-4b8a-90d9-77b38eb85cd0\"}},\"Expected\":{\"id\":{\"Exists\":false}}}" | Response "{}"
+
+# => D, [2019-05-12T20:01:07.842397 #75059] DEBUG -- : (231.28 ms) PUT ITEM - ["dynamoid_users", {:created_at=>0.1557680467608749e10, :updated_at=>0.1557680467608809e10, :id=>"1227eea7-2c96-4b8a-90d9-77b38eb85cd0", :User=>nil}, {}]
+```
+
+The first line is a body of HTTP request and response. The second line -
+Dynamoid internal logging of API call (`PUT ITEM` in our case) with
+timing (231.28 ms).
+
 ## Credits
 
 Dynamoid borrows code, structure, and even its name very liberally from the truly amazing [Mongoid](https://github.com/mongoid/mongoid). Without Mongoid to crib from none of this would have been possible, and I hope they don't mind me reusing their very awesome ideas to make DynamoDB just as accessible to the Ruby world as MongoDB.

--- a/README.md
+++ b/README.md
@@ -532,6 +532,18 @@ u.addresses.where(city: 'Chicago').all
 
 But keep in mind Dynamoid -- and document-based storage systems in general -- are not drop-in replacements for existing relational databases. The above query does not efficiently perform a conditional join, but instead finds all the user's addresses and naively filters them in Ruby. For large associations this is a performance hit compared to relational database engines.
 
+**WARNING:** There is a limitation of conditions passed to `where`
+method. Only one condition for some particular field could be specified.
+The last one only will be applyed and others will be ignored. E.g. in
+examples:
+
+```ruby
+User.where('age.gt': 10, 'age.lt': 20)
+User.where(name: 'Mike').where('name.begins_with': 'Ed')
+```
+
+the first one will be ignored and the last one will be used.
+
 #### Limits
 
 There are three types of limits that you can query with:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ These fields will not change an existing table: so specifying a new read_capacit
 You'll have to define all the fields on the model and the data type of each field. Every field on the object must be included here; if you miss any they'll be completely bypassed during DynamoDB's initialization and will not appear on the model objects.
 
 By default, fields are assumed to be of type `:string`. Other built-in types are
-`:integer`, `:number`, `:set`, `:array`, `:datetime`, `date`, `:boolean`, `:raw` and `:serialized`.
+`:integer`, `:number`, `:set`, `:array`, `:map`, `:datetime`, `date`, `:boolean`, `:raw` and `:serialized`.
+`array` and `map` match List and Map DynamoDB types respectively.
 `raw` type means you can store Ruby Array, Hash, String and numbers.
 If built-in types do not suit you, you can use a custom field type represented by an arbitrary class, provided that the class supports a compatible serialization interface.
 The primary use case for using a custom field type is to represent your business logic with high-level types, while ensuring portability or backward-compatibility of the serialized representation.

--- a/lib/dynamoid/type_casting.rb
+++ b/lib/dynamoid/type_casting.rb
@@ -29,6 +29,7 @@ module Dynamoid
                           when :number     then NumberTypeCaster
                           when :set        then SetTypeCaster
                           when :array      then ArrayTypeCaster
+                          when :map        then MapTypeCaster
                           when :datetime   then DateTimeTypeCaster
                           when :date       then DateTypeCaster
                           when :raw        then RawTypeCaster
@@ -200,6 +201,22 @@ module Dynamoid
           end
         else
           { type: element_type }
+        end
+      end
+    end
+
+    class MapTypeCaster < Base
+      def process(value)
+        return nil if value.nil?
+
+        if value.is_a? Hash
+          value
+        elsif value.respond_to? :to_hash
+          value.to_hash
+        elsif value.respond_to? :to_h
+          value.to_h
+        else
+          nil
         end
       end
     end

--- a/spec/dynamoid/type_casting_spec.rb
+++ b/spec/dynamoid/type_casting_spec.rb
@@ -448,6 +448,53 @@ describe 'Type casting' do
   describe 'Raw field' do
   end
 
+  describe 'Map field' do
+    let(:klass) do
+      new_class do
+        field :settings, :map
+      end
+    end
+
+    it 'accepts Hash object' do
+      obj = klass.new(settings: { foo: 21 })
+      expect(obj.settings).to eq(foo: 21)
+    end
+
+    it 'tries to convert to Hash with #to_h' do
+      settings = Object.new
+      def settings.to_h
+        { foo: 'bar' }
+      end
+
+      obj = klass.new(settings: settings)
+      expect(obj.settings).to eq(foo: 'bar')
+
+      obj = klass.new(settings: [[:foo, 'bar']])
+      expect(obj.settings).to eq(foo: 'bar')
+    end
+
+    it 'tries to convert to Hash with #to_hash' do
+      settings = Object.new
+      def settings.to_hash
+        { foo: 'bar' }
+      end
+
+      obj = klass.new(settings: settings)
+      expect(obj.settings).to eq(foo: 'bar')
+    end
+
+    it 'sets nil if fails to convert to Hash' do
+      obj = klass.new(settings: Object.new)
+      expect(obj.settings).to eq(nil)
+
+      obj = klass.new(settings: 'foo')
+      expect(obj.settings).to eq(nil)
+
+      obj = klass.new(settings: 42)
+      expect(obj.settings).to eq(nil)
+    end
+  end
+
   describe 'Integer field' do
     let(:klass) do
       new_class do


### PR DESCRIPTION
Changed:
* Added `map` type

There are already in use `array` type, that matches the List DynamoDB type, and `raw` type, that matches automatically any supported DynamoDB type (including List and Map). But there is no dedicated type for Map which forces using `raw` type in order to store Hash/JSON-like data. It may confuse users (and actually there was created issue with such request).

Example:

```ruby
class User
  include Dynamoid::Document
  field :settings, :map
end

User.create(settings: {foo: {bar: ['baz]'}})
```