### PR TITLE
Support `touch: false` option of the #save method

### DIFF
--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -192,7 +192,8 @@ module Dynamoid #:nodoc:
     #
     # @since 0.2.0
     def set_updated_at
-      if self.class.timestamps_enabled? && !updated_at_changed?
+      # @_touch_record=false means explicit disabling
+      if self.class.timestamps_enabled? && !updated_at_changed? && @_touch_record != false
         self.updated_at = DateTime.now.in_time_zone(Time.zone)
       end
     end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -289,8 +289,10 @@ module Dynamoid
     # Run the callbacks and then persist this object in the datastore.
     #
     # @since 0.2.0
-    def save(_options = {})
+    def save(options = {})
       self.class.create_table(sync: true)
+
+      @_touch_record = options[:touch]
 
       if new_record?
         run_callbacks(:create) do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -1866,6 +1866,20 @@ describe Dynamoid::Persistence do
         end
       end
     end
+
+    context 'when `touch: false` option passed' do
+      it 'does not update updated_at attribute' do
+        obj = klass.create!
+        updated_at = obj.updated_at
+
+        travel 1.minute do
+          obj.name = 'foo'
+          obj.save(touch: false)
+        end
+
+        expect(obj.updated_at).to eq updated_at
+      end
+    end
   end
 
   describe '#update_attribute' do


### PR DESCRIPTION
Add support of `touch: false` option to be aligned with Rails

Example:
```ruby
model.save(touch: false)
```

https://apidock.com/rails/ActiveRecord/Persistence/save

Closes https://github.com/Dynamoid/dynamoid/issues/419