### PR TITLE
Support changing type attribute value

### DIFF
--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -787,9 +787,9 @@ module Dynamoid
         condition = {}
         type = @source.inheritance_field
 
-        if @source.attributes.key?(type)
-          class_names = @source.deep_subclasses.map(&:name) << @source.name
-          condition[:"#{type}.in"] = class_names
+        if @source.attributes.key?(type) && !@source.abstract_class?
+          sti_names = @source.deep_subclasses.map(&:sti_name) << @source.sti_name
+          condition[:"#{type}.in"] = sti_names
         end
 
         condition

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -173,7 +173,7 @@ module Dynamoid
       def sti_class_for(type_name)
         type_name.constantize
       rescue NameError
-        raise SubclassNotFound, "STI subclass does not found. Subclass: '#{type_name}'"
+        raise Errors::SubclassNotFound, "STI subclass does not found. Subclass: '#{type_name}'"
       end
 
       # @private

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -160,6 +160,22 @@ module Dynamoid
         end
       end
 
+      attr_accessor :abstract_class
+
+      def abstract_class?
+        defined?(@abstract_class) && @abstract_class == true
+      end
+
+      def sti_name
+        name
+      end
+
+      def sti_class_for(type_name)
+        type_name.constantize
+      rescue NameError
+        raise SubclassNotFound, "STI subclass does not found. Subclass: '#{type_name}'"
+      end
+
       # @private
       def deep_subclasses
         subclasses + subclasses.map(&:deep_subclasses).flatten
@@ -167,7 +183,7 @@ module Dynamoid
 
       # @private
       def choose_right_class(attrs)
-        attrs[inheritance_field] ? attrs[inheritance_field].constantize : self
+        attrs[inheritance_field] ? sti_class_for(attrs[inheritance_field]) : self
       end
     end
 

--- a/lib/dynamoid/errors.rb
+++ b/lib/dynamoid/errors.rb
@@ -77,5 +77,7 @@ module Dynamoid
     class UnsupportedKeyType < Error; end
 
     class UnknownAttribute < Error; end
+
+    class SubclassNotFound < Error; end
   end
 end

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -386,11 +386,12 @@ module Dynamoid
 
     def set_inheritance_field
       # actually it does only following logic:
-      # self.type ||= self.class.name if self.class.attributes[:type]
+      # self.type ||= self.class.sti_name if self.class.attributes[:type]
+      return if self.class.abstract_class?
 
       type = self.class.inheritance_field
       if self.class.attributes[type] && send(type).nil?
-        send("#{type}=", self.class.name)
+        send("#{type}=", self.class.sti_name)
       end
     end
 

--- a/spec/dynamoid/sti_spec.rb
+++ b/spec/dynamoid/sti_spec.rb
@@ -191,4 +191,24 @@ RSpec.describe 'STI' do
       expect(b.type).to eql('beta')
     end
   end
+
+  describe 'sti_class_for' do
+    before do
+      A = new_class class_name: 'A' do
+        field :type
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :A)
+    end
+
+    it 'successes exist class' do
+      expect(A.sti_class_for('A')).to eql A
+    end
+
+    it 'fails non-exist class' do
+      expect { A.sti_class_for('NonExistClass') }.to raise_error(Dynamoid::Errors::SubclassNotFound)
+    end
+  end
 end

--- a/spec/dynamoid/sti_spec.rb
+++ b/spec/dynamoid/sti_spec.rb
@@ -160,4 +160,35 @@ RSpec.describe 'STI' do
       expect(b.type).to eql('Integer')
     end
   end
+
+  describe '`sti_name` support' do
+    before do
+      A = new_class class_name: 'A' do
+        field :type
+
+        def self.sti_class_for(type_name)
+          case type_name
+          when 'beta'
+            B
+          end
+        end
+      end
+      B = Class.new(A) do
+        def self.sti_name
+          'beta'
+        end
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :A)
+      Object.send(:remove_const, :B)
+    end
+
+    it 'saves subclass objects in the parent table' do
+      b = B.create
+      expect(A.find(b.id)).to eql b
+      expect(b.type).to eql('beta')
+    end
+  end
 end


### PR DESCRIPTION
Hello, Thank you for your maintenance.

I added the feature that supports changing `type` value for STI. It has `sti_name` and `sti_class_for` public methods like `ActiveRecord::Inheritance`.

Additionally, I added `abstract_class` class attribute for restricting not to add `sti_condition` when query or scan request.

Sample code is below.

```ruby
class Animal
  include Dynamoid::Document

  self.abstract_class = true

  field :type

  def self.sti_class_for(type_name)
    case type_name
    when "neko" # neko means cat in Japanese
      Cat
    when "inu" # inu means dog in Japanese
      Dog
    end
  end
end

class Cat < Animal
  def self.sti_name
    "neko"
  end
end

class Dog < Animal
  def self.sti_name
    "inu"
  end
end

Animal.all # This request does not add sti_condition
```