### PR TITLE
Check if required range key argument if missing in .find method

### DIFF
--- a/lib/dynamoid/finders.rb
+++ b/lib/dynamoid/finders.rb
@@ -25,6 +25,10 @@ module Dynamoid
       # specified +raise_error: false+ option then +find+ will not raise the
       # exception.
       #
+      # When a document schema includes range key it always should be specified
+      # in +find+ method call. In case it's missing +MissingRangeKey+ exception
+      # will be raised.
+      #
       # Please note that +find+ doesn't preserve order of models in result when
       # passes multiple ids.
       #
@@ -114,6 +118,8 @@ module Dynamoid
 
       # @private
       def _find_all(ids, options = {})
+        raise Errors::MissingRangeKey if range_key && ids.any? { |pk, sk| sk.nil? }
+
         if range_key
           ids = ids.map do |pk, sk|
             sk_casted = TypeCasting.cast_field(sk, attributes[range_key])
@@ -156,6 +162,8 @@ module Dynamoid
 
       # @private
       def _find_by_id(id, options = {})
+        raise Errors::MissingRangeKey if range_key && options[:range_key].nil?
+
         if range_key
           key = options[:range_key]
           key_casted = TypeCasting.cast_field(key, attributes[range_key])

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -58,6 +58,14 @@ describe Dynamoid::Finders do
           obj = klass_with_date.create(published_on: date)
           expect(klass_with_date.find(obj.id, range_key: date)).to eql(obj)
         end
+
+        it 'raises MissingRangeKey when range key is not specified' do
+          obj = klass_with_composite_key.create(age: 12)
+
+          expect {
+            klass_with_composite_key.find(obj.id)
+          }.to raise_error(Dynamoid::Errors::MissingRangeKey)
+        end
       end
 
       it 'returns persisted? object' do
@@ -215,6 +223,14 @@ describe Dynamoid::Finders do
           expect(
             klass_with_date.find([[obj1.id, obj1.published_on], [obj2.id, obj2.published_on]])
           ).to match_array([obj1, obj2])
+        end
+
+        it 'raises MissingRangeKey when range key is not specified' do
+          obj1, obj2 = klass_with_composite_key.create([{ age: 1 }, { age: 2 }])
+
+          expect {
+            klass_with_composite_key.find([obj1.id, obj2.id])
+          }.to raise_error(Dynamoid::Errors::MissingRangeKey)
         end
       end
 


### PR DESCRIPTION
Address an issue mentioned in https://github.com/Dynamoid/dynamoid/issues/364.

When `find` method is called without required range key instead of 

```
Aws::DynamoDB::Errors::ValidationException (The number of conditions on the keys is invalid)
```

`Dynamoid::Errors::MissingRangeKey` exception will be raised