### PR TITLE
Raising UnknownAttribute when adding an attribute not in the model

### DIFF
--- a/lib/dynamoid/errors.rb
+++ b/lib/dynamoid/errors.rb
@@ -75,5 +75,7 @@ module Dynamoid
     class InvalidQuery < Error; end
 
     class UnsupportedKeyType < Error; end
+
+    class UnknownAttribute < Error; end
   end
 end

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -309,6 +309,10 @@ module Dynamoid
     def write_attribute(name, value)
       name = name.to_sym
 
+      unless attribute_is_present_on_model?(name)
+        raise Dynamoid::Errors::UnknownAttribute.new("Attribute #{name} is not part of the model")
+      end
+
       if association = @associations[name]
         association.reset
       end
@@ -404,6 +408,11 @@ module Dynamoid
       if self.class.attributes[type] && send(type).nil?
         send("#{type}=", self.class.name)
       end
+    end
+
+    def attribute_is_present_on_model?(attribute_name)
+      setter = "#{attribute_name}=".to_sym
+      respond_to?(setter)
     end
   end
 end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -277,6 +277,9 @@ module Dynamoid
       # +update_fields+ uses the +UpdateItem+ operation so it saves changes and
       # loads an updated document back with one HTTP request.
       #
+      # Raises a +Dynamoid::Errors::UnknownAttribute+ exception if any of the
+      # attributes is not on the model
+      #
       # @param hash_key_value [Scalar value] hash key
       # @param range_key_value [Scalar value] range key (optional)
       # @param attrs [Hash]
@@ -324,6 +327,9 @@ module Dynamoid
       #
       # +upsert+ uses the +UpdateItem+ operation so it saves changes and loads
       # an updated document back with one HTTP request.
+      #
+      # Raises a +Dynamoid::Errors::UnknownAttribute+ exception if any of the
+      # attributes is not on the model
       #
       # @param hash_key_value [Scalar value] hash key
       # @param range_key_value [Scalar value] range key (optional)
@@ -492,14 +498,15 @@ module Dynamoid
     #
     #   user.update_attributes(age: 27, last_name: 'Tylor')
     #
+    # Raises a +Dynamoid::Errors::UnknownAttribute+ exception if any of the
+    # attributes is not on the model
+    #
     # @param attributes [Hash] a hash of attributes to update
     # @return [true|false] Whether updating successful or not
     # @since 0.2.0
     def update_attributes(attributes)
       attributes.each { |attribute, value| write_attribute(attribute, value) }
       save
-    rescue Dynamoid::Errors::UnknownAttribute
-      false
     end
 
     # Update multiple attributes at once, saving the object once the updates
@@ -525,6 +532,9 @@ module Dynamoid
     #
     #   user.update_attribute(:last_name, 'Tylor')
     #
+    # Raises a +Dynamoid::Errors::UnknownAttribute+ exception if any of the
+    # attributes is not on the model
+    #
     # @param attribute [Symbol] attribute name to update
     # @param value [Object] the value to assign it
     # @return [Dynamoid::Document] self
@@ -532,8 +542,6 @@ module Dynamoid
     def update_attribute(attribute, value)
       write_attribute(attribute, value)
       save
-    rescue Dynamoid::Errors::UnknownAttribute
-      false
     end
 
     # Update a model.

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -8,6 +8,7 @@ require 'dynamoid/persistence/import'
 require 'dynamoid/persistence/update_fields'
 require 'dynamoid/persistence/upsert'
 require 'dynamoid/persistence/save'
+require 'dynamoid/persistence/update_validations'
 
 # encoding: utf-8
 module Dynamoid
@@ -497,6 +498,8 @@ module Dynamoid
     def update_attributes(attributes)
       attributes.each { |attribute, value| write_attribute(attribute, value) }
       save
+    rescue Dynamoid::Errors::UnknownAttribute
+      false
     end
 
     # Update multiple attributes at once, saving the object once the updates
