### PR TITLE
Add TTL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ won't change its hash key, which it expects will be `user_id`. If this
 table doesn't exist yet, however, Dynamoid will create it with these
 options.
 
+There is a basic support of DynamoDB's [Time To Live (TTL)
+mechanism](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html).
+If you declare a field as TTL field - it will be initialised if doesn't
+have value yet. Default value is current time + specified seconds.
+
+```ruby
+class User
+  include Dynamoid::Document
+
+  table expires: { field: :ttl, after: 60 }
+
+  field :ttl, :integer
+end
+```
+
+Field used to store expiration time (e.g. `ttl`) should be declared
+explicitly and should have numeric type (`integer`, `number`) only.
+`datetime` type is also possible but only if it's stored as number
+(there is a way to store time as a string also).
+
 ### Fields
 
 You'll have to define all the fields on the model and the data type of

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -124,8 +124,12 @@ module Dynamoid
 
     def create_table(table_name, key, options = {})
       unless tables.include?(table_name)
-        benchmark('Create Table') { adapter.create_table(table_name, key, options) }
+        result = nil
+        benchmark('Create Table') { result = adapter.create_table(table_name, key, options) }
         tables << table_name
+        result
+      else
+        false
       end
     end
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -246,8 +246,22 @@ module Dynamoid
       def create_table(table_name, key = :id, options = {})
         Dynamoid.logger.info "Creating #{table_name} table. This could take a while."
         CreateTable.new(client, table_name, key, options).call
+        true
       rescue Aws::DynamoDB::Errors::ResourceInUseException => e
         Dynamoid.logger.error "Table #{table_name} cannot be created as it already exists"
+        false
+      end
+
+      def update_time_to_live(table_name:, attribute:)
+        request = {
+          table_name: table_name,
+          time_to_live_specification: {
+            attribute_name: attribute,
+            enabled: true,
+          }
+        }
+
+        client.update_time_to_live(request)
       end
 
       # Create a table on DynamoDB *synchronously*.

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -14,6 +14,7 @@ module Dynamoid
 
       before_create :set_created_at
       before_save :set_updated_at
+      before_save :set_expires_field
       after_initialize :set_inheritance_field
     end
 

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -178,6 +178,19 @@ module Dynamoid #:nodoc:
       end
     end
 
+    def set_expires_field
+      options = self.class.options[:expires]
+
+      if options.present?
+        name = options[:field]
+        seconds = options[:after]
+
+        if self[name].blank?
+          send("#{name}=", Time.now.to_i + seconds)
+        end
+      end
+    end
+
     def set_inheritance_field
       # actually it does only following logic:
       # self.type ||= self.class.name if self.class.attributes[:type]

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -54,7 +54,12 @@ module Dynamoid
           global_secondary_indexes: global_secondary_indexes.values
         }.merge(options)
 
-        Dynamoid.adapter.create_table(options[:table_name], options[:id], options)
+        created_successfuly = Dynamoid.adapter.create_table(options[:table_name], options[:id], options)
+
+        if created_successfuly && self.options[:expires]
+          attribute = self.options[:expires][:field]
+          Dynamoid.adapter.update_time_to_live(table_name: table_name, attribute: attribute)
+        end
       end
 
       # Deletes the table for the model

--- a/spec/dynamoid/adapter_spec.rb
+++ b/spec/dynamoid/adapter_spec.rb
@@ -93,6 +93,33 @@ describe Dynamoid::Adapter do
     end
   end
 
+  describe '#create_table' do
+    let(:table_name) { "#{Dynamoid::Config.namespace}_create_table_test" }
+
+    after do
+      Dynamoid.adapter.delete_table(table_name)
+    end
+
+    it 'does not try to create table if it is already in cache' do
+      expect(Dynamoid.adapter.client).to receive(:create_table).once
+        .and_call_original
+
+      3.times { Dynamoid.adapter.create_table(table_name, :id, sync: true) }
+    end
+
+    it 'returns true if table created' do
+      actual = Dynamoid.adapter.create_table(table_name, :id, sync: true)
+      expect(actual).to eq true
+    end
+
+    it 'returns false if table was created earlier' do
+      Dynamoid.adapter.create_table(table_name, :id, sync: true)
+
+      actual = Dynamoid.adapter.create_table(table_name, :id, sync: true)
+      expect(actual).to eq false
+    end
+  end
+
   describe '#delete' do
     it 'deletes through the adapter for one ID' do
       Dynamoid.adapter.put_item(test_table1, id: '1')

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -406,6 +406,23 @@ describe Dynamoid::Persistence do
         )
       end
     end
+
+    describe 'expires (Time To Live)' do
+      let(:class_with_expiration) do
+        new_class do
+          table expires: { field: :ttl, after: 60 }
+          field :ttl, :integer
+        end
+      end
+
+      it 'sets up TTL for table' do
+        expect(Dynamoid.adapter).to receive(:update_time_to_live)
+          .with(table_name: class_with_expiration.table_name, attribute: :ttl)
+          .and_call_original
+
+        class_with_expiration.create_table
+      end
+    end
   end
 
   describe 'delete_table' do


### PR DESCRIPTION
## Changes

- add table option `expires` to declare attribute name to store timestamp and default TTL (seconds)
- add support of creation table with TTL

## Example

```ruby
class User
  include Dynamoid::Document

  table expires: { field: :ttl, after: 60 }

  field :ttl, :integer
end
```

## How it works

When model is saved then specified numeric field (`ttl`) is initialized with expiration time (current time + `after` seconds).

When a table with specified expiration options is created - set up table TTL in DynamoDB as well with `UpdateTimeToLive` API call.

## Documentation

- https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html
- https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/DynamoDB/Client.html#update_time_to_live-instance_method

---

Related to abandoned PR #266