### PR TITLE
Support tables that use "hash_key" as their partition key name

### DIFF
--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -183,14 +183,14 @@ module Dynamoid #:nodoc:
     #
     # @since 0.4.0
     def hash_key
-      send(self.class.hash_key)
+      self[self.class.hash_key.to_sym]
     end
 
     # Assign an object's hash key, regardless of what it might be called to the object.
     #
     # @since 0.4.0
     def hash_key=(value)
-      send("#{self.class.hash_key}=", value)
+      self[self.class.hash_key.to_sym] = value
     end
 
     def range_value

--- a/spec/app/models/blog.rb
+++ b/spec/app/models/blog.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Blog
+  include Dynamoid::Document
+
+  table name: :blogs, key: :hash_key
+
+  field :title
+  field :content
+  field :likes, :integer
+end

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -172,6 +172,17 @@ describe Dynamoid::Document do
     expect(Tweet.write_capacity).to eq 200
   end
 
+  it 'supports tables with hash_key as the id' do
+    blog = Blog.create(title: 'Naming your partition key "hash_key"')
+
+    expect { blog.id }.to raise_error(NoMethodError)
+    expect(blog.hash_key).to_not be_nil
+    expect(Blog.table_name).to eq 'dynamoid_tests_blogs'
+    expect(Blog.hash_key).to eq :hash_key
+    expect(Blog.read_capacity).to eq 100
+    expect(Blog.write_capacity).to eq 20
+  end
+
   shared_examples 'it has equality testing and hashing' do
     it 'is equal to itself' do
       expect(document).to eq document


### PR DESCRIPTION
Working with tables that have their partition key set to "hash_key" causes a "stack level too deep" loop when looking up the symbol to reference the value. This CR updates the instances to make use `self` instead of `send` to look up the instance property when available, instead of making a call to the same instance method.