### PR TITLE
Add field aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,26 @@ field :actions_taken, :integer, default: 0
 field :joined_at, :datetime, default: -> { Time.now }
 ```
 
+#### Aliases
+
+It might be helpful to define an alias for already existing field when
+naming convention used for a table differs from conventions common in
+Ruby:
+
+```ruby
+field firstName, :string, alias: :first_name
+```
+
+This way there will be generated
+setters/getters/`<name>?`/`<name>_before_type_cast` methods for both
+original field name (`firstName`) and an alias (`first_name`).
+
+```ruby
+user = User.new(first_name: 'Michael')
+user.first_name # => 'Michael'
+user.firstName # => 'Michael'
+```
+
 #### Custom Types
 
 To use a custom type for a field, suppose you have a `Money` type.

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ u.email = 'josh@joshsymonds.com'
 u.save
 ```
 
-Save forces persistence to the datastore: a unique ID is also assigned,
+Save forces persistence to the data store: a unique ID is also assigned,
 but it is a string and not an auto-incrementing number.
 
 ```ruby

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -161,6 +161,17 @@ module Dynamoid
           define_method("#{named}=") { |value| write_attribute(named, value) }
           define_method("#{named}_before_type_cast") { read_attribute_before_type_cast(named) }
         end
+
+        if options[:alias]
+          alias_name = options[:alias].to_s
+
+          generated_methods.module_eval do
+            alias_method alias_name, named
+            alias_method "#{alias_name}=", "#{named}="
+            alias_method "#{alias_name}?", "#{named}?"
+            alias_method "#{alias_name}_before_type_cast", "#{named}_before_type_cast"
+          end
+        end
       end
 
       # Declare a table range key.

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -128,6 +128,19 @@ module Dynamoid
       #   user.age # => 21 - integer
       #   user.age_before_type_cast # => '21' - string
       #
+      # There is also an option +alias+ which allows to use another name for a
+      # field:
+      #
+      #   class User
+      #     include Dynamoid::Document
+      #
+      #     field :firstName, :string, alias: :first_name
+      #   end
+      #
+      #   user = User.new(firstName: 'Michael')
+      #   user.firstName # Michael
+      #   user.first_name # Michael
+      #
       # @param name [Symbol] name of the field
       # @param type [Symbol] type of the field (optional)
       # @param options [Hash] any additional options for the field type (optional)

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -45,15 +45,15 @@ module Dynamoid
       #   end
       #
       # Its type determines how it is coerced when read in and out of the
-      # datastore. You can specify +string+, +integer+, +number+, +set+, +array+,
+      # data store. You can specify +string+, +integer+, +number+, +set+, +array+,
       # +map+, +datetime+, +date+, +serialized+, +raw+, +boolean+ and +binary+
       # or specify a class that defines a serialization strategy.
       #
       # By default field type is +string+.
       #
       # Set can store elements of the same type only (it's a limitation of
-      # DynamoDB itself). If a set should store elements only some particular
-      # type +of+ option should be specified:
+      # DynamoDB itself). If a set should store elements only of some particular
+      # type then +of+ option should be specified:
       #
       #   field :hobbies, :set, of: :string
       #

--- a/lib/dynamoid/fields/declare.rb
+++ b/lib/dynamoid/fields/declare.rb
@@ -43,6 +43,7 @@ module Dynamoid
       end
 
       def generate_instance_methods
+        # only local variable is visible in `module_eval` block
         name = @name
 
         @source.generated_methods.module_eval do
@@ -62,8 +63,10 @@ module Dynamoid
       end
 
       def generate_instance_methods_for_alias
-        alias_name = @options[:alias].to_sym
+        # only local variable is visible in `module_eval` block
         name = @name
+
+        alias_name = @options[:alias].to_sym
 
         @source.generated_methods.module_eval do
           alias_method alias_name, name

--- a/lib/dynamoid/fields/declare.rb
+++ b/lib/dynamoid/fields/declare.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module Fields
+    # @private
+    class Declare
+      def initialize(source, name, type, options)
+        @source = source
+        @name = name.to_sym
+        @type = type
+        @options = options
+      end
+
+      def call
+        # Register new field metadata
+        @source.attributes = @source.attributes.merge(
+          @name => { type: @type }.merge(@options)
+        )
+
+        # Should be called before `define_attribute_methods` method because it
+        # defines an attribute getter itself
+        warn_about_method_overriding
+
+        # Dirty API
+        @source.define_attribute_method(@name)
+
+        # Generate getters and setters as well as other helper methods
+        generate_instance_methods
+
+        # If alias name specified - generate the same instance methods
+        if @options[:alias]
+          generate_instance_methods_for_alias
+        end
+      end
+
+      private
+
+      def warn_about_method_overriding
+        warn_if_method_exists(@name)
+        warn_if_method_exists("#{@name}=")
+        warn_if_method_exists("#{@name}?")
+        warn_if_method_exists("#{@name}_before_type_cast?")
+      end
+
+      def generate_instance_methods
+        name = @name
+
+        @source.generated_methods.module_eval do
+          define_method(name) { read_attribute(name) }
+          define_method("#{name}?") do
+            value = read_attribute(name)
+            case value
+            when true        then true
+            when false, nil  then false
+            else
+              !value.nil?
+            end
+          end
+          define_method("#{name}=") { |value| write_attribute(name, value) }
+          define_method("#{name}_before_type_cast") { read_attribute_before_type_cast(name) }
+        end
+      end
+
+      def generate_instance_methods_for_alias
+        alias_name = @options[:alias].to_sym
+        name = @name
+
+        @source.generated_methods.module_eval do
+          alias_method alias_name, name
+          alias_method "#{alias_name}=", "#{name}="
+          alias_method "#{alias_name}?", "#{name}?"
+          alias_method "#{alias_name}_before_type_cast", "#{name}_before_type_cast"
+        end
+      end
+
+      def warn_if_method_exists(method)
+        if @source.instance_methods.include?(method.to_sym)
+          Dynamoid.logger.warn("Method #{method} generated for the field #{@name} overrides already existing method")
+        end
+      end
+    end
+  end
+end

--- a/lib/dynamoid/loadable.rb
+++ b/lib/dynamoid/loadable.rb
@@ -10,7 +10,7 @@ module Dynamoid
       end
     end
 
-    # Reload an object from the database -- if you suspect the object has changed in the datastore and you need those
+    # Reload an object from the database -- if you suspect the object has changed in the data store and you need those
     # changes to be reflected immediately, you would call this method. This is a consistent read.
     #
     # @return [Dynamoid::Document] the document this method was called on

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -12,8 +12,8 @@ require 'dynamoid/persistence/update_validations'
 
 # encoding: utf-8
 module Dynamoid
-  #   # Persistence is responsible for dumping objects to and marshalling objects from the datastore. It tries to reserialize
-  #   # values to be of the same type as when they were passed in, based on the fields in the class.
+  # Persistence is responsible for dumping objects to and marshalling objects from the data store. It tries to reserialize
+  # values to be of the same type as when they were passed in, based on the fields in the class.
   module Persistence
     extend ActiveSupport::Concern
 

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -6,7 +6,40 @@ describe Dynamoid::Fields do
   let(:address) { Address.new }
 
   describe '.field' do
-    context 'generated method overrided existing one' do
+    context 'when :alias option specified' do
+      let(:klass) do
+        new_class do
+          field :Name, :string, alias: :name
+        end
+      end
+
+      it 'generates getter and setter for alias' do
+        object = klass.new
+
+        object.Name = 'Alex'
+        expect(object.name).to eq('Alex')
+
+        object.name = 'Michael'
+        expect(object.name).to eq('Michael')
+      end
+
+      it 'generates <name>? method' do
+        object = klass.new
+
+        expect(object.name?).to eq false
+        object.name = 'Alex'
+        expect(object.name?).to eq true
+      end
+
+      it 'generates <name>_before_type_cast method' do
+        object = klass.new(name: :Alex)
+
+        expect(object.name).to eq 'Alex'
+        expect(object.name_before_type_cast).to eq :Alex
+      end
+    end
+
+    context 'when new generated method overrides existing one' do
       let(:module_with_methods) do
         Module.new do
           def foo; end


### PR DESCRIPTION
Closes https://github.com/Dynamoid/dynamoid/issues/466

Changes:
- added `alias` option for the `field` method

### Example

```ruby
class User
  # ...
  field :createdAt, :datetime, alias: :created_at
end

user = User.new

user.created_at # => ...
user.created_at = Time.now
user.created_at? # => true
user.created_at_before_type_cast # => ...
```

### Reason

It allows to generate setter/getter/`<name>?` and `<name>_before_type_cast` instance methods for specified attribute alias.

### Notes

These aliases aren't supported in `where` conditions (e.g. you cannot use `'created_at.gt': Time.now - 1.hour` - use `createdAt.gt` instead). Dirty API also doesn't support aliases.