### PR TITLE
Replace NullLogger with Logger.new(nil)

### DIFF
--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activemodel',      '>=4'
   spec.add_runtime_dependency 'aws-sdk-dynamodb', '~> 1.0'
   spec.add_runtime_dependency 'concurrent-ruby',  '>= 1.0'
-  spec.add_runtime_dependency 'null-logger'
 
   spec.add_development_dependency 'appraisal',  '~> 2.2'
   spec.add_development_dependency 'bundler'

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -2,7 +2,6 @@
 
 require 'uri'
 require 'logger'
-require 'null_logger'
 require 'dynamoid/config/options'
 require 'dynamoid/config/backoff_strategies/constant_backoff'
 require 'dynamoid/config/backoff_strategies/exponential_backoff'
@@ -78,7 +77,7 @@ module Dynamoid
     # @since 0.2.0
     def logger=(logger)
       case logger
-      when false, nil then @logger = NullLogger.new
+      when false, nil then @logger = ::Logger.new(nil)
       when true then @logger = default_logger
       else
         @logger = logger if logger.respond_to?(:info)


### PR DESCRIPTION
https://github.com/Dynamoid/dynamoid/issues/449

NullLogger is GNU LGPL v3 license which may limit commercial use.
To avoid that, use `Logger.new(nil)` instead.
