### PR TITLE
Fix #reload and mark model as persisted after reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* [#567](https://github.com/Dynamoid/dynamoid/pull/567) Fix `#reload` and mark reloaded model as persisted
 ### Added
 * [#536](https://github.com/Dynamoid/dynamoid/pull/536) Modernization
   * Support for Ruby 3.1

--- a/lib/dynamoid/loadable.rb
+++ b/lib/dynamoid/loadable.rb
@@ -24,7 +24,10 @@ module Dynamoid
       end
 
       self.attributes = self.class.find(hash_key, **options).attributes
+
       @associations.values.each(&:reset)
+      @new_record = false
+
       self
     end
   end

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -131,41 +131,6 @@ describe Dynamoid::Document do
     expect(address.errors.full_messages).to be_empty
   end
 
-  context '.reload' do
-    let(:address) { Address.create }
-    let(:message) { Message.create(text: 'Nice, supporting datetime range!', time: Time.now.to_datetime) }
-    let(:tweet) { tweet = Tweet.create(tweet_id: 'x', group: 'abc') }
-
-    it 'reflects persisted changes' do
-      address.update_attributes(city: 'Chicago')
-      expect(address.reload.city).to eq 'Chicago'
-    end
-
-    it 'uses a :consistent_read' do
-      expect(Tweet).to receive(:find).with(tweet.hash_key, range_key: tweet.range_value, consistent_read: true).and_return(tweet)
-      tweet.reload
-    end
-
-    it 'works with range key' do
-      expect(tweet.reload.group).to eq 'abc'
-    end
-
-    it 'uses dumped value of sort key to load document' do
-      klass = new_class do
-        range :activated_on, :date
-        field :name
-      end
-
-      obj = klass.create!(activated_on: Date.today, name: 'Old value')
-      obj2 = klass.where(id: obj.id, activated_on: obj.activated_on).first
-      obj2.update_attributes(name: 'New value')
-
-      expect { obj.reload }.to change {
-        obj.name
-      }.from('Old value').to('New value')
-    end
-  end
-
   it 'has default table options' do
     address = Address.create
 

--- a/spec/dynamoid/loadable_spec.rb
+++ b/spec/dynamoid/loadable_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Dynamoid::Loadable do
+
+  context '.reload' do
+    let(:address) { Address.create }
+    let(:message) { Message.create(text: 'Nice, supporting datetime range!', time: Time.now.to_datetime) }
+    let(:tweet) { tweet = Tweet.create(tweet_id: 'x', group: 'abc') }
+
+    it 'reflects persisted changes' do
+      address.update_attributes(city: 'Chicago')
+      expect(address.reload.city).to eq 'Chicago'
+    end
+
+    it 'uses a :consistent_read' do
+      expect(Tweet).to receive(:find).with(tweet.hash_key, range_key: tweet.range_value, consistent_read: true).and_return(tweet)
+      tweet.reload
+    end
+
+    it 'works with range key' do
+      expect(tweet.reload.group).to eq 'abc'
+    end
+
+    it 'uses dumped value of sort key to load document' do
+      klass = new_class do
+        range :activated_on, :date
+        field :name
+      end
+
+      obj = klass.create!(activated_on: Date.today, name: 'Old value')
+      obj2 = klass.where(id: obj.id, activated_on: obj.activated_on).first
+      obj2.update_attributes(name: 'New value')
+
+      expect { obj.reload }.to change {
+        obj.name
+      }.from('Old value').to('New value')
+    end
+  end
+end

--- a/spec/dynamoid/loadable_spec.rb
+++ b/spec/dynamoid/loadable_spec.rb
@@ -10,17 +10,36 @@ describe Dynamoid::Loadable do
     let(:tweet) { tweet = Tweet.create(tweet_id: 'x', group: 'abc') }
 
     it 'reflects persisted changes' do
+      klass = new_class do
+        field :city
+      end
+
+      address = klass.create(city: 'Miami')
+      copy = klass.find(address.id)
+
       address.update_attributes(city: 'Chicago')
-      expect(address.reload.city).to eq 'Chicago'
+      expect(copy.reload.city).to eq 'Chicago'
     end
 
-    it 'uses a :consistent_read' do
-      expect(Tweet).to receive(:find).with(tweet.hash_key, range_key: tweet.range_value, consistent_read: true).and_return(tweet)
+    it 'reads with strong consistency' do
+      klass = new_class do
+        field :message
+      end
+
+      tweet = klass.create
+
+      expect(klass).to receive(:find).with(tweet.id, consistent_read: true).and_return(tweet)
       tweet.reload
     end
 
     it 'works with range key' do
-      expect(tweet.reload.group).to eq 'abc'
+      klass = new_class do
+        field :message
+        range :group
+      end
+
+      tweet = klass.create(group: 'tech')
+      expect(tweet.reload.group).to eq 'tech'
     end
 
     it 'uses dumped value of sort key to load document' do
@@ -33,9 +52,7 @@ describe Dynamoid::Loadable do
       obj2 = klass.where(id: obj.id, activated_on: obj.activated_on).first
       obj2.update_attributes(name: 'New value')
 
-      expect { obj.reload }.to change {
-        obj.name
-      }.from('Old value').to('New value')
+      expect { obj.reload }.to change { obj.name }.from('Old value').to('New value')
     end
   end
 end

--- a/spec/dynamoid/loadable_spec.rb
+++ b/spec/dynamoid/loadable_spec.rb
@@ -54,5 +54,18 @@ describe Dynamoid::Loadable do
 
       expect { obj.reload }.to change { obj.name }.from('Old value').to('New value')
     end
+
+    # https://github.com/Dynamoid/dynamoid/issues/564
+    it 'marks model as persisted if not saved model is already persisted and successfuly reloaded' do
+      klass = new_class do
+        field :message
+      end
+
+      object = klass.create(message: 'a')
+      copy = klass.new(id: object.id)
+
+      expect { copy.reload }.to change { copy.new_record? }.from(true).to(false)
+      expect(copy.message).to eq 'a'
+    end
   end
 end


### PR DESCRIPTION
Fix the following scenario:
- there is a persisted item
- we initialize a new model with the same primary key
- try to save it and fail because such item already exists
- try to reload it

Expected result
- reloaded model should be marked as persisted and `#new_record?` should return `false`.

Closes https://github.com/Dynamoid/dynamoid/issues/564