### PR TITLE
Add block argument to create/create! methods

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -162,22 +162,29 @@ module Dynamoid
       #
       # Initializes a new model and immediately saves it to DynamoDB.
       #
-      #   user = User.create(first_name: 'Mark', last_name: 'Tyler')
+      #   User.create(first_name: 'Mark', last_name: 'Tyler')
       #
       # Accepts both Hash and Array of Hashes and can create several models.
       #
-      #   users = User.create([{ first_name: 'Alice' }, { first_name: 'Bob' }])
+      #   User.create([{ first_name: 'Alice' }, { first_name: 'Bob' }])
+      #
+      # Creates a model and pass it into a block to set other attributes.
+      #
+      #   User.create(first_name: 'Mark') do |u|
+      #     u.age = 21
+      #   end
       #
       # Validates model and runs callbacks.
       #
       # @param attrs [Hash|Array[Hash]] Attributes of the models
+      # @param block [Proc] Block to process a document after initialization
       # @return [Dynamoid::Document] The created document
       # @since 0.2.0
-      def create(attrs = {})
+      def create(attrs = {}, &block)
         if attrs.is_a?(Array)
-          attrs.map { |attr| create(attr) }
+          attrs.map { |attr| create(attr, &block) }
         else
-          build(attrs).tap(&:save)
+          build(attrs, &block).tap(&:save)
         end
       end
 
@@ -189,13 +196,14 @@ module Dynamoid
       # models.
       #
       # @param attrs [Hash|Array[Hash]] Attributes with which to create the object.
+      # @param block [Proc] Block to process a document after initialization
       # @return [Dynamoid::Document] The created document
       # @since 0.2.0
-      def create!(attrs = {})
+      def create!(attrs = {}, &block)
         if attrs.is_a?(Array)
-          attrs.map { |attr| create!(attr) }
+          attrs.map { |attr| create!(attr, &block) }
         else
-          build(attrs).tap(&:save!)
+          build(attrs, &block).tap(&:save!)
         end
       end
 

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -661,7 +661,7 @@ module Dynamoid
     # default is 1). Only makes sense for number-based attributes.
     #
     #   user.increment(:followers_count)
-    #   user.increment(followers_count: 2)
+    #   user.increment(:followers_count, 2)
     #
     # @param attribute [Symbol] attribute name
     # @param by [Numeric] value to add (optional)
@@ -678,7 +678,7 @@ module Dynamoid
     # default is 1). Only makes sense for number-based attributes.
     #
     #   user.increment!(:followers_count)
-    #   user.increment!(followers_count: 2)
+    #   user.increment!(:followers_count, 2)
     #
     # Returns +true+ if a model was saved and +false+ otherwise.
     #
@@ -696,7 +696,7 @@ module Dynamoid
     # (by default is 1). Only makes sense for number-based attributes.
     #
     #   user.decrement(:followers_count)
-    #   user.decrement(followers_count: 2)
+    #   user.decrement(:followers_count, 2)
     #
     # @param attribute [Symbol] attribute name
     # @param by [Numeric] value to subtract (optional)
@@ -713,7 +713,7 @@ module Dynamoid
     # (by default is 1). Only makes sense for number-based attributes.
     #
     #   user.decrement!(:followers_count)
-    #   user.decrement!(followers_count: 2)
+    #   user.decrement!(:followers_count, 2)
     #
     # Returns +true+ if a model was saved and +false+ otherwise.
     #

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -62,6 +62,22 @@ describe Dynamoid::Document do
   end
 
   describe '#initialize' do
+    let(:klass) do
+      new_class do
+        field :foo
+      end
+    end
+
+    context 'when block specified' do
+      it 'calls a block and passes a model as argument' do
+        object = klass.new(foo: 'bar') do |obj|
+          obj.foo = 'baz'
+        end
+
+        expect(object.foo).to eq('baz')
+      end
+    end
+
     describe 'type casting' do
       let(:klass) do
         new_class do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -622,6 +622,25 @@ describe Dynamoid::Persistence do
       expect(addresses[1].city).to eq 'New York'
     end
 
+    context 'when block specified' do
+      it 'calls a block and passes a model as argument' do
+        object = klass.create(city: 'a') do |obj|
+          obj.city = 'b'
+        end
+
+        expect(object.city).to eq('b')
+      end
+
+      it 'calls a block and passes each model as argument if there are multiple models' do
+        objects = klass.create([{ city: 'a' }, { city: 'b' }]) do |obj|
+          obj.city = obj.city * 2
+        end
+
+        expect(objects[0].city).to eq('aa')
+        expect(objects[1].city).to eq('bb')
+      end
+    end
+
     describe 'validation' do
       let(:klass_with_validation) do
         new_class do
@@ -787,6 +806,31 @@ describe Dynamoid::Persistence do
   end
 
   describe '.create!' do
+    let(:klass) do
+      new_class do
+        field :city
+      end
+    end
+
+    context 'when block specified' do
+      it 'calls a block and passes a model as argument' do
+        object = klass.create!(city: 'a') do |obj|
+          obj.city = 'b'
+        end
+
+        expect(object.city).to eq('b')
+      end
+
+      it 'calls a block and passes each model as argument if there are multiple models' do
+        objects = klass.create!([{ city: 'a' }, { city: 'b' }]) do |obj|
+          obj.city = obj.city * 2
+        end
+
+        expect(objects[0].city).to eq('aa')
+        expect(objects[1].city).to eq('bb')
+      end
+    end
+
     context 'validation' do
       let(:klass_with_validation) do
         new_class do


### PR DESCRIPTION
`create` method accepts now optional block argument like `ActiveRecord::Base.create` method does.

https://api.rubyonrails.org/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-create

Example:

```ruby
User.create(first_name: 'Mark') do |u|
  u.age = 21
end
```