@@ -506,6 +509,9 @@ module Dynamoid
     #
     # Raises a +Dynamoid::Errors::DocumentNotValid+ exception if some vaidation
     # fails.
+    #
+    # Raises a +Dynamoid::Errors::UnknownAttribute+ exception if any of the
+    # attributes is not on the model
     #
     # @param attributes [Hash] a hash of attributes to update
     def update_attributes!(attributes)
@@ -526,6 +532,8 @@ module Dynamoid
     def update_attribute(attribute, value)
       write_attribute(attribute, value)
       save
+    rescue Dynamoid::Errors::UnknownAttribute
+      false
     end
 
     # Update a model.

--- a/lib/dynamoid/persistence/update_fields.rb
+++ b/lib/dynamoid/persistence/update_fields.rb
@@ -25,7 +25,7 @@ module Dynamoid
 
         raw_attributes = update_item
         @model_class.new(undump_attributes(raw_attributes))
-      rescue Dynamoid::Errors::ConditionalCheckFailedException, Dynamoid::Errors::UnknownAttribute
+      rescue Dynamoid::Errors::ConditionalCheckFailedException
       end
 
       private

--- a/lib/dynamoid/persistence/update_fields.rb
+++ b/lib/dynamoid/persistence/update_fields.rb
@@ -17,13 +17,15 @@ module Dynamoid
       end
 
       def call
+        UpdateValidations.validate_attributes_exist(@model_class, @attributes)
+
         if Dynamoid::Config.timestamps
           @attributes[:updated_at] ||= DateTime.now.in_time_zone(Time.zone)
         end
 
         raw_attributes = update_item
         @model_class.new(undump_attributes(raw_attributes))
-      rescue Dynamoid::Errors::ConditionalCheckFailedException
+      rescue Dynamoid::Errors::ConditionalCheckFailedException, Dynamoid::Errors::UnknownAttribute
       end
 
       private

