### PR TITLE
Support n parameter in Criteria::Chain#first

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -190,11 +190,13 @@ module Dynamoid
       #   Post.first
       #
       # @return [Model|nil]
-      def first
-        return scan_limit(1).to_a.first if @query.blank?
+      def first(*args)
+        n = args.first || 1
+
+        return scan_limit(n).to_a.first(*args) if @query.blank?
         return super if @key_fields_detector.non_key_present?
 
-        record_limit(1).to_a.first
+        record_limit(n).to_a.first(*args)
       end
 
       # Returns the last item matching the criteria.

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -1446,12 +1446,32 @@ describe Dynamoid::Criteria::Chain do
       expect(chain.first).to eq(document)
     end
 
+    it 'applies the correct scan limit if no conditions are present' do
+      document1 = model.create(name: 'Bob', age: 5)
+      document2 = model.create(name: 'Bob', age: 6)
+      document3 = model.create(name: 'Bob', age: 7)
+
+      chain = Dynamoid::Criteria::Chain.new(model)
+      expect(chain).to receive(:scan_limit).with(2).and_call_original
+      expect(chain.first(2).to_set).to eq([document1, document2].to_set)
+    end
+
     it 'applies a record limit if only key conditions are present' do
       document = model.create(name: 'Bob', age: 5)
 
       chain = Dynamoid::Criteria::Chain.new(model)
       expect(chain).to receive(:record_limit).with(1).and_call_original
       expect(chain.where(name: 'Bob', age: 5).first).to eq(document)
+    end
+
+    it 'applies the correct record limit if only key conditions are present' do
+      document1 = model.create(name: 'Bob', age: 5)
+      document2 = model.create(name: 'Bob', age: 6)
+      document3 = model.create(name: 'Bob', age: 7)
+
+      chain = Dynamoid::Criteria::Chain.new(model)
+      expect(chain).to receive(:record_limit).with(2).and_call_original
+      expect(chain.where(name: 'Bob').first(2)).to eq([document1, document2])
     end
 
     it 'does not apply a record limit if the hash key is missing' do


### PR DESCRIPTION
I recognized we forgot about the optional n parameter in Criteria::Chain#first, such that this PR adds support for it by applying the param to scan_limit respectively record_limit.