### PR TITLE
Allow custom type for index fields

### DIFF
--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -8,17 +8,6 @@ module Dynamoid
   module Fields
     extend ActiveSupport::Concern
 
-    # @private
-    # Types allowed in indexes:
-    PERMITTED_KEY_TYPES = %i[
-      number
-      integer
-      string
-      date
-      datetime
-      serialized
-    ].freeze
-
     # Initialize the attributes we know the class has, in addition to our magic attributes: id, created_at, and updated_at.
     included do
       class_attribute :attributes, instance_accessor: false

--- a/lib/dynamoid/indexes.rb
+++ b/lib/dynamoid/indexes.rb
@@ -294,10 +294,10 @@ module Dynamoid
         if @range_key.present?
           range_field_attributes = @dynamoid_class.attributes[@range_key]
           if range_field_attributes.present?
-            range_key_type = range_field_attributes[:type]
-            if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(range_key_type)
+            range_key_type_dynamodb_type = dynamodb_type(range_field_attributes[:type], range_field_attributes)
+            if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(range_key_type_dynamodb_type)
               @range_key_schema = {
-                @range_key => PrimaryKeyTypeMapping.dynamodb_type(range_key_type, range_field_attributes)
+                @range_key => range_key_type_dynamodb_type
               }
             else
               errors.add(:range_key, 'Index :range_key is not a valid key type')
@@ -311,10 +311,10 @@ module Dynamoid
       def validate_hash_key
         hash_field_attributes = @dynamoid_class.attributes[@hash_key]
         if hash_field_attributes.present?
-          hash_field_type = hash_field_attributes[:type]
-          if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(hash_field_type)
+          hash_field_dynamodb_type = dynamodb_type(hash_field_attributes[:type], hash_field_attributes)
+          if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(hash_field_dynamodb_type)
             @hash_key_schema = {
-              @hash_key => PrimaryKeyTypeMapping.dynamodb_type(hash_field_type, hash_field_attributes)
+              @hash_key => hash_field_dynamodb_type
             }
           else
             errors.add(:hash_key, 'Index :hash_key is not a valid key type')
@@ -322,6 +322,12 @@ module Dynamoid
         else
           errors.add(:hash_key, "No such field #{@hash_key} defined on table")
         end
+      end
+
+      def dynamodb_type(field_type, options)
+        PrimaryKeyTypeMapping.dynamodb_type(field_type, options)
+      rescue Errors::UnsupportedKeyType
+        field_type
       end
     end
   end

--- a/lib/dynamoid/indexes.rb
+++ b/lib/dynamoid/indexes.rb
@@ -4,6 +4,14 @@ module Dynamoid
   module Indexes
     extend ActiveSupport::Concern
 
+    # @private
+    # Types allowed in indexes:
+    PERMITTED_KEY_DYNAMODB_TYPES = %i[
+      string
+      binary
+      number
+    ].freeze
+
     included do
       class_attribute :local_secondary_indexes, instance_accessor: false
       class_attribute :global_secondary_indexes, instance_accessor: false
@@ -309,7 +317,7 @@ module Dynamoid
         end
 
         key_dynamodb_type = dynamodb_type(key_field_attributes[:type], key_field_attributes)
-        if Dynamoid::Fields::PERMITTED_KEY_TYPES.include?(key_dynamodb_type)
+        if PERMITTED_KEY_DYNAMODB_TYPES.include?(key_dynamodb_type)
           self.send("#{key_param}_schema=", { key_val => key_dynamodb_type })
         else
           errors.add(key_param, "Index :#{key_param} is not a valid key type")

--- a/spec/dynamoid/indexes_spec.rb
+++ b/spec/dynamoid/indexes_spec.rb
@@ -370,6 +370,40 @@ describe Dynamoid::Indexes do
             )
           end
         end
+
+        context 'with custom type key params' do
+          let(:doc_class) do
+            new_class do
+
+              class CustomType
+                def dynamoid_dump
+                  name
+                end
+
+                def self.dynamoid_load(string)
+                  new(string.to_s)
+                end
+              end
+
+              field :custom_type_field, CustomType
+              field :custom_type_range_field, CustomType
+            end
+          end
+
+          let(:index) do
+            Dynamoid::Indexes::Index.new(
+              dynamoid_class: doc_class,
+              hash_key: :custom_type_field,
+              range_key: :custom_type_range_field,
+              type: :global_secondary
+            )
+          end
+
+          it 'sets the correct key_schema' do
+            expect(index.hash_key_schema).to eql({ custom_type_field: :string })
+            expect(index.range_key_schema).to eql({ custom_type_range_field: :string })
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Since custom types could use allowed index types such as `string`. Allow to be used as keys on indexes.