### PR TITLE
Create a table including TTL setting with :table_name keyword argument

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -112,7 +112,7 @@ module Dynamoid
 
         if created_successfuly && self.options[:expires]
           attribute = self.options[:expires][:field]
-          Dynamoid.adapter.update_time_to_live(table_name, attribute)
+          Dynamoid.adapter.update_time_to_live(options[:table_name], attribute)
         end
       end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -427,6 +427,16 @@ describe Dynamoid::Persistence do
 
         class_with_expiration.create_table
       end
+
+      it 'sets up TTL for table with specified table_name' do
+        table_name = "#{class_with_expiration.table_name}_alias"
+
+        expect(Dynamoid.adapter).to receive(:update_time_to_live)
+          .with(table_name, :ttl)
+          .and_call_original
+
+        class_with_expiration.create_table(table_name: table_name)
+      end
     end
 
     describe 'capacity mode' do


### PR DESCRIPTION
Thank you for your maintenance.
This PR resolves an error that occurs when it calls `.create_table` with `table_name` keyword for a Model with TTL set.

A simple reproduced code is below,

```rb
require 'dynamoid'

Aws.config.update(
  region: 'us-west-2',
  credentials: Aws::Credentials.new('sample', 'sample')
)

Dynamoid.configure do |config|
  config.namespace = 'dynamoid_app_development'
  config.endpoint = 'http://127.0.0.1:8000'
  config.region = 'us-west-2'
end

Dynamoid.adapter.list_tables.each do |table|
  Dynamoid.adapter.delete_table(table)
end

Dynamoid.adapter.tables.clear

class User
  include Dynamoid::Document

  table expires: { field: :ttl, after: 60 }

  field :ttl, :integer
end

User.create_table(table_name: 'dynamoid_app_test_users')
# => Cannot do operations on a non-existent table (Aws::DynamoDB::Errors::ResourceNotFoundException)

# or

User.create_table
User.create_table(table_name: 'dynamoid_app_test_users')
# => TimeToLive is already enabled (Aws::DynamoDB::Errors::ValidationException)
```

This is because when setting TTL with `.create_table`, the table name based on `Dynamoid.config.namespace` is used instead of the keyword argument `:table_name`. In this case, changing to use the value of `:table_name` would solve this problem.

My practical use case is to create tables during development using the `db:create` hook in Ruby on Rails. I need to create a table for development and a table for testing during development, and call `.create_table` for each environment. The `:table_name` keyword argument is required to create the table for testing.
