### PR TITLE
Add Criteria::Chain#project method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Features
 
+* Feature: [#374](https://github.com/Dynamoid/dynamoid/pull/374) Add `#project` query method to load only specified fields
+
 ## Improvements
 
 * Improvement: [#359](https://github.com/Dynamoid/dynamoid/pull/359) Add support of `NULL` and `NOT_NULL` operators

--- a/README.md
+++ b/README.md
@@ -674,6 +674,32 @@ operators check attribute presence in a document, not value.
 So if attribute `postcode`'s value is `NULL`, `NULL` operator will return false
 because attribute exists even if has `NULL` value.
 
+#### Selecting some specific fields only
+
+It could be done with `project` method:
+
+```ruby
+class User
+  include Dynamoid::Document
+  field :name
+end
+
+User.create(name: 'Alex')
+user = User.project(:name).first
+
+user.id         # => nil
+user.name       # => 'Alex'
+user.created_at # => nil
+```
+
+Returned models with have filled specified fields only.
+
+Several fields could be specified:
+
+```ruby
+user = User.project(:name, :created_at)
+```
+
 ### Consistent Reads
 
 Querying supports consistent reading. By default, DynamoDB reads are eventually consistent: if you do a write and then a read immediately afterwards, the results of the previous write may not be reflected. If you need to do a consistent read (that is, you need to read the results of a write immediately) you can do so, but keep in mind that consistent reads are twice as expensive as regular reads for DynamoDB.

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/query.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/query.rb
@@ -11,6 +11,7 @@ module Dynamoid
         OPTIONS_KEYS = %i[
           limit hash_key hash_value range_key consistent_read scan_index_forward
           select index_name batch_size exclusive_start_key record_limit scan_limit
+          project
         ].freeze
 
         attr_reader :client, :table, :options, :conditions
@@ -63,10 +64,11 @@ module Dynamoid
           batch_size = options[:batch_size]
           limit = [record_limit, scan_limit, batch_size].compact.min
 
-          request[:limit]          = limit if limit
-          request[:table_name]     = table.name
-          request[:key_conditions] = key_conditions
-          request[:query_filter]   = query_filter
+          request[:limit]             = limit if limit
+          request[:table_name]        = table.name
+          request[:key_conditions]    = key_conditions
+          request[:query_filter]      = query_filter
+          request[:attributes_to_get] = attributes_to_get
 
           request
         end
@@ -116,6 +118,11 @@ module Dynamoid
             result[attr] = condition
             result
           end
+        end
+
+        def attributes_to_get
+          return if options[:project].nil?
+          options[:project].map(&:to_s)
         end
       end
     end

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/scan.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/scan.rb
@@ -54,9 +54,10 @@ module Dynamoid
           batch_size = options[:batch_size]
           limit = [record_limit, scan_limit, batch_size].compact.min
 
-          request[:limit]       = limit if limit
-          request[:table_name]  = table.name
-          request[:scan_filter] = scan_filter
+          request[:limit]             = limit if limit
+          request[:table_name]        = table.name
+          request[:scan_filter]       = scan_filter
+          request[:attributes_to_get] = attributes_to_get
 
           request
         end
@@ -80,6 +81,11 @@ module Dynamoid
             result[attr] = condition
             result
           end
+        end
+
+        def attributes_to_get
+          return if options[:project].nil?
+          options[:project].map(&:to_s)
         end
       end
     end

--- a/lib/dynamoid/criteria.rb
+++ b/lib/dynamoid/criteria.rb
@@ -8,7 +8,7 @@ module Dynamoid
     extend ActiveSupport::Concern
 
     module ClassMethods
-      %i[where all first last each record_limit scan_limit batch start scan_index_forward find_by_pages].each do |meth|
+      %i[where all first last each record_limit scan_limit batch start scan_index_forward find_by_pages project].each do |meth|
         # Return a criteria chain in response to a method that will begin or end a chain. For more information,
         # see Dynamoid::Criteria::Chain.
         #

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -159,6 +159,11 @@ module Dynamoid
         pages.each(&block)
       end
 
+      def project(*fields)
+        @project = fields.map(&:to_sym)
+        self
+      end
+
       private
 
       # The actual records referenced by the association.
@@ -368,13 +373,16 @@ module Dynamoid
 
       def query_opts
         opts = {}
+        # Don't specify select = ALL_ATTRIBUTES option explicitly because it's
+        # already a default value of Select statement. Explicite Select value
+        # conflicts with AttributesToGet statement (project option).
         opts[:index_name] = @key_fields_detector.index_name if @key_fields_detector.index_name
-        opts[:select] = 'ALL_ATTRIBUTES'
         opts[:record_limit] = @record_limit if @record_limit
         opts[:scan_limit] = @scan_limit if @scan_limit
         opts[:batch_size] = @batch_size if @batch_size
         opts[:exclusive_start_key] = start_key if @start
         opts[:scan_index_forward] = @scan_index_forward
+        opts[:project] = @project
         opts
       end
 
@@ -398,6 +406,7 @@ module Dynamoid
         opts[:batch_size] = @batch_size if @batch_size
         opts[:exclusive_start_key] = start_key if @start
         opts[:consistent_read] = true if @consistent_read
+        opts[:project] = @project
         opts
       end
     end

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -195,9 +195,12 @@ module Dynamoid
       #
       # @since 3.1.0
       def pages_via_query
-        Enumerator.new do |yielder|
+        Enumerator.new do |y|
           Dynamoid.adapter.query(source.table_name, range_query).each do |items, metadata|
-            yielder.yield items.map { |hash| source.from_database(hash) }, metadata.slice(:last_evaluated_key)
+            page = items.map { |h| source.from_database(h) }
+            options = metadata.slice(:last_evaluated_key)
+
+            y.yield page, options
           end
         end
       end
@@ -208,9 +211,12 @@ module Dynamoid
       #
       # @since 3.1.0
       def pages_via_scan
-        Enumerator.new do |yielder|
+        Enumerator.new do |y|
           Dynamoid.adapter.scan(source.table_name, scan_query, scan_opts).each do |items, metadata|
-            yielder.yield(items.map { |hash| source.from_database(hash) }, metadata.slice(:last_evaluated_key))
+            page = items.map { |h| source.from_database(h) }
+            options = metadata.slice(:last_evaluated_key)
+
+            y.yield page, options
           end
         end
       end


### PR DESCRIPTION
Changes:
- Added query `#project` method to load specified attributes only

Example:

```ruby
class User
  include Dynamoid::Document
  field :name
end

User.create(name: 'Alex')
user = User.project(:name).first

user.id         # => nil
user.name       # => 'Alex'
user.created_at # => nil
```


Related issue - https://github.com/Dynamoid/dynamoid/issues/369