### PR TITLE
Use `timestamps_enabled?` in `UpdateFields` and `Upsert`  to prevent `updated_at` from being added to the item

### DIFF
--- a/lib/dynamoid/persistence/update_fields.rb
+++ b/lib/dynamoid/persistence/update_fields.rb
@@ -19,7 +19,7 @@ module Dynamoid
       def call
         UpdateValidations.validate_attributes_exist(@model_class, @attributes)
 
-        if Dynamoid::Config.timestamps
+        if @model_class.timestamps_enabled?
           @attributes[:updated_at] ||= DateTime.now.in_time_zone(Time.zone)
         end
 

--- a/lib/dynamoid/persistence/upsert.rb
+++ b/lib/dynamoid/persistence/upsert.rb
@@ -19,7 +19,7 @@ module Dynamoid
       def call
         UpdateValidations.validate_attributes_exist(@model_class, @attributes)
 
-        if Dynamoid::Config.timestamps
+        if @model_class.timestamps_enabled?
           @attributes[:updated_at] ||= DateTime.now.in_time_zone(Time.zone)
         end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -1263,6 +1263,15 @@ describe Dynamoid::Persistence do
           document_class.update_fields(obj.id, title: 'New title')
         end.not_to raise_error
       end
+
+      it 'does not set updated_at if Config.timestamps=true and table timestamps=false', config: { timestamps: true } do
+        document_class.table timestamps: false
+
+        obj = document_class.create(title: 'Old title')
+        document_class.update_fields(obj.id, title: 'New title')
+
+        expect(obj.reload.attributes).to_not have_key(:updated_at)
+      end
     end
 
     describe 'type casting' do
@@ -1447,6 +1456,15 @@ describe Dynamoid::Persistence do
         expect do
           document_class.upsert(obj.id, title: 'New title')
         end.not_to raise_error
+      end
+
+      it 'does not set updated_at if Config.timestamps=true and table timestamps=false', config: { timestamps: true } do
+        document_class.table timestamps: false
+
+        obj = document_class.create(title: 'Old title')
+        document_class.upsert(obj.id, title: 'New title')
+
+        expect(obj.reload.attributes).to_not have_key(:updated_at)
       end
     end
 


### PR DESCRIPTION
Use `timestamps_enabled?` in `UpdateFields` and `Upsert` to prevent `updated_at` from being added to the item.

Currently, When I use `upsert` or `update_fields`, `updated_at` is added to the item even if I set `table timestamps: false`.