### PR TITLE
Create table synchronously at model saving

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -290,7 +290,7 @@ module Dynamoid
     #
     # @since 0.2.0
     def save(_options = {})
-      self.class.create_table
+      self.class.create_table(sync: true)
 
       if new_record?
         run_callbacks(:create) do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -1531,6 +1531,8 @@ describe Dynamoid::Persistence do
     it 'creates table if it does not exist' do
       model = klass.new
 
+      expect(klass).to receive(:create_table).with(sync: true).and_call_original
+
       expect { model.save }
         .to change { tables_created.include?(klass.table_name) }
         .from(false).to(true)


### PR DESCRIPTION
Fix an error `Requested resource not found` when a model saving creates a corresponded table lazily:

```
Traceback (most recent call last):
	26: from ./1.rb:26:in `<main>'
	25: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/persistence.rb:107:in `create'
	24: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/persistence.rb:107:in `tap'
	23: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/identity_map.rb:64:in `save'
	22: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/validations.rb:18:in `save'
	21: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/dirty.rb:48:in `save'
	20: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/persistence.rb:296:in `save'
	19: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.0.2.1/lib/active_support/callbacks.rb:135:in `run_callbacks'
	18: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/persistence.rb:297:in `block in save'
	17: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.0.2.1/lib/active_support/callbacks.rb:135:in `run_callbacks'
	16: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/persistence.rb:298:in `block (2 levels) in save'
	15: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/persistence/save.rb:7:in `call'
	14: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/persistence/save.rb:23:in `call'
	13: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/adapter.rb:70:in `write'
	12: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/adapter.rb:150:in `block (2 levels) in <class:Adapter>'
	11: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/adapter.rb:55:in `benchmark'
	10: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/adapter.rb:150:in `block (3 levels) in <class:Adapter>'
	 9: from /Users/andrykonchin/projects/dynamoid/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb:451:in `put_item'
	 8: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/aws-sdk-dynamodb-1.41.0/lib/aws-sdk-dynamodb/client.rb:3437:in `put_item'
	 7: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.89.1/lib/seahorse/client/request.rb:70:in `send_request'
	 6: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.89.1/lib/seahorse/client/plugins/response_target.rb:23:in `call'
	 5: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.89.1/lib/aws-sdk-core/plugins/response_paging.rb:10:in `call'
	 4: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.89.1/lib/aws-sdk-core/plugins/param_converter.rb:24:in `call'
	 3: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.89.1/lib/aws-sdk-core/plugins/idempotency_token.rb:17:in `call'
	 2: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.89.1/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
	 1: from /Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/aws-sdk-dynamodb-1.41.0/lib/aws-sdk-dynamodb/plugins/simple_attributes.rb:117:in `call'
/Users/andrykonchin/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.89.1/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call': Requested resource not found (Aws::DynamoDB::Errors::ResourceNotFoundException)
```

Related issue https://github.com/Dynamoid/dynamoid/issues/70#issuecomment-589036261