### PR TITLE
Adding #with_index to chain to force allow the user to force an index

### DIFF
--- a/lib/dynamoid/criteria/key_fields_detector.rb
+++ b/lib/dynamoid/criteria/key_fields_detector.rb
@@ -24,10 +24,11 @@ module Dynamoid
         end
       end
 
-      def initialize(query, source)
+      def initialize(query, source, forced_index_name: nil)
         @query = query
         @source = source
         @query = Query.new(query)
+        @forced_index_name = forced_index_name
         @result = find_keys_in_query
       end
 
@@ -54,6 +55,8 @@ module Dynamoid
       private
 
       def find_keys_in_query
+        return match_forced_index if @forced_index_name
+
         match_table_and_sort_key ||
           match_local_secondary_index ||
           match_global_secondary_index_and_sort_key ||
@@ -132,6 +135,16 @@ module Dynamoid
             index_name: gsi.name,
           }
         end
+      end
+
+      def match_forced_index
+        idx = @source.find_index_by_name(@forced_index_name)
+
+        {
+          hash_key: idx.hash_key,
+          range_key: idx.range_key,
+          index_name: idx.name,
+        }
       end
     end
   end

--- a/lib/dynamoid/indexes.rb
+++ b/lib/dynamoid/indexes.rb
@@ -154,6 +154,16 @@ module Dynamoid
         index
       end
 
+      # Returns an index by its name
+      #
+      # @param name [string, symbol] the name of the index to lookup
+      # @return [Dynamoid::Indexes::Index, nil] index object or nil if it isn't found
+      def find_index_by_name(name)
+        string_name = name.to_s
+        indexes.each_value.detect{ |i| i.name.to_s == string_name }
+      end
+
+
       # Returns true iff the provided hash[,range] key combo is a local
       # secondary index.
       #


### PR DESCRIPTION
This PR adds the ability to force an index selection when constructing a query chain. 

There are queries, which would fit an existing index but not return results in the desired order. The example from the method docs:

```ruby
class Comment
  include Dynamoid::Document

  hash_key :post_id
  range_key :author_id

  field :post_date, :datetime

  local_secondary_index name: :time_sorted_comments, range_key: post_date, projected_attributes: :all
end


 Comment.where(post_id: id).with_index(:time_sorted_comments).scan_index_forward(false)
```

The current behavior of Dynamoid would only select this index if I also filtered by the secondary index. This PR allows me to not add a null-op filter, and just hint at the index.

There are open questions in the PR:

1) What do we want to do when the named index is not found
2) What do we do when the user materializes a query which cannot be applied to the index? (Isn't performing equality on the index hash key)
