### PR TITLE
Disable timestamps fields on a table level

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ explicitly and should have numeric type (`integer`, `number`) only.
 `datetime` type is also possible but only if it's stored as number
 (there is a way to store time as a string also).
 
+It's also possible to override a global option `Dynamoid::Config.timestamps`
+on a table level:
+
+```ruby
+table timestamps: false
+```
+
+This option controls generation of timestamp fields
+`created_at`/`updated_at`.
+
 ### Fields
 
 You'll have to define all the fields on the model and the data type of

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -75,11 +75,19 @@ module Dynamoid #:nodoc:
         self.range_key = name
       end
 
-      def table(_options)
+      def table(options)
         # a default 'id' column is created when Dynamoid::Document is included
         unless attributes.key? hash_key
           remove_field :id
           field(hash_key)
+        end
+
+        if options[:timestamps] && !Dynamoid::Config.timestamps
+          field :created_at, :datetime
+          field :updated_at, :datetime
+        elsif options[:timestamps] == false && Dynamoid::Config.timestamps
+          remove_field :created_at
+          remove_field :updated_at
         end
       end
 

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -21,6 +21,9 @@ module Dynamoid #:nodoc:
       class_attribute :range_key
 
       self.attributes = {}
+
+      # Timestamp fields could be disabled later in `table` method call.
+      # So let's declare them here and remove them later if it will be necessary
       field :created_at, :datetime if Dynamoid::Config.timestamps
       field :updated_at, :datetime if Dynamoid::Config.timestamps
 
@@ -83,9 +86,13 @@ module Dynamoid #:nodoc:
         end
 
         if options[:timestamps] && !Dynamoid::Config.timestamps
+          # Timestamp fields weren't declared in `included` hook because they
+          # are disabled globaly
           field :created_at, :datetime
           field :updated_at, :datetime
         elsif options[:timestamps] == false && Dynamoid::Config.timestamps
+          # Timestamp fields were declared in `included` hook but they are
+          # disabled for a table
           remove_field :created_at
           remove_field :updated_at
         end
@@ -105,6 +112,10 @@ module Dynamoid #:nodoc:
           remove_method :"#{field}?"
           remove_method :"#{field}_before_type_cast"
         end
+      end
+
+      def timestamps_enabled?
+        options[:timestamps] || (options[:timestamps].nil? && Dynamoid::Config.timestamps)
       end
 
       private
@@ -174,14 +185,14 @@ module Dynamoid #:nodoc:
     #
     # @since 0.2.0
     def set_created_at
-      self.created_at ||= DateTime.now.in_time_zone(Time.zone) if Dynamoid::Config.timestamps
+      self.created_at ||= DateTime.now.in_time_zone(Time.zone) if self.class.timestamps_enabled?
     end
 
     # Automatically called during the save callback to set the updated_at time.
     #
     # @since 0.2.0
     def set_updated_at
-      if Dynamoid::Config.timestamps && !updated_at_changed?
+      if self.class.timestamps_enabled? && !updated_at_changed?
         self.updated_at = DateTime.now.in_time_zone(Time.zone)
       end
     end

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -21,8 +21,8 @@ module Dynamoid #:nodoc:
       class_attribute :range_key
 
       self.attributes = {}
-      field :created_at, :datetime
-      field :updated_at, :datetime
+      field :created_at, :datetime if Dynamoid::Config.timestamps
+      field :updated_at, :datetime if Dynamoid::Config.timestamps
 
       field :id # Default primary key
     end

--- a/lib/dynamoid/persistence/import.rb
+++ b/lib/dynamoid/persistence/import.rb
@@ -32,7 +32,7 @@ module Dynamoid
       def build_model(attributes)
         attrs = attributes.symbolize_keys
 
