### PR TITLE
Get rid of some YARD errors/warnings

### DIFF
--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -79,8 +79,8 @@ module Dynamoid
     #
     # @param [String] table the name of the table to write the object to
     # @param [Array] ids to fetch, can also be a string of just one id
-    # @param [Hash] options: Passed to the underlying query. The :range_key option is required whenever the table has a range key,
-    #                        unless multiple ids are passed in.
+    # @param [Hash] options Passed to the underlying query. The :range_key option is required whenever the table has a range key,
+    #                       unless multiple ids are passed in.
     #
     # @since 0.2.0
     def read(table, ids, options = {}, &blk)
@@ -95,7 +95,9 @@ module Dynamoid
     #
     # @param [String] table the name of the table to write the object to
     # @param [Array] ids to delete, can also be a string of just one id
-    # @param [Hash] range_key of the record to delete, can also be a string of just one range_key
+    # @param [Hash] options allowed only +range_key+ - range key or array of
+    #                       range keys of the record to delete, can also be
+    #                       a string of just one range_key, and +conditions+
     #
     def delete(table, ids, options = {})
       range_key = options[:range_key] # array of range keys that matches the ids passed in
@@ -116,7 +118,7 @@ module Dynamoid
     # Scans a table. Generally quite slow; try to avoid using scan if at all possible.
     #
     # @param [String] table the name of the table to write the object to
-    # @param [Hash] scan_hash a hash of attributes: matching records will be returned by the scan
+    # @param [Hash] query a hash of attributes: matching records will be returned by the scan
     #
     # @since 0.2.0
     def scan(table, query = {}, opts = {})

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -65,8 +65,8 @@ module Dynamoid
       # Build an array of values for Condition
       # Is used in ScanFilter and QueryFilter
       # https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html
-      # @params [String] operator: value of RANGE_MAP or FIELD_MAP hash, e.g. "EQ", "LT" etc
-      # @params [Object] value: scalar value or array/set
+      # @param [String] operator value of RANGE_MAP or FIELD_MAP hash, e.g. "EQ", "LT" etc
+      # @param [Object] value scalar value or array/set
       def self.attribute_value_list(operator, value)
         # For BETWEEN and IN operators we should keep value as is (it should be already an array)
         # NULL and NOT_NULL require absence of attribute list
@@ -142,9 +142,9 @@ module Dynamoid
       #   end
       #
       # @param [String] table_name the name of the table
-      # @param [Array]  items to be processed
-      # @param [Hash]   additional options
-      # @param [Proc]   optional block
+      # @param [Array]  objects to be processed
+      # @param [Hash]   options additional options
+      # @yield [true|false] invokes an optional block with argument - whether there are unprocessed items
       #
       # See:
       # * http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
@@ -199,9 +199,9 @@ module Dynamoid
       #     end
       #   end
       #
-      # @param [Hash] table_ids the hash of tables and IDs to retrieve
+      # @param [Hash] table_names_with_ids the hash of tables and IDs to retrieve
       # @param [Hash] options to be passed to underlying BatchGet call
-      # @param [Proc] optional block can be passed to handle each batch of items
+      # @param [Proc] block optional block can be passed to handle each batch of items
       #
       # @return [Hash] a hash where keys are the table names and the values are the retrieved items
       #

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/create_table.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/create_table.rb
@@ -88,9 +88,9 @@ module Dynamoid
         # Builds aws attributes definitions based off of primary hash/range and
         # secondary indexes
         #
-        # @param key_data
-        # @option key_data [Hash] hash_key_schema - eg: {:id => :string}
-        # @option key_data [Hash] range_key_schema - eg: {:created_at => :number}
+        # @param key_schema
+        # @option key_schema [Hash] hash_key_schema - eg: {:id => :string}
+        # @option key_schema [Hash] range_key_schema - eg: {:created_at => :number}
         # @param [Hash] secondary_indexes
         # @option secondary_indexes [Array<Dynamoid::Indexes::Index>] :local_secondary_indexes
         # @option secondary_indexes [Array<Dynamoid::Indexes::Index>] :global_secondary_indexes
@@ -131,8 +131,8 @@ module Dynamoid
         end
 
         # Builds an attribute definitions based on hash key and range key
-        # @params [Hash] hash_key_schema - eg: {:id => :string}
-        # @params [Hash] range_key_schema - eg: {:created_at => :datetime}
+        # @param [Hash] hash_key_schema - eg: {:id => :string}
+        # @param [Hash] range_key_schema - eg: {:created_at => :datetime}
         # @return [Array]
         def build_attribute_definitions(hash_key_schema, range_key_schema = nil)
           attrs = []
@@ -153,8 +153,8 @@ module Dynamoid
         end
 
         # Builds an aws attribute definition based on name and dynamoid type
-        # @params [Symbol] name - eg: :id
-        # @params [Symbol] dynamoid_type - eg: :string
+        # @param [Symbol] name - eg: :id
+        # @param [Symbol] dynamoid_type - eg: :string
         # @return [Hash]
         def attribute_definition_element(name, dynamoid_type)
           aws_type = api_type(dynamoid_type)

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
@@ -21,8 +21,8 @@ module Dynamoid
         # Adds the given values to the values already stored in the corresponding columns.
         # The column must contain a Set or a number.
         #
-        # @param [Hash] vals keys of the hash are the columns to update, vals are the values to
-        #               add. values must be a Set, Array, or Numeric
+        # @param [Hash] values keys of the hash are the columns to update, values
+        #                      are the values to add. values must be a Set, Array, or Numeric
         #
         def add(values)
           @additions.merge!(sanitize_attributes(values))


### PR DESCRIPTION
There were plenty of warnings:
- `Unknown tag @params`
- `@param tag has unknown parameter name: ...`

Currently there are only warnings for bash scripts and Readme.md file

```shell
$ yard doc
[warn]: Syntax error in `bin/setup`:(2,17): syntax error, unexpected local variable or method, expecting `do' or '{' or '('
[warn]: Syntax error in `bin/stop_dynamodblocal`:(4,1): syntax error, unexpected '.'
[warn]: Syntax error in `bin/start_dynamodblocal`:(4,1): syntax error, unexpected '.'
[warn]: In file `README.md':1236: Cannot resolve link to Dynamoid::Config.namespace from text:
	...{Dynamoid::Config.namespace}...
[warn]: In file `README.md':1236: Cannot resolve link to Dynamoid::Config.namespace from text:
	...{Dynamoid::Config.namespace}...
Files:          38
Modules:        24 (   14 undocumented)
Classes:        26 (   16 undocumented)
Constants:      25 (   25 undocumented)
Attributes:     31 (    0 undocumented)
Methods:       229 (   67 undocumented)
 63.58% documented
```
