### PR TITLE
Add `raise_error` option for `find` method

### DIFF
--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -19,6 +19,19 @@ module Dynamoid
     module ClassMethods
       # Find one or many objects, specified by one id or an array of ids.
       #
+      # By default it raises `RecordNotFound` exception if at least one model
+      # isn't found. This behavior can be changed with `raise_error` option. If
+      # specified `raise_error: false` option then `find` will not raise the
+      # exception.
+      #
+      # Please note that `find` doesn't preserve order of models in result when
+      # passes multiple ids.
+      #
+      # Supported following options:
+      # - `consistent_read`
+      # - `range_key`
+      # - `raise_error`
+      #
       # @param [Array/String] *id an array of ids or one single id
       # @param [Hash] options
       #
@@ -45,9 +58,9 @@ module Dynamoid
       # @since 0.2.0
       def find(*ids, **options)
         if ids.size == 1 && !ids[0].is_a?(Array)
-          _find_by_id(ids[0], options.merge(raise_error: true))
+          _find_by_id(ids[0], options.reverse_merge(raise_error: true))
         else
-          _find_all(ids.flatten(1), options.merge(raise_error: true))
+          _find_all(ids.flatten(1), options.reverse_merge(raise_error: true))
         end
       end
 

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -83,6 +83,26 @@ describe Dynamoid::Finders do
           expect(obj.id).to eql('1')
         end
       end
+
+      describe 'raise_error option' do
+        before do
+          klass.create_table
+        end
+
+        context 'when true' do
+          it 'leads to raising RecordNotFound exception if model not found' do
+            expect do
+              klass.find('blah-blah', raise_error: true)
+            end.to raise_error(Dynamoid::Errors::RecordNotFound)
+          end
+        end
+
+        context 'when true' do
+          it 'leads to not raising exception if model not found' do
+            expect(klass.find('blah-blah', raise_error: false)).to eq nil
+          end
+        end
+      end
     end
 
     context 'multiple primary keys provided' do
@@ -207,6 +227,31 @@ describe Dynamoid::Finders do
 
         expect(obj1).to be_persisted
         expect(obj2).to be_persisted
+      end
+
+      describe 'raise_error option' do
+        before do
+          klass.create_table
+        end
+
+        context 'when true' do
+          it 'leads to raising exception if model not found' do
+            obj = klass.create
+
+            expect do
+              klass.find([obj.id, 'blah-blah'], raise_error: true)
+            end.to raise_error(Dynamoid::Errors::RecordNotFound)
+          end
+        end
+
+        context 'when true' do
+          it 'leads to not raising exception if model not found' do
+            obj = klass.create
+
+            #expect(klass.find([obj.id, 'blah-blah'], raise_error: false)).to eq [obj]
+            expect(klass.find_all([obj.id, 'blah-blah'])).to eq [obj]
+          end
+        end
       end
 
       context 'field is not declared in document' do


### PR DESCRIPTION
Changes:
- `find` support new option `raise_error` to prevent raising `RecordNotFound` exception.

## Notes

Default behavior is the same - method `find` raises the exception if a model/models not found. With new option `raise_error: false` the method `find` works exactly like `find_all`. As far as `find_all` and `find_by_id` are deprecated we have to provide replacement with the same behavior.

So now any call of 
```ruby
Model.find_all(ids)
Model.find_by_id(id)
```
can be replaced with 
```ruby
Model.find(ids, raise_error: false)
Model.find(id, raise_error: false)
```