### PR TITLE
Add binary type

### DIFF
--- a/.document
+++ b/.document
@@ -1,5 +1,0 @@
-lib/**/*.rb
-bin/*
-- 
-features/**/*.feature
-LICENSE.txt

--- a/README.md
+++ b/README.md
@@ -212,16 +212,17 @@ each field. Every field on the object must be included here; if you miss
 any they'll be completely bypassed during DynamoDB's initialization and
 will not appear on the model objects.
 
-By default, fields are assumed to be of type `:string`. Other built-in
-types are `:integer`, `:number`, `:set`, `:array`, `:map`, `:datetime`,
-`date`, `:boolean`, `:raw` and `:serialized`. `array` and `map` match
-List and Map DynamoDB types respectively. `raw` type means you can store
-Ruby Array, Hash, String and numbers. If built-in types do not suit you,
-you can use a custom field type represented by an arbitrary class,
-provided that the class supports a compatible serialization interface.
-The primary use case for using a custom field type is to represent your
-business logic with high-level types, while ensuring portability or
-backward-compatibility of the serialized representation.
+By default, fields are assumed to be of type `string`. Other built-in
+types are `integer`, `number`, `set`, `array`, `map`, `datetime`,
+`date`, `boolean`, `binary`, `raw` and `serialized`. `array` and
+`map` match List and Map DynamoDB types respectively. `raw` type means
+you can store Ruby Array, Hash, String and numbers. If built-in types do
+not suit you, you can use a custom field type represented by an
+arbitrary class, provided that the class supports a compatible
+serialization interface.  The primary use case for using a custom field
+type is to represent your business logic with high-level types, while
+ensuring portability or backward-compatibility of the serialized
+representation.
 
 #### Note on boolean type
 

--- a/lib/dynamoid/dumping.rb
+++ b/lib/dynamoid/dumping.rb
@@ -36,6 +36,7 @@ module Dynamoid
                      when :serialized then SerializedDumper
                      when :raw        then RawDumper
                      when :boolean    then BooleanDumper
+                     when :binary     then BinaryDumper
                      when Class       then CustomTypeDumper
                      end
 
@@ -285,6 +286,13 @@ module Dynamoid
             value.to_s[0] # => "f" or "t"
           end
         end
+      end
+    end
+
+    # string -> string
+    class BinaryDumper < Base
+      def process(value)
+        Base64.strict_encode64(value)
       end
     end
 

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -44,8 +44,10 @@ module Dynamoid
       #
       # Its type determines how it is coerced when read in and out of the
       # datastore. You can specify +string+, +integer+, +number+, +set+, +array+,
-      # +map+, +datetime+, +date+, +serialized+, +raw+ and +boolean+ or specify a
-      # class that defines a serialization strategy.
+      # +map+, +datetime+, +date+, +serialized+, +raw+, +boolean+ and +binary+
+      # or specify a class that defines a serialization strategy.
+      #
+      # By default field type is +string+.
       #
       # Set can store elements of the same type only (it's a limitation of
       # DynamoDB itself). If a set should store elements only some particular
@@ -71,7 +73,7 @@ module Dynamoid
       #
       #   field :published_on, :datetime, store_as_string: true
       #
-      # Boolean field by default is stored as a string +t+ or 'f'. But DynamoDB
+      # Boolean field by default is stored as a string +t+ or +f+. But DynamoDB
       # supports boolean type natively. In order to switch to the native
       # boolean type an option +store_as_native_boolean+ should be specified:
       #

--- a/lib/dynamoid/type_casting.rb
+++ b/lib/dynamoid/type_casting.rb
@@ -36,6 +36,7 @@ module Dynamoid
                           when :raw        then RawTypeCaster
                           when :serialized then SerializedTypeCaster
                           when :boolean    then BooleanTypeCaster
+                          when :binary     then BinaryTypeCaster
                           when Class       then CustomTypeCaster
                           end
 
@@ -280,6 +281,16 @@ module Dynamoid
           false
         else
           true
+        end
+      end
+    end
+
+    class BinaryTypeCaster < Base
+      def process(value)
+        if value.is_a? String
+          value.dup
+        else
+          value.to_s
         end
       end
     end

--- a/lib/dynamoid/undumping.rb
+++ b/lib/dynamoid/undumping.rb
@@ -39,6 +39,7 @@ module Dynamoid
                        when :raw        then RawUndumper
                        when :serialized then SerializedUndumper
                        when :boolean    then BooleanUndumper
+                       when :binary     then BinaryUndumper
                        when Class       then CustomTypeUndumper
                        end
 
@@ -260,6 +261,12 @@ module Dynamoid
         else
           raise ArgumentError, 'Boolean column neither true nor false'
         end
+      end
+    end
+
+    class BinaryUndumper < Base
+      def process(value)
+        Base64.strict_decode64(value)
       end
     end
 

--- a/spec/dynamoid/dumping_spec.rb
+++ b/spec/dynamoid/dumping_spec.rb
@@ -1491,4 +1491,21 @@ describe 'Dumping' do
       end
     end
   end
+
+  describe 'Binary field' do
+    let(:klass) do
+      new_class do
+        field :image, :binary
+      end
+    end
+
+    let(:binary_value) { "\x00\x88\xFF".dup.force_encoding('ASCII-8BIT') }
+
+    it "encodes a string in base64-encoded format" do
+      obj = klass.create(image: binary_value)
+
+      expect(reload(obj).image).to eql(binary_value)
+      expect(raw_attributes(obj)[:image]).to eql(Base64.strict_encode64(binary_value))
+    end
+  end
 end

--- a/spec/dynamoid/type_casting_spec.rb
+++ b/spec/dynamoid/type_casting_spec.rb
@@ -653,6 +653,30 @@ describe 'Type casting' do
     end
   end
 
+  describe 'Binary field' do
+    let(:klass) do
+      new_class do
+        field :image, :binary
+      end
+    end
+
+    it 'converts to string with #to_s method' do
+      value = double('object')
+      allow(value).to receive(:to_s).and_return('string representation')
+
+      obj = klass.new(image: value)
+      expect(obj.image).to eql('string representation')
+    end
+
+    it 'dups a string' do
+      value = 'foo'
+      obj = klass.new(image: value)
+
+      expect(obj.image).to eql(value)
+      expect(obj.image).not_to equal(value)
+    end
+  end
+
   describe 'Serialized field' do
   end
 


### PR DESCRIPTION
The only not supported DynamoDB data type is [Binary](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Binary).

Now it's possible to declare `:binary` field and automatically encode and decode 'ASCII-8BIT' strings in Base64 format.

```ruby
class User
  include Dynamoid::Document

  field :image, :binary
end
```