--- a/lib/dynamoid/persistence/update_validations.rb
+++ b/lib/dynamoid/persistence/update_validations.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module Persistence
+    # @private
+    module UpdateValidations
+      def self.validate_attributes_exist(model_class, attributes)
+        model_attributes = model_class.attributes.keys
+
+        attributes.each do |attr_name, _|
+          unless model_attributes.include?(attr_name)
+            raise Dynamoid::Errors::UnknownAttribute.new("Attribute #{attr_name} does not exist in #{model_class}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dynamoid/persistence/upsert.rb
+++ b/lib/dynamoid/persistence/upsert.rb
@@ -25,7 +25,7 @@ module Dynamoid
 
         raw_attributes = update_item
         @model_class.new(undump_attributes(raw_attributes))
-      rescue Dynamoid::Errors::ConditionalCheckFailedException, Dynamoid::Errors::UnknownAttribute
+      rescue Dynamoid::Errors::ConditionalCheckFailedException
       end
 
       private

--- a/lib/dynamoid/persistence/upsert.rb
+++ b/lib/dynamoid/persistence/upsert.rb
@@ -17,13 +17,15 @@ module Dynamoid
       end
 
       def call
+        UpdateValidations.validate_attributes_exist(@model_class, @attributes)
+
         if Dynamoid::Config.timestamps
           @attributes[:updated_at] ||= DateTime.now.in_time_zone(Time.zone)
         end
 
         raw_attributes = update_item
         @model_class.new(undump_attributes(raw_attributes))
-      rescue Dynamoid::Errors::ConditionalCheckFailedException
+      rescue Dynamoid::Errors::ConditionalCheckFailedException, Dynamoid::Errors::UnknownAttribute
       end
 
       private

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -381,5 +381,13 @@ describe Dynamoid::Fields do
         expect(obj.attributes[:count]).to eql(101)
       end
     end
+
+    it 'raises an UnknownAttribute error if the attribute is not on the model' do
+      obj = new_class.new
+
+      expect {
+        obj.write_attribute(:name, 'Alex')
+      }.to raise_error Dynamoid::Errors::UnknownAttribute
+    end
   end
 end

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -1058,7 +1058,7 @@ describe Dynamoid::Persistence do
       end.to change { d.reload.name }.to('[Updated]')
     end
 
-    it 'does not save when adding an attribute that is not on the model' do
+    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
       klass = new_class do
         field :name
       end
@@ -1067,7 +1067,7 @@ describe Dynamoid::Persistence do
 
       expect do
         klass.update(obj.id, name: 'New name', age: 26)
-      end.not_to change { obj.reload.name }
+      end.to raise_error Dynamoid::Errors::UnknownAttribute
     end
 
     describe 'timestamps' do
@@ -1302,11 +1302,12 @@ describe Dynamoid::Persistence do
       end
     end
 
-    it 'returns nil if an attribute does not exist in the model' do
+    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
       obj = document_class.create(title: 'New Document')
 
-      result = document_class.update_fields(obj.id, { title: 'New title', publisher: 'New publisher' } )
-      expect(result).to be_nil
+      expect {
+        document_class.update_fields(obj.id, { title: 'New title', publisher: 'New publisher' } )
+      }.to raise_error Dynamoid::Errors::UnknownAttribute
     end
   end
 
@@ -1486,11 +1487,12 @@ describe Dynamoid::Persistence do
       end
     end
 
-    it 'returns nil if an attribute does not exist in the model' do
+    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
       obj = document_class.create(title: 'New Document')
 
-      result = document_class.upsert(obj.id, { title: 'New title', publisher: 'New publisher' } )
-      expect(result).to be_nil
+      expect {
+        document_class.upsert(obj.id, { title: 'New title', publisher: 'New publisher' } )
+      }.to raise_error Dynamoid::Errors::UnknownAttribute
     end
   end
 
@@ -2015,7 +2017,7 @@ describe Dynamoid::Persistence do
       end
     end
 
-    it 'does not save the document if the attribute is not on the model' do
+    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
       klass = new_class do
         field :age, :integer
         field :name, :string
@@ -2023,8 +2025,9 @@ describe Dynamoid::Persistence do
 
       obj = klass.create!(name: 'Alex', age: 26)
 
-      expect(obj.update_attribute(:city, 'Dublin')).to eq false
-      expect(klass.find(obj.id)[:city]).to be_nil
+      expect {
+        obj.update_attribute(:city, 'Dublin')
+      }.to raise_error(Dynamoid::Errors::UnknownAttribute)
     end
   end
 
@@ -2118,13 +2121,12 @@ describe Dynamoid::Persistence do
       end
     end
 
-    it 'does not save the document if an attribute is not on the model' do
+    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
       obj = klass.create!(name: 'Alex', age: 26)
 
-      expect(obj.update_attributes(city: 'Dublin', age: 27)).to eq false
-      saved_object = klass.find(obj.id)
-      expect(saved_object[:city]).to be_nil
-      expect(saved_object[:age]).to eq 26
+      expect {
+        obj.update_attributes!(city: 'Dublin', age: 27)
+      }.to raise_error(Dynamoid::Errors::UnknownAttribute)
     end
   end
 
@@ -2168,7 +2170,7 @@ describe Dynamoid::Persistence do
       expect(klass.find(obj.id).age).to eql 26
     end
 
-    it 'raises UnknownAttributeError if any attribute is not on the model' do
+    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
       obj = klass.create!(name: 'Alex', age: 26)
 
       expect {


### PR DESCRIPTION
Fixes #462 

### Changes
Modified the method `write_attribute` to raise an `UnknownAttribute` error if the user tries to write a field that hasn't been defined on the model class

Created a new module, `Dynamoid::Persistence::UpdateValidations`, with a method to validate if a specific attribute is part of a model class

Adding tests to validate the new behavior in:
- `.upsert`
- `.update_fields`
- `.update`
- `#update`
- `#update_attribute`
- `#update_attributes`