### PR TITLE
ISSUE-391: broke build - fix for credentials impl

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -78,14 +78,14 @@ module Dynamoid
 
         # if credentials are passed, they already contain access key & secret key
         if Dynamoid::Config.credentials?
-          connection_hash[:credentials] = Dynamoid::Config.credentials
+          @connection_hash[:credentials] = Dynamoid::Config.credentials
         else
           # otherwise, pass access key & secret key for credentials creation
           if Dynamoid::Config.access_key?
-            connection_hash[:access_key_id] = Dynamoid::Config.access_key
+            @connection_hash[:access_key_id] = Dynamoid::Config.access_key
           end
           if Dynamoid::Config.secret_key?
-            connection_hash[:secret_access_key] = Dynamoid::Config.secret_key
+            @connection_hash[:secret_access_key] = Dynamoid::Config.secret_key
           end
         end
 


### PR DESCRIPTION
Regarding: https://github.com/Dynamoid/dynamoid/pull/393
Addresses failure reported in above link by @zerooverride: 
"It seems this change has broken the gem, when I update to 3.4.0 I get this error (regardless of using the new feature or not):

NameError: undefined local variable or method `connection_hash' for #Dynamoid::AdapterPlugin::AwsSdkV3:0x0782cda8
Did you mean? @connection_hash

That looks like a valid error and changing aws_sdk_v3.rb to always use @connection_hash makes the change seem to work as expected.

Am I maybe doing something wrong or does this need to be fixed?"