### PR TITLE
ISSUE-391: support pre-configured credentials passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,27 @@ Dynamoid.configure do |config|
 end
 ```
 
+Additionally, If you would like to pass in pre-configured AWS credentials 
+(e.g. you have an IAM role credential, you configure your credentials 
+elsewhere in your project, etc.), you may do so: 
+
+```ruby
+require 'dynamoid'
+
+credentials = Aws::AssumeRoleCredentials.new(
+    region: region,
+    access_key_id: key,
+    secret_access_key: secret,
+    role_arn: role_arn,
+    role_session_name: 'our-session'
+  )
+  
+Dynamoid.configure do |config|
+  config.region = 'us-west-2',
+  config.credentials = credentials
+end
+```
+
 For a full list of the DDB regions, you can go
 [here](http://docs.aws.amazon.com/general/latest/gr/rande.html#ddb_region).
 
@@ -992,12 +1013,14 @@ Listed below are all configuration options.
 * `logger` - by default it's a `Rails.logger` in Rails application and
   `stdout` otherwise. You can disable logging by setting `nil` or
   `false` values. Set `true` value to use defaults
-* `access_key` - DynamoDb custom credentials for AWS, override global
-  AWS credentials if they present
-* `secret_key` - DynamoDb custom credentials for AWS, override global
-  AWS credentials if they present
+* `access_key` - DynamoDb custom access key for AWS credentials, override global
+  AWS credentials if they're present
+* `secret_key` - DynamoDb custom secret key for AWS credentials, override global
+  AWS credentials if they're present
+* `credentials` - DynamoDb custom pre-configured credentials, override global 
+  AWS credentials if they're present
 * `region` - DynamoDb custom credentials for AWS, override global AWS
-  credentials if they present
+  credentials if they're present
 * `batch_size` - when you try to load multiple items at once with
 * `batch_get_item` call Dynamoid loads them not with one api call but
   piece by piece. Default is 100 items

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -75,11 +75,18 @@ module Dynamoid
         (Dynamoid::Config.settings.compact.keys & CONNECTION_CONFIG_OPTIONS).each do |option|
           @connection_hash[option] = Dynamoid::Config.send(option)
         end
-        if Dynamoid::Config.access_key?
-          @connection_hash[:access_key_id] = Dynamoid::Config.access_key
-        end
-        if Dynamoid::Config.secret_key?
-          @connection_hash[:secret_access_key] = Dynamoid::Config.secret_key
+
+        # if credentials are passed, they already contain access key & secret key
+        if Dynamoid::Config.credentials?
+          connection_hash[:credentials] = Dynamoid::Config.credentials
+        else
+          # otherwise, pass access key & secret key for credentials creation
+          if Dynamoid::Config.access_key?
+            connection_hash[:access_key_id] = Dynamoid::Config.access_key
+          end
+          if Dynamoid::Config.secret_key?
+            connection_hash[:secret_access_key] = Dynamoid::Config.secret_key
+          end
         end
 
         # https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -29,6 +29,7 @@ module Dynamoid
     option :namespace, default: DEFAULT_NAMESPACE
     option :access_key, default: nil
     option :secret_key, default: nil
+    option :credentials, default: nil
     option :region, default: nil
     option :batch_size, default: 100
     option :read_capacity, default: 100


### PR DESCRIPTION
Provides support for pre-configured credentials being passed into the client, as in: 
```ruby
@client = Aws::DynamoDB::Client.new(region: _region, credentials: _credentials)
```
