### PR TITLE
Fix synchronous table creation issue

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -356,7 +356,7 @@ module Dynamoid
       # @since 1.0.0
       def delete_table(table_name, options = {})
         resp = client.delete_table(table_name: table_name)
-        UntilPastTableStatus.new(table_name, :deleting).call if options[:sync] &&
+        UntilPastTableStatus.new(client, table_name, :deleting).call if options[:sync] &&
                                                                 (status = PARSE_TABLE_STATUS.call(resp, :table_description)) &&
                                                                 status == TABLE_STATUSES[:deleting]
         table_cache.delete(table_name)

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/create_table.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/create_table.rb
@@ -62,7 +62,7 @@ module Dynamoid
           end
           resp = client.create_table(client_opts)
           options[:sync] = true if !options.key?(:sync) && ls_indexes.present? || gs_indexes.present?
-          UntilPastTableStatus.new(table_name, :creating).call if options[:sync] &&
+          UntilPastTableStatus.new(client, table_name, :creating).call if options[:sync] &&
                                                                   (status = PARSE_TABLE_STATUS.call(resp, :table_description)) &&
                                                                   status == TABLE_STATUSES[:creating]
           # Response to original create_table, which, if options[:sync]

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/until_past_table_status.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/until_past_table_status.rb
@@ -4,9 +4,10 @@ module Dynamoid
   module AdapterPlugin
     class AwsSdkV3
       class UntilPastTableStatus
-        attr_reader :table_name, :status
+        attr_reader :client, :table_name, :status
 
-        def initialize(table_name, status = :creating)
+        def initialize(client, table_name, status = :creating)
+          @client = client
           @table_name = table_name
           @status = status
         end

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3/until_past_table_status_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3/until_past_table_status_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'dynamoid/adapter_plugin/aws_sdk_v3'
+
+describe Dynamoid::AdapterPlugin::AwsSdkV3::UntilPastTableStatus do
+  describe 'call' do
+    context 'table creation' do
+      let(:client) { double('client') }
+      let(:response_creating) { double('response#creating', table: creating_table) }
+      let(:response_active) { double('response#active', table: active_table) }
+      let(:creating_table) { double('creating_table', table_status: 'CREATING') }
+      let(:active_table) { double('creating_table', table_status: 'ACTIVE') }
+
+      it 'wait until table is created', config: { sync_retry_max_times: 60 } do
+        expect(client).to receive(:describe_table)
+          .with(table_name: :dogs).exactly(3).times
+          .and_return(response_creating, response_creating, response_active)
+
+        described_class.new(client, :dogs, :creating).call
+      end
+
+      it 'stops if exceeded Dynamoid.config.sync_retry_max_times attempts limit',
+        config: { sync_retry_max_times: 5 } do
+
+        expect(client).to receive(:describe_table)
+          .exactly(6).times
+          .and_return(*[response_creating]*6)
+
+        described_class.new(client, :dogs, :creating).call
+      end
+
+      it 'uses :sync_retry_max_times seconds to delay attempts',
+        config: { sync_retry_wait_seconds: 2, sync_retry_max_times: 3 } do
+
+        service = described_class.new(client, :dogs, :creating)
+        allow(client).to receive(:describe_table).and_return(response_creating).exactly(4).times
+        expect(service).to receive(:sleep).with(2).exactly(4).times
+
+        service.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
The issue with `create_table(sync: true)` is fixed.

### Issue description

There is a bug introduced in the recent release. It was reported here https://github.com/Dynamoid/dynamoid/commit/bc08d10cdc7916705f4403f2aa8df3c57a42565b#r33625659 by @cabello.

`create_table(sync: true)` method call leads to exception in `UntilPastTableStatus` class:

```
NameError:
  undefined local variable or method `client' for #<Dynamoid::AdapterPlugin::AwsSdkV3::UntilPastTableStatus:0x00007fe3d68d44f8>
# ./lib/dynamoid/adapter_plugin/aws_sdk_v3/until_past_table_status.rb:21:in `call'
# ./spec/dynamoid/adapter_plugin/aws_sdk_v3/until_past_table_status_spec.rb:21:in `block (4 levels) in <top (required)>'
# ./spec/support/unregister_declared_classes.rb:6:in `block (2 levels) in <top (required)>'

```