### PR TITLE
Fix Ruby 2.7 keyword argument deprecation warnings

### DIFF
--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -155,9 +155,15 @@ module Dynamoid
     #
     # @since 0.2.0
     def method_missing(method, *args, &block)
-      return benchmark(method, *args) { adapter.send(method, *args, &block) } if adapter.respond_to?(method)
+      super unless adapter.respond_to?(method)
 
-      super
+      if args.last.is_a?(Hash)
+        return benchmark(method, *args[0..-2], **args.last) do
+          adapter.send(method, *args[0..-2], **args.last, &block)
+        end
+      end
+
+      benchmark(method, *args) { adapter.send(method, *args, &block) }
     end
 
     # Query the DynamoDB table. This employs DynamoDB's indexes so is generally faster than scanning, but is

--- a/lib/dynamoid/loadable.rb
+++ b/lib/dynamoid/loadable.rb
@@ -23,7 +23,7 @@ module Dynamoid
         options[:range_key] = range_value
       end
 
-      self.attributes = self.class.find(hash_key, options).attributes
+      self.attributes = self.class.find(hash_key, **options).attributes
       @associations.values.each(&:reset)
       self
     end

--- a/lib/dynamoid/persistence/update_fields.rb
+++ b/lib/dynamoid/persistence/update_fields.rb
@@ -4,7 +4,7 @@ module Dynamoid
   module Persistence
     class UpdateFields
       def self.call(*args)
-        new(*args).call
+        new(args.first, **args.last).call
       end
 
       def initialize(model_class, partition_key:, sort_key:, attributes:, conditions:)

--- a/lib/dynamoid/persistence/upsert.rb
+++ b/lib/dynamoid/persistence/upsert.rb
@@ -4,7 +4,7 @@ module Dynamoid
   module Persistence
     class Upsert
       def self.call(*args)
-        new(*args).call
+        new(args.first, **args.last).call
       end
 
       def initialize(model_class, partition_key:, sort_key:, attributes:, conditions:)

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -339,6 +339,10 @@ describe Dynamoid::Document do
       end
     end
 
+    it 'does not output a deprecation warning' do
+      expect { model.create }.to_not output(/is deprecated/).to_stderr
+    end
+
     it 'sets default value at the updating' do
       obj = model.create
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -1118,6 +1118,14 @@ describe Dynamoid::Persistence do
       end
     end
 
+    it 'does not output a deprecation warning' do
+      document_class.create_table
+
+      expect do
+        document_class.update_fields('some-fake-id', title: 'Title')
+      end.not_to output(/is deprecated/).to_stderr
+    end
+
     it 'does not create new document if it does not exist yet' do
       document_class.create_table
 
@@ -1243,6 +1251,13 @@ describe Dynamoid::Persistence do
         field :version, :integer
         field :published_on, :date
       end
+    end
+
+    it 'does not output a deprecation warning' do
+      obj = document_class.create(title: 'Old title')
+      expect do
+        document_class.upsert(obj.id, title: 'New title')
+      end.to_not output(/is deprecated/).to_stderr
     end
 
     it 'changes field value' do


### PR DESCRIPTION
Serveral methods had been written in a way that calling them resulted in the
following deprecation warning when using Dynamoid with Ruby 2.7:

warning: Using the last argument as keyword parameters is deprecated; maybe **
should be added to the call

This change rectifies this by explicitly using keyword arguments instead of
implicitly relying on Ruby to do the right thing.