### PR TITLE
Simplify using Rake tasks in non-Rails environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,8 +856,22 @@ end
 
 ## Rake Tasks
 
+There are a few Rake tasks available out of the box:
+
   * `rake dynamoid:create_tables`
   * `rake dynamoid:ping`
+
+In order to use them in non-Rails application they should be required explicitly:
+
+```ruby
+# Rakefile
+
+Rake::Task.define_task(:environment)
+require 'dynamoid/tasks'
+```
+
+The Rake tasks depend on `:environment` task so it should be declared
+as well.
 
 ## Test Environment
 

--- a/lib/dynamoid/tasks.rb
+++ b/lib/dynamoid/tasks.rb
@@ -1,0 +1,1 @@
+load "dynamoid/tasks/database.rake"

--- a/lib/dynamoid/tasks/database.rake
+++ b/lib/dynamoid/tasks/database.rake
@@ -30,12 +30,12 @@ namespace :dynamoid do
     end
 
     msg = "Connection to DynamoDB #{success ? 'OK' : 'FAILED'}"
-    msg << if Dynamoid.config.endpoint
+    msg += if Dynamoid.config.endpoint
              " at local endpoint '#{Dynamoid.config.endpoint}'"
            else
              ' at remote AWS endpoint'
            end
-    msg << ", reason being '#{failure_reason}'" unless success
+    msg += ", reason being '#{failure_reason}'" unless success
     puts msg
   end
 end


### PR DESCRIPTION
Dynamoid registers provided Rake tasks `dynamoid:create_tables` and `dynamoid:ping` in Rails application out of the box. But in order to use them in non-Rails application it needed to load them manually like

```ruby
# Rakefile

load 'dynamoid/tasks/database.rake'
```

Now it can be archived with following code:

```ruby
# Rakefile

require 'dynamoid/tasks'
```