### PR TITLE
Allocate only one hash to initialize the attributes of the document

### DIFF
--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -138,13 +138,11 @@ module Dynamoid #:nodoc:
         @associations ||= {}
         @attributes_before_type_cast ||= {}
 
-        attrs_with_defaults = self.class.attributes.reduce({}) do |res, (attribute, options)|
+        attrs_with_defaults = self.class.attributes.each_with_object({}) do |(attribute, options), res|
           if attrs.key?(attribute)
-            res.merge(attribute => attrs[attribute])
+            res[attribute] = attrs[attribute]
           elsif options.key?(:default)
-            res.merge(attribute => evaluate_default_value(options[:default]))
-          else
-            res
+            res[attribute] = evaluate_default_value(options[:default])
           end
         end
 


### PR DESCRIPTION
Currently the initialize is allocating a LOT of objects which are unnecessary. 

The first object is allocated for reduce and then on each attribute which is passed in, or has a default, a hash is allocated for the argument to merge, and then another hash returned from the merge call for the next iteration.

This change allocates only a single hash for the entire initialization process. 

No spec changes since this is expected to have no functional change