### PR TITLE
Repair Readme on http://rubydoc.info

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ end
 
 require 'yard'
 YARD::Rake::YardocTask.new do |t|
-  t.files   = ['lib/**/*.rb', 'README', 'LICENSE'] # optional
+  t.files   = ['lib/**/*.rb', 'README.md', 'LICENSE.txt'] # optional
   t.options = ['-m', 'markdown'] # optional
 end
 


### PR DESCRIPTION
Changes:
- fixed YARD configuration - use correct Readme file name

The documentation published on http://rubydoc.info was outdated and didn't include Readme.md file. 