### PR TITLE
ISSUE-391: support pre-configured credentials passed in

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -75,11 +75,17 @@ module Dynamoid
         (Dynamoid::Config.settings.compact.keys & CONNECTION_CONFIG_OPTIONS).each do |option|
           @connection_hash[option] = Dynamoid::Config.send(option)
         end
-        if Dynamoid::Config.access_key?
-          @connection_hash[:access_key_id] = Dynamoid::Config.access_key
-        end
-        if Dynamoid::Config.secret_key?
-          @connection_hash[:secret_access_key] = Dynamoid::Config.secret_key
+        # if credentials are passed, they already contain access key & secret key
+        if Dynamoid::Config.credentials?
+          @connection_hash[:credentials] = Dynamoid::Config.credentials
+        else
+          # otherwise, pass access key & secret key for credentials creation
+          if Dynamoid::Config.access_key?
+            @connection_hash[:access_key_id] = Dynamoid::Config.access_key
+          end
+          if Dynamoid::Config.secret_key?
+            @connection_hash[:secret_access_key] = Dynamoid::Config.secret_key
+          end
         end
 
         # https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -29,6 +29,7 @@ module Dynamoid
     option :namespace, default: DEFAULT_NAMESPACE
     option :access_key, default: nil
     option :secret_key, default: nil
+    option :credentials, default: nil
     option :region, default: nil
     option :batch_size, default: 100
     option :read_capacity, default: 100


### PR DESCRIPTION
Provides support for pre-configured credentials being passed into the client, as in: 
```ruby
@client = Aws::DynamoDB::Client.new(region: _region, credentials: _credentials)
```
