### PR TITLE
Support relationships between classes with a common module parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1320,6 +1320,7 @@ just as accessible to the Ruby world as MongoDB.
 Also, without contributors the project wouldn't be nearly as awesome. So
 many thanks to:
 
+* [Josh Menden](https://github.com/joshmenden)
 * [Logan Bowers](https://github.com/loganb)
 * [Lane LaRue](https://github.com/luxx)
 * [Craig Heneveld](https://github.com/cheneveld)

--- a/lib/dynamoid/associations/belongs_to.rb
+++ b/lib/dynamoid/associations/belongs_to.rb
@@ -39,8 +39,14 @@ module Dynamoid
       #
       # @since 0.2.0
       def target_association
-        has_many_key_name = options[:inverse_of] || source.class.to_s.underscore.pluralize.to_sym
+        has_many_key_name = options[:inverse_of] || source.class.to_s.pluralize.underscore.to_sym
         has_one_key_name = options[:inverse_of] || source.class.to_s.underscore.to_sym
+
+        if target_class.module_parent != Object && (target_class.module_parent == source.class.module_parent)
+          has_many_key_name = source.class.to_s.demodulize.pluralize.underscore.to_sym
+          has_one_key_name = source.class.to_s.demodulize.underscore.to_sym
+        end
+
         unless target_class.associations[has_many_key_name].nil?
           return has_many_key_name if target_class.associations[has_many_key_name][:type] == :has_many
         end

--- a/lib/dynamoid/associations/has_and_belongs_to_many.rb
+++ b/lib/dynamoid/associations/has_and_belongs_to_many.rb
@@ -15,6 +15,11 @@ module Dynamoid
       # @since 0.2.0
       def target_association
         key_name = options[:inverse_of] || source.class.to_s.pluralize.underscore.to_sym
+
+        if target_class.module_parent != Object && (target_class.module_parent == source.class.module_parent)
+          key_name = source.class.to_s.demodulize.pluralize.underscore.to_sym
+        end
+
         guess = target_class.associations[key_name]
         return nil if guess.nil? || guess[:type] != :has_and_belongs_to_many
 

--- a/lib/dynamoid/associations/has_many.rb
+++ b/lib/dynamoid/associations/has_many.rb
@@ -15,6 +15,11 @@ module Dynamoid
       # @since 0.2.0
       def target_association
         key_name = options[:inverse_of] || source.class.to_s.singularize.underscore.to_sym
+
+        if target_class.module_parent != Object && (target_class.module_parent == source.class.module_parent)
+          key_name = source.class.to_s.demodulize.singularize.underscore.to_sym
+        end
+
         guess = target_class.associations[key_name]
         return nil if guess.nil? || guess[:type] != :belongs_to
 

--- a/lib/dynamoid/associations/has_one.rb
+++ b/lib/dynamoid/associations/has_one.rb
@@ -16,6 +16,11 @@ module Dynamoid
       # @since 0.2.0
       def target_association
         key_name = options[:inverse_of] || source.class.to_s.singularize.underscore.to_sym
+
+        if target_class.module_parent != Object && (target_class.module_parent == source.class.module_parent)
+          key_name = source.class.to_s.demodulize.singularize.underscore.to_sym
+        end
+
         guess = target_class.associations[key_name]
         return nil if guess.nil? || guess[:type] != :belongs_to
 


### PR DESCRIPTION
I came about this problem because I am using Dynamoid in a [Rails Engine](https://edgeguides.rubyonrails.org/engines.html), and I discovered issues where the relationships between models were not functioning correctly due to the `isolate_namespace` functionality of engines.

For example, piggybacking off the example in the README, if I had classes like this, but in an engine named `MyEngine`...
```ruby
module MyEngine
  class User
    include Dynamoid::Document
  
    # ...
  
    has_many :addresses
  end
end

module MyEngine
  class Address
    include Dynamoid::Document
  
    # ...
  
    belongs_to :user # Automatically links up with the user model
  end
end
```

I would get the following in a rails console
```ruby
> u = MyEngine::User.create! 
> address = MyEngine::Address.create(user: u)
> u.addresses.count # gives 0
```

In other words, the `MyEngine::Address` ID would not be saved on the `MyEngine::User` dynamo record.

This is because [in this line of code](https://github.com/Dynamoid/dynamoid/blob/master/lib/dynamoid/associations/belongs_to.rb#L42) in `belongs_to.rb`, the `MyEngine::Address` class would evaluate to `:"my_engine/addresses"` which of course is incorrect.

My solution is to check if both the `target_class` and the `source_class` share the same `module_parent`, check that that module parent custom to the app, and then use the `demodulize` functionality to strip the class down to its bare name.