### PR TITLE
Fix issue with using type attribute as a GSI hash key

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -629,15 +629,7 @@ module Dynamoid
 
         # Add range key
         if @key_fields_detector.range_key
-          opts[:range_key] = @key_fields_detector.range_key
-          if query[@key_fields_detector.range_key].present?
-            value = type_cast_condition_parameter(@key_fields_detector.range_key, query[@key_fields_detector.range_key])
-            opts.update(range_eq: value)
-          end
-
-          query.keys.select { |k| k.to_s =~ /^#{@key_fields_detector.range_key}\./ }.each do |key|
-            opts.merge!(range_hash(key))
-          end
+          add_range_key_to_range_query(query, opts)
         end
 
         (query.keys.map(&:to_sym) - [@key_fields_detector.hash_key.to_sym, @key_fields_detector.range_key.try(:to_sym)])
@@ -652,6 +644,18 @@ module Dynamoid
         end
 
         opts.merge(query_opts).merge(consistent_opts)
+      end
+
+      def add_range_key_to_range_query(query, opts)
+        opts[:range_key] = @key_fields_detector.range_key
+        if query[@key_fields_detector.range_key].present?
+          value = type_cast_condition_parameter(@key_fields_detector.range_key, query[@key_fields_detector.range_key])
+          opts.update(range_eq: value)
+        end
+
+        query.keys.select { |k| k.to_s =~ /^#{@key_fields_detector.range_key}\./ }.each do |key|
+          opts.merge!(range_hash(key))
+        end
       end
 
       # TODO: casting should be operator aware

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -22,12 +22,6 @@ module Dynamoid
         @consistent_read = false
         @scan_index_forward = true
 
-        # Honor STI and :type field if it presents
-        type = @source.inheritance_field
-        if @source.attributes.key?(type)
-          @query[:"#{type}.in"] = @source.deep_subclasses.map(&:name) << @source.name
-        end
-
         # we should re-initialize keys detector every time we change query
         @key_fields_detector = KeyFieldsDetector.new(@query, @source)
       end
@@ -621,6 +615,13 @@ module Dynamoid
 
       def range_query
         opts = {}
+        query = self.query
+
+        # Honor STI and :type field if it presents
+        if @source.attributes.key?(@source.inheritance_field) &&
+             @key_fields_detector.hash_key.to_sym != @source.inheritance_field.to_sym
+          query.update(sti_condition)
+        end
 
         # Add hash key
         opts[:hash_key] = @key_fields_detector.hash_key
@@ -714,6 +715,13 @@ module Dynamoid
       end
 
       def scan_query
+        query = self.query
+
+        # Honor STI and :type field if it presents
+        if sti_condition
+          query.update(sti_condition)
+        end
+
         {}.tap do |opts|
           query.keys.map(&:to_sym).each do |key|
             if key.to_s.include?('.')
@@ -735,6 +743,18 @@ module Dynamoid
         opts[:consistent_read] = true if @consistent_read
         opts[:project] = @project
         opts
+      end
+
+      def sti_condition
+        condition = {}
+        type = @source.inheritance_field
+
+        if @source.attributes.key?(type)
+          class_names = @source.deep_subclasses.map(&:name) << @source.name
+          condition[:"#{type}.in"] = class_names
+        end
+
+        condition
       end
     end
   end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -1144,6 +1144,24 @@ describe Dynamoid::Criteria::Chain do
         end
       end
     end
+
+    # Regression
+    # https://github.com/Dynamoid/dynamoid/issues/435
+    context 'when inheritance field (:type by default) is a GSI hash key' do
+      it 'works without exception' do
+        UserWithGSI = new_class class_name: 'UserWithGSI' do
+          field :type
+
+          global_secondary_index hash_key: :type,
+                                 range_key: :created_at,
+                                 projected_attributes: :all
+        end
+        obj = UserWithGSI.create
+
+        actual = UserWithGSI.where(type: 'UserWithGSI').all.to_a
+        expect(actual).to eq [obj]
+      end
+    end
   end
 
   describe '#find_by_pages' do


### PR DESCRIPTION
Closes https://github.com/Dynamoid/dynamoid/issues/435

Don't filter by `type` attribute (in order to support STI and fetch only instances of current class and its subclasses) when GSI index is used with `type` attribute as a hash key