### PR TITLE
Add `store_attribute_with_nil_value ` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,27 @@ User.where(name: 'Mike').where('name.begins_with': 'Ed')
 
 the first one will be ignored and the last one will be used.
 
+**Warning:** There is a caveat with filtering documents by `nil`
+value attribute. By default Dynamoid ignores attributes with `nil`
+value and doesn't store them in a DynamoDB document. This behavior
+could be changed with `store_attribute_with_nil_value` config option.
+
+If Dynamoid ignores `nil` value attributes `null`/`not_null` operators
+should be used in query:
+
+```ruby
+Address.where('postcode.null': true)
+Address.where('postcode.not_null': true)
+```
+
+If Dynamoid keeps `nil` value attributes `eq`/`ne` operators
+should be used instead:
+
+```ruby
+Address.where('postcode': nil)
+Address.where('postcode.ne': nil)
+```
+
 #### Limits
 
 There are three types of limits that you can query with:

--- a/README.md
+++ b/README.md
@@ -813,6 +813,9 @@ Listed below are all configuration options.
 * `sync_retry_max_times` - when Dynamoid creates or deletes table synchronously it checks for completion specified times. Default is 60 (times). It's a bit over 2 minutes by default
 * `sync_retry_wait_seconds` - time to wait between retries. Default is 2 (seconds)
 * `convert_big_decimal` - if `true` then Dynamoid converts numbers stored in `Hash` in `raw` field to float. Default is `false`
+* `store_attribute_with_nil_value` - if `true` Dynamoid keeps attribute
+with `nil` value in a document. Otherwise Dynamoid removes it while saving
+a document. Default is `nil` which equals behaviour with `false` value.
 * `models_dir` - `dynamoid:create_tables` rake task loads DynamoDb models from this directory. Default is `./app/models`.
 * `application_timezone` - Dynamoid converts all `datetime` fields to specified time zone when loads data from the storage.
   Acceptable values - `:utc`, `:local` (to use system time zone) and time zone name e.g. `Eastern Time (US & Canada)`. Default is `utc`

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -639,8 +639,12 @@ module Dynamoid
       end
 
       def sanitize_item(attributes)
+        config_value = Dynamoid.config.store_attribute_with_nil_value
+        store_attribute_with_nil_value = config_value.nil? ? false : !!config_value
+
         attributes.reject do |_, v|
-          v.nil? || ((v.is_a?(Set) || v.is_a?(String)) && v.empty?)
+          ((v.is_a?(Set) || v.is_a?(String)) && v.empty?) ||
+            (!store_attribute_with_nil_value && v.nil?)
         end.transform_values do |v|
           v.is_a?(Hash) ? v.stringify_keys : v
         end

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -31,6 +31,7 @@ module Dynamoid
     option :sync_retry_max_times, default: 60 # a bit over 2 minutes
     option :sync_retry_wait_seconds, default: 2
     option :convert_big_decimal, default: false
+    option :store_attribute_with_nil_value, default: false # keep or ignore attribute with nil value at saving
     option :models_dir, default: './app/models' # perhaps you keep your dynamoid models in a different directory?
     option :application_timezone, default: :utc # available values - :utc, :local, time zone name like "Hawaii"
     option :dynamodb_timezone, default: :utc # available values - :utc, :local, time zone name like "Hawaii"

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -695,6 +695,43 @@ describe Dynamoid::Persistence do
         end
       end
     end
+
+    describe '`store_attribute_with_nil_value` config option' do
+      let(:klass) do
+        new_class do
+          field :age, :integer
+        end
+      end
+
+      context 'true', config: { store_attribute_with_nil_value: true } do
+        it 'keeps document attribute with nil' do
+          obj = klass.new(age: nil)
+          obj.save
+
+          expect(raw_attributes(obj)).to include(age: nil)
+        end
+      end
+
+      context 'false', config: { store_attribute_with_nil_value: false } do
+        it 'does not keep document attribute with nil' do
+          obj = klass.new(age: nil)
+          obj.save
+
+          # doesn't contain :age key
+          expect(raw_attributes(obj).keys).to contain_exactly(:id, :created_at, :updated_at)
+        end
+      end
+
+      context 'by default', config: { store_attribute_with_nil_value: nil } do
+        it 'does not keep document attribute with nil' do
+          obj = klass.new(age: nil)
+          obj.save
+
+          # doesn't contain :age key
+          expect(raw_attributes(obj).keys).to contain_exactly(:id, :created_at, :updated_at)
+        end
+      end
+    end
   end
 
   describe '#update_attribute' do


### PR DESCRIPTION
New config option `store_attribute_with_nil_value` means whether Dynamoid should store model attribute with `nil` value in DynamoDB item.

By default Dynamoid will not store such attributes in order to maintain current behaviour and to not introduce breaking changes.

Recently I found out that such attributes are rejected at saving stage which I would consider as incorrect behaviour. In order to allow users to keep current behavoiur and not introduce breaking changes I would like to add this new option.

So to keep old behaviour nothing should be changed. If user want to have fixed behaviour `store_attribute_with_nil_value` config option should be set to `true` (default is `nil`)

One of the consequences of this behaviour change (storing nil value attributes) is different way to filter document with `nil` attributes. For instance now with old behaviour `null`/`not_null` operators should be used. With new behaviour `eq`/`ne` operators should be used.

Old behaviour:
```ruby
Address.where('postcode.null': true)
Address.where('postcode.not_null': true)
```
New behaviour:
```ruby
Address.where('postcode': nil)
Address.where('postcode.ne': nil)
```