-        if Dynamoid::Config.timestamps
+        if @model_class.timestamps_enabled?
           time_now = DateTime.now.in_time_zone(Time.zone)
           attrs[:created_at] ||= time_now
           attrs[:updated_at] ||= time_now

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -280,4 +280,22 @@ describe Dynamoid::Document do
       end.to raise_error(NoMethodError, /undefined method `foo='/)
     end
   end
+
+  describe 'timestamps fields `created_at` and `updated_at`' do
+    it 'declares timestamps when Dynamoid::Config.timestamps = true', config: { timestamps: true } do
+      expect(new_class.attributes).to have_key(:created_at)
+      expect(new_class.attributes).to have_key(:updated_at)
+
+      expect(new_class.new).to respond_to(:created_at)
+      expect(new_class.new).to respond_to(:updated_at)
+    end
+
+    it 'does not declare timestamps when Dynamoid::Config.timestamps = false', config: { timestamps: false } do
+      expect(new_class.attributes).not_to have_key(:created_at)
+      expect(new_class.attributes).not_to have_key(:updated_at)
+
+      expect(new_class.new).not_to respond_to(:created_at)
+      expect(new_class.new).not_to respond_to(:updated_at)
+    end
+  end
 end

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -282,6 +282,18 @@ describe Dynamoid::Document do
   end
 
   describe 'timestamps fields `created_at` and `updated_at`' do
+    let(:class_with_timestamps_true) do
+      new_class do
+        table timestamps: true
+      end
+    end
+
+    let(:class_with_timestamps_false) do
+      new_class do
+        table timestamps: false
+      end
+    end
+
     it 'declares timestamps when Dynamoid::Config.timestamps = true', config: { timestamps: true } do
       expect(new_class.attributes).to have_key(:created_at)
       expect(new_class.attributes).to have_key(:updated_at)
@@ -296,6 +308,22 @@ describe Dynamoid::Document do
 
       expect(new_class.new).not_to respond_to(:created_at)
       expect(new_class.new).not_to respond_to(:updated_at)
+    end
+
+    it 'does not declare timestamps when Dynamoid::Config.timestamps = true but table timestamps = false', config: { timestamps: true } do
+      expect(class_with_timestamps_false.attributes).not_to have_key(:created_at)
+      expect(class_with_timestamps_false.attributes).not_to have_key(:updated_at)
+
+      expect(class_with_timestamps_false.new).not_to respond_to(:created_at)
+      expect(class_with_timestamps_false.new).not_to respond_to(:updated_at)
+    end
+
+    it 'declares timestamps when Dynamoid::Config.timestamps = false but table timestamps = true', config: { timestamps: false } do
+      expect(class_with_timestamps_true.attributes).to have_key(:created_at)
+      expect(class_with_timestamps_true.attributes).to have_key(:updated_at)
+
+      expect(class_with_timestamps_true.new).to respond_to(:created_at)
+      expect(class_with_timestamps_true.new).to respond_to(:updated_at)
     end
   end
 end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -42,14 +42,6 @@ describe Dynamoid::Fields do
     expect(model_loaded.special_date).to eq date
   end
 
-  it 'automatically declares and fills in created_at and updated_at' do
-    address.save
-
-    address.reload
-    expect(address.created_at).to be_a DateTime
-    expect(address.updated_at).to be_a DateTime
-  end
-
   context 'query attributes' do
     it 'are declared' do
       expect(address.city?).to be_falsey

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -708,11 +708,7 @@ describe Dynamoid::Persistence do
       end
 
       it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
-        created_at = updated_at = Time.now
-        obj = klass.create
-
-        expect(obj.created_at).to eql(nil)
-        expect(obj.updated_at).to eql(nil)
+        expect { klass.create }.not_to raise_error
       end
     end
   end
@@ -837,10 +833,11 @@ describe Dynamoid::Persistence do
       end
 
       it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
-        d = document_class.create(name: 'Document#1')
-        document_class.update(d.id, name: '[Updated]')
-        expect(d.reload.name).to eql('[Updated]')
-        expect(d.reload.updated_at).to eql(nil)
+        doc = document_class.create(name: 'Document#1')
+
+        expect do
+          document_class.update(doc.id, name: '[Updated]')
+        end.not_to raise_error
       end
     end
 
@@ -993,9 +990,10 @@ describe Dynamoid::Persistence do
 
       it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
         obj = document_class.create(title: 'Old title')
-        document_class.update_fields(obj.id, title: 'New title')
-        expect(obj.reload.title).to eql('New title')
-        expect(obj.reload.updated_at).to eql(nil)
+
+        expect do
+          document_class.update_fields(obj.id, title: 'New title')
+        end.not_to raise_error
       end
     end
 
@@ -1169,9 +1167,10 @@ describe Dynamoid::Persistence do
 
       it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
         obj = document_class.create(title: 'Old title')
-        document_class.upsert(obj.id, title: 'New title')
-        expect(obj.reload.title).to eql('New title')
-        expect(obj.reload.updated_at).to eql(nil)
+
+        expect do
+          document_class.upsert(obj.id, title: 'New title')
+        end.not_to raise_error
       end
     end
 
@@ -1582,10 +1581,8 @@ describe Dynamoid::Persistence do
         it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
           created_at = updated_at = Time.now
           obj = klass.new
-          obj.save
 
-          expect(obj.created_at).to eql(nil)
-          expect(obj.updated_at).to eql(nil)
+          expect { obj.save }.not_to raise_error
         end
       end
 
@@ -1629,9 +1626,8 @@ describe Dynamoid::Persistence do
         it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
           obj = klass.create(title: 'Old title')
           obj.title = 'New title'
-          obj.save
 
-          expect(obj.updated_at).to eql(nil)
+          expect { obj.save }.not_to raise_error
         end
       end
     end
@@ -1719,9 +1715,10 @@ describe Dynamoid::Persistence do
 
       it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
         obj = klass.create(title: 'Old title')
-        obj.update_attribute(:title, 'New title')
 
-        expect(obj.updated_at).to eql(nil)
+        expect do
+          obj.update_attribute(:title, 'New title')
+        end.not_to raise_error
       end
     end
   end
@@ -1809,9 +1806,10 @@ describe Dynamoid::Persistence do
 
       it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
         obj = klass.create(title: 'Old title')
-        obj.update_attributes(title: 'New title')
 
-        expect(obj.updated_at).to eql(nil)
+        expect do
+          obj.update_attributes(title: 'New title')
+        end.not_to raise_error
       end
     end
   end
@@ -1901,9 +1899,10 @@ describe Dynamoid::Persistence do
 
       it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
         obj = klass.create(title: 'Old title')
-        obj.update_attributes!(title: 'New title')
 
-        expect(obj.updated_at).to eql(nil)
+        expect do
+          obj.update_attributes!(title: 'New title')
+        end.not_to raise_error
       end
     end
   end
@@ -2205,10 +2204,10 @@ describe Dynamoid::Persistence do
 
       it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
         obj = klass.create(title: 'Old title')
-        obj.update { |d| d.set(title: 'New title') }
 
-        expect(obj.reload.title).to eql('New title')
-        expect(obj.reload.updated_at).to eql(nil)
+        expect do
+          obj.update { |d| d.set(title: 'New title') }
+        end.not_to raise_error
       end
     end
 
@@ -2391,11 +2390,7 @@ describe Dynamoid::Persistence do
       end
 
       it 'does not raise error if Config.timestamps=false', config: { timestamps: false } do
-        created_at = updated_at = Time.now
-        obj, = klass.import([{}])
-
-        expect(obj.created_at).to eql(nil)
-        expect(obj.updated_at).to eql(nil)
+        expect { klass.import([{}]) }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
Changes:
- added new table option `timestamps`
- fixed bug with timestamps when they are disabled globally but are still declared

Example:

```ruby
class User
  include Dynamoid::Document

  table timestamps: false
end
```

Related to abandoned PR https://github.com/Dynamoid/dynamoid/pull/266