### PR TITLE
Support Date index

### DIFF
--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -14,6 +14,7 @@ module Dynamoid
       number
       integer
       string
+      date
       datetime
       serialized
     ].freeze


### PR DESCRIPTION
Hi!
This PR supports `:date` type index.

`Dynamoid::Errors::InvalidIndex` occurs when `:date` type field is specified for hash_key or range_key.

```
Validation failed: Range key Index :range_key is not a valid key type (Dynamoid::Errors::InvalidIndex)
```