### PR TITLE
Add support of NULL and NOT_NULL operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,13 +634,20 @@ Address.where('latitude.between': [10212, 20000])
 ```
 
 You are able to filter results on the DynamoDB side and specify conditions for non-key fields.
-Following operators are available: `in`, `contains`, `not_contains`:
+Following additional operators are available: `in`, `contains`, `not_contains`, `null`, `not_null`:
 
 ```ruby
 Address.where('city.in': ['London', 'Edenburg', 'Birmingham'])
 Address.where('city.contains': ['on'])
 Address.where('city.not_contains': ['ing'])
+Address.where('postcode.null': false)
+Address.where('postcode.not_null': true)
 ```
+
+**WARNING:** Please take into accout that `NULL` and `NOT_NULL`
+operators check attribute presence in a document, not value.
+So if attribute `postcode`'s value is `NULL`, `NULL` operator will return false
+because attribute exists even if has `NULL` value.
 
 ### Consistent Reads
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/create_table.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/create_table.rb
@@ -62,11 +62,16 @@ module Dynamoid
           end
           resp = client.create_table(client_opts)
           options[:sync] = true if !options.key?(:sync) && ls_indexes.present? || gs_indexes.present?
-          UntilPastTableStatus.new(client, table_name, :creating).call if options[:sync] &&
-                                                                  (status = PARSE_TABLE_STATUS.call(resp, :table_description)) &&
-                                                                  status == TABLE_STATUSES[:creating]
+
+          if options[:sync]
+            status = PARSE_TABLE_STATUS.call(resp, :table_description)
+            if status == TABLE_STATUSES[:creating]
+              UntilPastTableStatus.new(client, table_name, :creating).call
+            end
+          end
+
           # Response to original create_table, which, if options[:sync]
-          #   may have an outdated table_description.table_status of "CREATING"
+          # may have an outdated table_description.table_status of "CREATING"
           resp
         end
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/scan.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/scan.rb
@@ -75,6 +75,8 @@ module Dynamoid
               comparison_operator: AwsSdkV3::FIELD_MAP[cond.keys[0]],
               attribute_value_list: AwsSdkV3.attribute_value_list(AwsSdkV3::FIELD_MAP[cond.keys[0]], cond.values[0].freeze)
             }
+            # nil means operator doesn't require attribute value list
+            conditions.delete(:attribute_value_list) if conditions[:attribute_value_list].nil?
             result[attr] = condition
             result
           end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -341,6 +341,34 @@ describe Dynamoid::Criteria::Chain do
       expect(model.where(name: 'a', 'job_title.not_contains': 'Consul').all)
         .to contain_exactly(customer2)
     end
+
+    it 'supports null' do
+      model.create_table
+
+      put_attributes(model.table_name, name: 'a', last_name: 'aa', age: 1)
+      put_attributes(model.table_name, name: 'a', last_name: 'bb', age: 2)
+      put_attributes(model.table_name, name: 'a', last_name: 'cc', )
+
+      documents = model.where(name: 'a', 'age.null': true).to_a
+      expect(documents.map(&:last_name)).to contain_exactly('cc')
+
+      documents = model.where(name: 'a', 'age.null': false).to_a
+      expect(documents.map(&:last_name)).to contain_exactly('aa', 'bb')
+    end
+
+    it 'supports not_null' do
+      model.create_table
+
+      put_attributes(model.table_name, name: 'a', last_name: 'aa', age: 1)
+      put_attributes(model.table_name, name: 'a', last_name: 'bb', age: 2)
+      put_attributes(model.table_name, name: 'a', last_name: 'cc', )
+
+      documents = model.where(name: 'a', 'age.not_null': true).to_a
+      expect(documents.map(&:last_name)).to contain_exactly('aa', 'bb')
+
+      documents = model.where('age.not_null': false).to_a
+      expect(documents.map(&:last_name)).to contain_exactly('cc')
+    end
   end
 
   # http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.ScanFilter.html?shortFooter=true
@@ -489,6 +517,34 @@ describe Dynamoid::Criteria::Chain do
 
       expect(model.where('job_title.not_contains': 'Consul').all)
         .to contain_exactly(customer2)
+    end
+
+    it 'supports null' do
+      model.create_table
+
+      put_attributes(model.table_name, id: '1', age: 1)
+      put_attributes(model.table_name, id: '2', age: 2)
+      put_attributes(model.table_name, id: '3')
+
+      documents = model.where('age.null': true).to_a
+      expect(documents.map(&:id)).to contain_exactly('3')
+
+      documents = model.where('age.null': false).to_a
+      expect(documents.map(&:id)).to contain_exactly('1', '2')
+    end
+
+    it 'supports not_null' do
+      model.create_table
+
+      put_attributes(model.table_name, id: '1', age: 1)
+      put_attributes(model.table_name, id: '2', age: 2)
+      put_attributes(model.table_name, id: '3')
+
+      documents = model.where('age.not_null':  true).to_a
+      expect(documents.map(&:id)).to contain_exactly('1', '2')
+
+      documents = model.where('age.not_null':  false).to_a
+      expect(documents.map(&:id)).to contain_exactly('3')
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,5 +47,6 @@ RSpec.configure do |config|
   config.include NewClassHelper
   config.include DumpingHelper
   config.include PersistenceHelper
+  config.include ChainHelper
   config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/support/chain_helper.rb
+++ b/spec/support/chain_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ChainHelper
+  def put_attributes(table_name, attributes)
+    Dynamoid.adapter.put_item(table_name, attributes)
+  end
+end


### PR DESCRIPTION
Added new operators `null` and `not_null` for `where` chain method conditions. They keep semantic of `NULL` and `NOT_NULL` operators.

Example:

```
Address.where('postcode.null': false)
Address.where('postcode.not_null': true)
```


Documentation - https://docs.aws.amazon.com/en_us/amazondynamodb/latest/APIReference/API_Condition.html

Related Issue https://github.com/Dynamoid/dynamoid/issues/358