### PR TITLE
Add warning when generated for a field methods override existing ones

### DIFF
--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -55,6 +55,12 @@ module Dynamoid #:nodoc:
         end
         self.attributes = attributes.merge(name => { type: type }.merge(options))
 
+        # should be called before `define_attribute_methods` method because it defines a getter itself
+        warn_about_method_overriding(name, name)
+        warn_about_method_overriding("#{named}=", name)
+        warn_about_method_overriding("#{named}?", name)
+        warn_about_method_overriding("#{named}_before_type_cast?", name)
+
         define_attribute_method(name) # Dirty API
 
         generated_methods.module_eval do
@@ -125,6 +131,12 @@ module Dynamoid #:nodoc:
           Module.new.tap do |mod|
             include(mod)
           end
+        end
+      end
+
+      def warn_about_method_overriding(method_name, field_name)
+        if self.instance_methods.include?(method_name.to_sym)
+          Dynamoid.logger.warn("Method #{method_name} generated for the field #{field_name} overrides already existing method")
         end
       end
     end

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -619,7 +619,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       let(:doc_class) do
         Class.new do
           include Dynamoid::Document
-          range range: :number
+          range :range, :number
           field :range2
           field :hash2
         end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -5,6 +5,60 @@ require 'spec_helper'
 describe Dynamoid::Fields do
   let(:address) { Address.new }
 
+
+  describe '.field' do
+    context 'generated method overrided existing one' do
+      let(:module_with_methods) do
+        Module.new do
+          def foo; end
+          def bar=; end
+          def baz?; end
+          def foobar_before_type_cast?; end
+        end
+      end
+
+      it 'warns about getter' do
+        message = 'Method foo generated for the field foo overrides already existing method'
+        expect(Dynamoid.logger).to receive(:warn).with(message)
+
+        new_class(module: module_with_methods, class_name: 'Foobar') do
+          include @helper_options[:module]
+          field :foo
+        end
+      end
+
+      it 'warns about setter' do
+        message = 'Method bar= generated for the field bar overrides already existing method'
+        expect(Dynamoid.logger).to receive(:warn).with(message)
+
+        new_class(module: module_with_methods) do
+          include @helper_options[:module]
+          field :bar
+        end
+      end
+
+      it 'warns about <name>?' do
+        message = 'Method baz? generated for the field baz overrides already existing method'
+        expect(Dynamoid.logger).to receive(:warn).with(message)
+
+        new_class(module: module_with_methods) do
+          include @helper_options[:module]
+          field :baz
+        end
+      end
+
+      it 'warns about <name>_before_type_cast' do
+        message = 'Method foobar_before_type_cast? generated for the field foobar overrides already existing method'
+        expect(Dynamoid.logger).to receive(:warn).with(message)
+
+        new_class(module: module_with_methods) do
+          include @helper_options[:module]
+          field :foobar
+        end
+      end
+    end
+  end
+
   it 'declares read attributes' do
     expect(address.city).to be_nil
   end

--- a/spec/support/helpers/new_class_helper.rb
+++ b/spec/support/helpers/new_class_helper.rb
@@ -28,6 +28,7 @@ module NewClassHelper
       end
 
       @class_name = class_name
+      @helper_options = options
 
       def self.name
         @class_name


### PR DESCRIPTION
It's a difficult issue to investigate when table attribute name conflicts with standard Object instance method or with some custom method.

So now when generated for a field methods like `<name>`, `<name>=`, `<name>?` override existing methods warning message will be printed - `Method foo generated for the field foo overrides already existing method`
