### PR TITLE
Fix #persisted? for deleted/destroyed model

### DIFF
--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -43,7 +43,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal',  '~> 2.2'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls',  '~> 0.8'
-  spec.add_development_dependency 'pry',        '~> 0.12'
+  spec.add_development_dependency 'pry',        '~> 0.12.0' # Since 0.13.0 pry is incompatible with old versions of pry-byebug.
+                                                            # We use these old versions of pry-byebug to run tests on Ruby 2.3 which new versions dont't support
   spec.add_development_dependency 'rake',       '~> 13.0'
   spec.add_development_dependency 'rspec',      '~> 3.9'
   spec.add_development_dependency 'rubocop'

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -283,7 +283,7 @@ module Dynamoid
     #
     # @since 0.2.0
     def persisted?
-      !new_record?
+      !(new_record? || @destroyed)
     end
 
     # Run the callbacks and then persist this object in the datastore.
@@ -407,6 +407,9 @@ module Dynamoid
       ret = run_callbacks(:destroy) do
         delete
       end
+
+      @destroyed = true
+
       ret == false ? false : self
     end
 
@@ -431,6 +434,9 @@ module Dynamoid
           end
         options[:conditions] = conditions
       end
+
+      @destroyed = true
+
       Dynamoid.adapter.delete(self.class.table_name, hash_key, options)
     rescue Dynamoid::Errors::ConditionalCheckFailedException
       raise Dynamoid::Errors::StaleObjectError.new(self, 'delete')

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -2713,4 +2713,38 @@ describe Dynamoid::Persistence do
       end
     end
   end
+
+  describe '#persisted?' do
+    before do
+      klass.create_table
+    end
+
+    let(:klass) do
+      new_class
+    end
+
+    it 'returns true for saved model' do
+      model = klass.create!
+      expect(model.persisted?).to eq true
+    end
+
+    it 'returns false for new model' do
+      model = klass.new
+      expect(model.persisted?).to eq false
+    end
+
+    it 'returns false for deleted model' do
+      model = klass.create!
+
+      model.delete
+      expect(model.persisted?).to eq false
+    end
+
+    it 'returns false for destroyed model' do
+      model = klass.create!
+
+      model.destroy
+      expect(model.persisted?).to eq false
+    end
+  end
 end


### PR DESCRIPTION
Now `persisted?` method returns `false` for a deleted/destroyed model.

Closes https://github.com/Dynamoid/dynamoid/issues/411