### PR TITLE
Allow attribute deletion without a value

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
@@ -59,9 +59,9 @@ module Dynamoid
           end
           @deletions.each do |k, v|
             ret[k.to_s] = {
-              action: DELETE,
-              value: v
+              action: DELETE
             }
+            ret[k.to_s][:value] = v unless v.nil?
           end
           @updates.each do |k, v|
             ret[k.to_s] = {

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -1151,6 +1151,16 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         expect(Dynamoid.adapter.get_item(test_table1, '1')).to include(expected_attributes)
       end
 
+      it 'deletes attributes' do
+        Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh', hobbies: %w[skying climbing].to_set)
+
+        Dynamoid.adapter.update_item(test_table1, '1') do |t|
+          t.delete(hobbies: nil)
+        end
+
+        expect(Dynamoid.adapter.get_item(test_table1, '1')).not_to include(:hobbies)
+      end
+
       it 'sets attribute values' do
         Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
 


### PR DESCRIPTION
Currently it seems that once an attribute is created, it can only be set to null, or - if it is a set/array - a value can be deleted from it.

With this change, the attribute appears to be deleteable entirely.