### PR TITLE
Add record_limit to Criteria::Chain#first

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -176,6 +176,25 @@ module Dynamoid
         end
       end
 
+      # Returns the first item matching the criteria.
+      #
+      #   Post.where(links_count: 2).first
+      #
+      # Applies `record_limit(1)` to ensure only a single record is fetched
+      # when no non-key conditions are present.
+      #
+      # If used without criteria it just returns the first item of some
+      # arbitrary order.
+      #
+      #   Post.first
+      #
+      # @return [Model|nil]
+      def first
+        return super if @key_fields_detector.non_key_present?
+
+        record_limit(1).to_a.first
+      end
+
       # Returns the last item matching the criteria.
       #
       #   Post.where(links_count: 2).last

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -181,7 +181,8 @@ module Dynamoid
       #   Post.where(links_count: 2).first
       #
       # Applies `record_limit(1)` to ensure only a single record is fetched
-      # when no non-key conditions are present.
+      # when no non-key conditions are present and `scan_limit(1)` when no
+      # conditions are present at all.
       #
       # If used without criteria it just returns the first item of some
       # arbitrary order.
@@ -190,6 +191,7 @@ module Dynamoid
       #
       # @return [Model|nil]
       def first
+        return scan_limit(1).to_a.first if @query.blank?
         return super if @key_fields_detector.non_key_present?
 
         record_limit(1).to_a.first

--- a/lib/dynamoid/criteria/key_fields_detector.rb
+++ b/lib/dynamoid/criteria/key_fields_detector.rb
@@ -10,6 +10,10 @@ module Dynamoid #:nodoc:
           @fields = query_hash.keys.map(&:to_s).map { |s| s.split('.').first }
         end
 
+        def contain_only?(field_names)
+          (@fields - field_names.map(&:to_s)).blank?
+        end
+
         def contain?(field_name)
           @fields.include?(field_name.to_s)
         end
@@ -24,6 +28,10 @@ module Dynamoid #:nodoc:
         @source = source
         @query = Query.new(query)
         @result = find_keys_in_query
+      end
+
+      def non_key_present?
+        !@query.contain_only?([hash_key, range_key].compact)
       end
 
       def key_present?

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -1438,47 +1438,47 @@ describe Dynamoid::Criteria::Chain do
       end
     end
 
-    it 'applies a record_limit' do
-      model.create(name: 'Bob', age: 5)
+    it 'applies a scan limit if no conditions are present' do
+      document = model.create(name: 'Bob', age: 5)
 
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:record_limit).with(1)
-      chain.first
+      expect(chain).to receive(:scan_limit).with(1).and_call_original
+      expect(chain.first).to eq(document)
     end
 
     it 'applies a record limit if only key conditions are present' do
-      model.create(name: 'Bob', age: 5)
+      document = model.create(name: 'Bob', age: 5)
 
       chain = Dynamoid::Criteria::Chain.new(model)
-      expect(chain).to receive(:record_limit).with(1)
-      chain.where(name: 'Bob', age: 5).first
+      expect(chain).to receive(:record_limit).with(1).and_call_original
+      expect(chain.where(name: 'Bob', age: 5).first).to eq(document)
     end
 
     it 'does not apply a record limit if the hash key is missing' do
-      model.create(name: 'Bob', city: 'New York', age: 5)
+      document = model.create(name: 'Bob', city: 'New York', age: 5)
 
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).not_to receive(:record_limit)
-      chain.where(age: 5).first
+      expect(chain.where(age: 5).first).to eq(document)
     end
 
     it 'does not apply a record limit if non-key conditions are present' do
-      model.create(name: 'Bob', city: 'New York', age: 5)
+      document = model.create(name: 'Bob', city: 'New York', age: 5)
 
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).not_to receive(:record_limit)
-      chain.where(city: 'New York').first
-      chain.where(name: 'Bob', city: 'New York').first
-      chain.where(name: 'Bob', age: 5, city: 'New York').first
+      expect(chain.where(city: 'New York').first).to eq(document)
+      expect(chain.where(name: 'Bob', city: 'New York').first).to eq(document)
+      expect(chain.where(name: 'Bob', age: 5, city: 'New York').first).to eq(document)
     end
 
     it 'does not apply a record limit if non-equality conditions are present' do
-      model.create(name: 'Bob', age: 5)
-      model.create(name: 'Alice', age: 6)
+      document1 = model.create(name: 'Bob', age: 5)
+      document2 = model.create(name: 'Alice', age: 6)
 
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).not_to receive(:record_limit)
-      chain.where('name.gt': 'Alice').first
+      expect(chain.where('name.gt': 'Alice').first).to eq(document1)
     end
 
     it 'returns nil if no matching document is present' do
@@ -1488,17 +1488,17 @@ describe Dynamoid::Criteria::Chain do
     end
 
     it 'returns the first document with regards to the sort order' do
-      customer1 = model.create(name: 'Bob', age: 5)
-      customer2 = model.create(name: 'Bob', age: 9)
-      customer3 = model.create(name: 'Bob', age: 12)
+      document1 = model.create(name: 'Bob', age: 5)
+      document2 = model.create(name: 'Bob', age: 9)
+      document3 = model.create(name: 'Bob', age: 12)
 
       expect(model.first.age).to eq(5)
     end
 
     it 'returns the first document matching the criteria and with regards to the sort order' do
-      customer1 = model.create(name: 'Bob', age: 4)
-      customer3 = model.create(name: 'Alice', age: 6)
-      customer4 = model.create(name: 'Alice', age: 8)
+      document1 = model.create(name: 'Bob', age: 4)
+      document3 = model.create(name: 'Alice', age: 6)
+      document4 = model.create(name: 'Alice', age: 8)
 
       expect(model.where(name: 'Alice').first.age).to eq(6)
     end


### PR DESCRIPTION
Hi, thanks for this nice gem. I recognized `Criteria::Chain#first` basically fetches all records matching the criteria and then returns just the first document. This is rather inefficient, such that this PR applies `record_limit(1)` within `#first`. However, i'm still a bit new to dynamo/dynamoid, so maybe i'm not yet aware of any complications this could introduce.