### PR TITLE
Minor cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           - "2.4"
           - "2.5"
           - "2.6"
+          - jruby
           - "2.7"
           - "3.0"
           - "3.1"
@@ -61,6 +62,8 @@ jobs:
             ruby: "2.5"
           - gemfile: rails_7_0
             ruby: "2.6"
+          - gemfile: rails_7_0
+            ruby: jruby
 
           # Rails 6.1 requires Ruby 2.5 and above.
           - gemfile: rails_6_1

--- a/README.md
+++ b/README.md
@@ -477,6 +477,10 @@ Second argument, type, is optional. Default type is `string`.
 Just like in ActiveRecord (or your other favorite ORM), Dynamoid uses
 associations to create links between models.
 
+**WARNING:** Associations are not supported for models with compound
+primary key. If a model declares a range key it should not declare any
+association itself and be referenced by an association in another model.
+
 The only supported associations (so far) are `has_many`, `has_one`,
 `has_and_belongs_to_many`, and `belongs_to`. Associations are very
 simple to create: just specify the type, the name, and then any options

--- a/README.md
+++ b/README.md
@@ -1086,7 +1086,7 @@ Listed below are all configuration options.
   when referring to them. Isn't thread safe. Default is `false`.
   `Use Dynamoid::Middleware::IdentityMap` to clear identity map for each HTTP request
 * `timestamps` - by default Dynamoid sets `created_at` and `updated_at`
-  fields for model creation and updating. You can disable this
+  fields at model creation and updating. You can disable this
   behavior by setting `false` value
 * `sync_retry_max_times` - when Dynamoid creates or deletes table
   synchronously it checks for completion specified times. Default is 60

--- a/README.md
+++ b/README.md
@@ -1386,6 +1386,12 @@ bundle install
 
 See [SECURITY.md][security].
 
+## Related links
+
+This documentation may be useful for the contributors:
+- <https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/welcome.html>
+- <https://docs.aws.amazon.com/sdk-for-ruby/v3/api/index.html>
+
 ## License
 
 The gem is available as open source under the terms of

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-# require only 'concurrent/atom' once this issue is resolved:
-#   https://github.com/ruby-concurrency/concurrent-ruby/pull/377
-require 'concurrent'
+require 'concurrent/atom'
 require 'dynamoid/adapter_plugin/aws_sdk_v3'
 
-# encoding: utf-8
 module Dynamoid
   # Adapter's value-add:
   # 1) For the rest of Dynamoid, the gateway to DynamoDB.

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -41,7 +41,7 @@ module Dynamoid
 
     # Shows how long it takes a method to run on the adapter. Useful for generating logged output.
     #
-    # @param [Symbol] method the name of the method to appear in the log
+    # @param [Symbol|String] method the name of the method to appear in the log
     # @param [Array] args the arguments to the method to appear in the log
     # @yield the actual code to benchmark
     #
@@ -147,7 +147,7 @@ module Dynamoid
       #
       # @since 0.2.0
       define_method(m) do |*args, &blk|
-        benchmark(m.to_s, *args) { adapter.send(m, *args, &blk) }
+        benchmark(m, *args) { adapter.send(m, *args, &blk) }
       end
     end
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -416,14 +416,15 @@ module Dynamoid
         conditions = options.delete(:conditions)
         table = describe_table(table_name)
 
-        yield(iu = ItemUpdater.new(table, key, range_key))
+        item_updater = ItemUpdater.new(table, key, range_key)
+        yield(item_updater)
 
         raise "non-empty options: #{options}" unless options.empty?
 
         begin
           result = client.update_item(table_name: table_name,
                                       key: key_stanza(table, key, range_key),
-                                      attribute_updates: iu.to_h,
+                                      attribute_updates: item_updater.attribute_updates,
                                       expected: expected_stanza(conditions),
                                       return_values: 'ALL_NEW')
           result_item_to_hash(result[:attributes])

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/batch_get_item.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/batch_get_item.rb
@@ -87,8 +87,8 @@ module Dynamoid
             # unprocessed_keys Hash contains as values instances of
             # Aws::DynamoDB::Types::KeysAndAttributes
             @api_response.unprocessed_keys[table.name].keys.map do |h|
-              # If a table has a composite key then we need to return an array
-              # of [hash_key, composite_key]. Otherwise just return hash key's
+              # If a table has a composite primary key then we need to return an array
+              # of [hash key, range key]. Otherwise just return hash key's
               # value.
               if table.range_key.nil?
                 h[table.hash_key.to_s]

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
@@ -6,6 +6,10 @@ module Dynamoid
     class AwsSdkV3
       # Mimics behavior of the yielded object on DynamoDB's update_item API (high level).
       class ItemUpdater
+        ADD    = 'ADD'
+        DELETE = 'DELETE'
+        PUT    = 'PUT'
+
         attr_reader :table, :key, :range_key
 
         def initialize(table, key, range_key = nil)
@@ -48,29 +52,31 @@ module Dynamoid
         #
         # Returns an AttributeUpdates hash suitable for passing to the V2 Client API
         #
-        def to_h
-          ret = {}
+        def attribute_updates
+          result = {}
 
           @additions.each do |k, v|
-            ret[k.to_s] = {
+            result[k] = {
               action: ADD,
               value: v
             }
           end
+
           @deletions.each do |k, v|
-            ret[k.to_s] = {
+            result[k] = {
               action: DELETE
             }
-            ret[k.to_s][:value] = v unless v.nil?
+            result[k][:value] = v unless v.nil?
           end
+
           @updates.each do |k, v|
-            ret[k.to_s] = {
+            result[k] = {
               action: PUT,
               value: v
             }
           end
 
-          ret
+          result
         end
 
         private
@@ -80,10 +86,6 @@ module Dynamoid
             v.is_a?(Hash) ? v.stringify_keys : v
           end
         end
-
-        ADD    = 'ADD'
-        DELETE = 'DELETE'
-        PUT    = 'PUT'
       end
     end
   end

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
@@ -35,11 +35,15 @@ module Dynamoid
         #
         # Removes values from the sets of the given columns
         #
-        # @param [Hash] values keys of the hash are the columns, values are Arrays/Sets of items
-        #               to remove
+        # @param [Hash|Symbol|String] values keys of the hash are the columns, values are Arrays/Sets of items
+        #                                    to remove
         #
         def delete(values)
-          @deletions.merge!(sanitize_attributes(values))
+          if values.is_a?(Hash)
+            @deletions.merge!(sanitize_attributes(values))
+          else
+            @deletions.merge!(values.to_s => nil)
+          end
         end
 
         #

--- a/lib/dynamoid/criteria.rb
+++ b/lib/dynamoid/criteria.rb
@@ -9,12 +9,15 @@ module Dynamoid
 
     # @private
     module ClassMethods
-      %i[where consistent all first last delete_all destroy_all each record_limit scan_limit batch start scan_index_forward find_by_pages project pluck].each do |meth|
+      %i[
+        where consistent all first last delete_all destroy_all each record_limit
+        scan_limit batch start scan_index_forward find_by_pages project pluck
+      ].each do |name|
         # Return a criteria chain in response to a method that will begin or end a chain. For more information,
         # see Dynamoid::Criteria::Chain.
         #
         # @since 0.2.0
-        define_method(meth) do |*args, &blk|
+        define_method(name) do |*args, &blk|
           # Don't use keywork arguments delegating (with **kw). It works in
           # different way in different Ruby versions: <= 2.6, 2.7, 3.0 and in some
           # future 3.x versions. Providing that there are no downstream methods
@@ -23,11 +26,7 @@ module Dynamoid
           # https://eregon.me/blog/2019/11/10/the-delegation-challenge-of-ruby27.html
 
           chain = Dynamoid::Criteria::Chain.new(self)
-          if args
-            chain.send(meth, *args, &blk)
-          else
-            chain.send(meth, &blk)
-          end
+          chain.send(name, *args, &blk)
         end
       end
     end

--- a/lib/dynamoid/dirty.rb
+++ b/lib/dynamoid/dirty.rb
@@ -25,17 +25,15 @@ module Dynamoid
     # @private
     module ClassMethods
       def update_fields(*)
-        if model = super
-          model.send(:clear_changes_information)
+        super.tap do |model|
+          model.send(:clear_changes_information) if model
         end
-        model
       end
 
       def upsert(*)
-        if model = super
-          model.send(:clear_changes_information)
+        super.tap do |model|
+          model.send(:clear_changes_information) if model
         end
-        model
       end
 
       def from_database(*)
@@ -47,10 +45,9 @@ module Dynamoid
 
     # @private
     def save(*)
-      if status = super
-        changes_applied
+      super.tap do |status|
+        changes_applied if status
       end
-      status
     end
 
     # @private

--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -17,12 +17,6 @@ module Dynamoid
     end
 
     module ClassMethods
-      # @private
-      def table(options = {})
-        self.options = options
-        super if defined? super
-      end
-
       def attr_readonly(*read_only_attributes)
         self.read_only_attributes.concat read_only_attributes.map(&:to_s)
       end

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -285,6 +285,7 @@ module Dynamoid
     #
     # @param name [Symbol] the name of the field
     # @param value [Object] the value to assign to that field
+    # @return [Dynamoid::Document] self
     #
     # @since 0.2.0
     def write_attribute(name, value)
@@ -305,6 +306,7 @@ module Dynamoid
       attribute_will_change!(name) if old_value != value_casted # Dirty API
 
       attributes[name] = value_casted
+      self
     end
     alias []= write_attribute
 

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -217,14 +217,18 @@ module Dynamoid
           field(hash_key)
         end
 
+        # The created_at/updated_at fields are declared in the `included` callback first.
+        # At that moment the only known setting is `Dynamoid::Config.timestamps`.
+        # Now `options[:timestamps]` may override the global setting for a model.
+        # So we need to make decision again and declare the fields or rollback thier declaration.
+        #
+        # Do not replace with `#timestamps_enabled?`.
         if options[:timestamps] && !Dynamoid::Config.timestamps
-          # Timestamp fields weren't declared in `included` hook because they
-          # are disabled globaly
+          # The fields weren't declared in `included` callback because they are disabled globaly
           field :created_at, :datetime
           field :updated_at, :datetime
         elsif options[:timestamps] == false && Dynamoid::Config.timestamps
-          # Timestamp fields were declared in `included` hook but they are
-          # disabled for a table
+          # The fields were declared in `included` callback but they are disabled for a table
           remove_field :created_at
           remove_field :updated_at
         end

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -209,6 +209,8 @@ module Dynamoid
       #
       # @since 0.4.0
       def table(options)
+        self.options = options
+
         # a default 'id' column is created when Dynamoid::Document is included
         unless attributes.key? hash_key
           remove_field :id

--- a/lib/dynamoid/indexes.rb
+++ b/lib/dynamoid/indexes.rb
@@ -5,7 +5,8 @@ module Dynamoid
     extend ActiveSupport::Concern
 
     # @private
-    # Types allowed in indexes:
+    # @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.PrimaryKey
+    # Types allowed in indexes
     PERMITTED_KEY_DYNAMODB_TYPES = %i[
       string
       binary

--- a/lib/dynamoid/loadable.rb
+++ b/lib/dynamoid/loadable.rb
@@ -8,12 +8,14 @@ module Dynamoid
       attrs.each do |key, value|
         send("#{key}=", value) if respond_to?("#{key}=")
       end
+
+      self
     end
 
     # Reload an object from the database -- if you suspect the object has changed in the data store and you need those
     # changes to be reflected immediately, you would call this method. This is a consistent read.
     #
-    # @return [Dynamoid::Document] the document this method was called on
+    # @return [Dynamoid::Document] self
     #
     # @since 0.2.0
     def reload

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -656,6 +656,12 @@ module Dynamoid
     #     t.delete(age: nil)
     #   end
     #
+    # or even without useless value at all:
+    #
+    #   user.update do |t|
+    #     t.delete(:age)
+    #   end
+    #
     # Operation +set+ just changes an attribute value:
     #
     #   user.update do |t|

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -365,6 +365,9 @@ module Dynamoid
       #
       #   User.inc('1', 'Tylor', age: 2)
       #
+      # It's an atomic operation it does not interfere with other write
+      # requests.
+      #
       # Uses efficient low-level +UpdateItem+ operation and does only one HTTP
       # request.
       #
@@ -575,10 +578,14 @@ module Dynamoid
     #     t.set(age: 21)
     #   end
     #
-    # All the operations works like +ADD+, +DELETE+ and +PUT+ actions supported
+    # All the operations work like +ADD+, +DELETE+ and +PUT+ actions supported
     # by +AttributeUpdates+
     # {parameter}[https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributeUpdates.html]
     # of +UpdateItem+ operation.
+    #
+    # It's an atomic operation. So adding or deleting elements in a collection
+    # or incrementing or decrementing a numeric field is atomic and does not
+    # interfere with other write requests.
     #
     # Can update a model conditionaly:
     #

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -625,7 +625,7 @@ module Dynamoid
           new_attrs = Dynamoid.adapter.update_item(table_name, hash_key, update_item_options) do |t|
             t.add(lock_version: 1) if self.class.attributes[:lock_version]
 
-            if Dynamoid::Config.timestamps
+            if self.class.timestamps_enabled?
               time_now = DateTime.now.in_time_zone(Time.zone)
               time_now_dumped = Dumping.dump_field(time_now, self.class.attributes[:updated_at])
               t.set(updated_at: time_now_dumped)

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -545,6 +545,7 @@ module Dynamoid
     # @return [Dynamoid::Document] self
     # @since 0.2.0
     def update_attribute(attribute, value)
+      # final implementation is in the Dynamoid::Validation module
       write_attribute(attribute, value)
       save
     end

--- a/lib/dynamoid/validations.rb
+++ b/lib/dynamoid/validations.rb
@@ -41,6 +41,7 @@ module Dynamoid
     def update_attribute(attribute, value)
       write_attribute(attribute, value)
       save(validate: false)
+      self
     end
 
     module ClassMethods

--- a/lib/dynamoid/validations.rb
+++ b/lib/dynamoid/validations.rb
@@ -38,6 +38,11 @@ module Dynamoid
       self
     end
 
+    def update_attribute(attribute, value)
+      write_attribute(attribute, value)
+      save(validate: false)
+    end
+
     module ClassMethods
       # Override validates_presence_of to handle false values as present.
       #

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -1186,13 +1186,14 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       end
 
       it 'deletes attributes' do
-        Dynamoid.adapter.put_item(test_table1, id: '1', hobbies: %w[skying climbing].to_set)
+        Dynamoid.adapter.put_item(test_table1, id: '1', hobbies: %w[skying climbing].to_set, category_id: 1)
 
         Dynamoid.adapter.update_item(test_table1, '1') do |t|
           t.delete(hobbies: nil)
+          t.delete(:category_id)
         end
 
-        expect(Dynamoid.adapter.get_item(test_table1, '1')).not_to include(:hobbies)
+        expect(Dynamoid.adapter.get_item(test_table1, '1')).not_to include(:hobbies, :category_id)
       end
 
       it 'sets attribute values' do

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -452,7 +452,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       end
     end
 
-    context 'when composite key' do
+    context 'when composite primary key' do
       it 'accepts one id passed as singular value' do
         skip 'It is not supported and needed yet'
 
@@ -499,7 +499,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       expect(items.size).to eq 101
     end
 
-    it 'loads unprocessed items for a table without a composite key' do
+    it 'loads unprocessed items for a table without a range key' do
       # BatchGetItem has following limitations:
       # * up to 100 items at once
       # * up to 16 MB at once
@@ -533,7 +533,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       expect(items.map { |h| h[:id] }).to match_array(ids)
     end
 
-    it 'loads unprocessed items for a table with a composite key' do
+    it 'loads unprocessed items for a table with a range key' do
       # BatchGetItem has following limitations:
       # * up to 100 items at once
       # * up to 16 MB at once

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -1175,7 +1175,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       end
 
       it 'deletes attribute values' do
-        Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh', hobbies: %w[skying climbing].to_set)
+        Dynamoid.adapter.put_item(test_table1, id: '1', hobbies: %w[skying climbing].to_set)
 
         Dynamoid.adapter.update_item(test_table1, '1') do |t|
           t.delete(hobbies: ['skying'].to_set)
@@ -1186,7 +1186,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       end
 
       it 'deletes attributes' do
-        Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh', hobbies: %w[skying climbing].to_set)
+        Dynamoid.adapter.put_item(test_table1, id: '1', hobbies: %w[skying climbing].to_set)
 
         Dynamoid.adapter.update_item(test_table1, '1') do |t|
           t.delete(hobbies: nil)

--- a/spec/dynamoid/dirty_spec.rb
+++ b/spec/dynamoid/dirty_spec.rb
@@ -28,10 +28,11 @@ describe Dynamoid::Dirty do
       obj = model.create(name: 'Bob')
       expect(obj.changed?).to eq false
 
-      obj.name = 'Bob'
+      obj = model.new
       expect(obj.changed?).to eq false
 
-      obj = model.new
+      obj = model.create(name: 'Bob')
+      obj.name = 'Bob'
       expect(obj.changed?).to eq false
     end
   end
@@ -50,10 +51,11 @@ describe Dynamoid::Dirty do
       obj = model.create(name: 'Alex')
       expect(obj.changed).to eq []
 
-      obj.name = 'Alex'
+      obj = model.new
       expect(obj.changed).to eq []
 
-      obj = model.new
+      obj = model.create(name: 'Alex')
+      obj.name = 'Alex'
       expect(obj.changed).to eq []
     end
   end
@@ -74,10 +76,11 @@ describe Dynamoid::Dirty do
       obj = model.create(name: 'Alex')
       expect(obj.changed_attributes).to eq({})
 
-      obj.name = 'Alex'
+      obj = model.new
       expect(obj.changed_attributes).to eq({})
 
-      obj = model.new
+      obj = model.create(name: 'Alex')
+      obj.name = 'Alex'
       expect(obj.changed_attributes).to eq({})
     end
   end
@@ -96,10 +99,11 @@ describe Dynamoid::Dirty do
       obj = model.create(name: 'Alex')
       expect(obj.changes).to eq({})
 
-      obj.name = 'Alex'
+      obj = model.new
       expect(obj.changes).to eq({})
 
-      obj = model.new
+      obj = model.create(name: 'Alex')
+      obj.name = 'Alex'
       expect(obj.changes).to eq({})
     end
   end
@@ -145,11 +149,12 @@ describe Dynamoid::Dirty do
       obj = model.create(name: 'Bob')
       expect(obj.name_changed?).to eq false
 
-      obj.name = 'Bob'
-      expect(obj.name_changed?).to eq false
-
       obj = model.new
       expect(obj.name_changed?).to eq false # in Rails => nil
+
+      obj = model.create(name: 'Bob')
+      obj.name = 'Bob'
+      expect(obj.name_changed?).to eq false
     end
   end
 
@@ -167,10 +172,11 @@ describe Dynamoid::Dirty do
       obj = model.create(name: 'Alex')
       expect(obj.name_change).to eq(nil)
 
-      obj.name = 'Alex'
+      obj = model.new
       expect(obj.name_change).to eq(nil)
 
-      obj = model.new
+      obj = model.create(name: 'Alex')
+      obj.name = 'Alex'
       expect(obj.name_change).to eq(nil)
     end
   end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -403,6 +403,16 @@ describe Dynamoid::Fields do
   end
 
   describe '#write_attribute' do
+    it 'writes attribute on the model' do
+      klass = new_class do
+        field :count, :integer
+      end
+
+      obj = klass.new
+      obj.write_attribute(:count, 10)
+      expect(obj.attributes[:count]).to eql(10)
+    end
+
     describe 'type casting' do
       it 'type casts attributes' do
         klass = new_class do
@@ -421,6 +431,28 @@ describe Dynamoid::Fields do
       expect {
         obj.write_attribute(:name, 'Alex')
       }.to raise_error Dynamoid::Errors::UnknownAttribute
+    end
+
+    it 'marks an attribute as changed' do
+      klass = new_class do
+        field :name
+      end
+
+      obj = klass.new
+      obj.write_attribute(:name, 'Alex')
+      expect(obj.name_changed?).to eq true
+    end
+
+    it 'does not mark an attribute as changed if new value equals the old one' do
+      klass = new_class do
+        field :name
+      end
+
+      obj = klass.create(name: 'Alex')
+      obj = klass.find(obj.id)
+
+      obj.write_attribute(:name, 'Alex')
+      expect(obj.name_changed?).to eq false
     end
   end
 end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -413,6 +413,16 @@ describe Dynamoid::Fields do
       expect(obj.attributes[:count]).to eql(10)
     end
 
+    it 'returns self' do
+      klass = new_class do
+        field :count, :integer
+      end
+
+      obj = klass.new
+      result = obj.write_attribute(:count, 10)
+      expect(result).to eql(obj)
+    end
+
     describe 'type casting' do
       it 'type casts attributes' do
         klass = new_class do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -989,6 +989,14 @@ describe Dynamoid::Persistence do
           document_class.update!(doc.id, name: '[Updated]')
         end.not_to raise_error
       end
+
+      it 'does not change updated_at if attributes were assigned the same values' do
+        doc = document_class.create(name: 'Document#1', updated_at: Time.now - 1)
+
+        expect do
+          document_class.update!(doc.id, name: doc.name)
+        end.not_to change { doc.reload.updated_at }
+      end
     end
 
     describe 'type casting' do
@@ -1170,6 +1178,14 @@ describe Dynamoid::Persistence do
         expect do
           document_class.update(doc.id, name: '[Updated]')
         end.not_to raise_error
+      end
+
+      it 'does not change updated_at if attributes were assigned the same values' do
+        doc = document_class.create(name: 'Document#1', updated_at: Time.now - 1)
+
+        expect do
+          document_class.update(doc.id, name: doc.name)
+        end.not_to change { doc.reload.updated_at }
       end
     end
 
@@ -2015,6 +2031,19 @@ describe Dynamoid::Persistence do
 
           expect { obj.save }.not_to raise_error
         end
+
+        it 'does not change updated_at if there are no changes' do
+          obj = klass.create(title: 'Old title', updated_at: Time.now - 1)
+
+          expect { obj.save }.not_to change { obj.updated_at }
+        end
+
+        it 'does not change updated_at if attributes were assigned the same values' do
+          obj = klass.create(title: 'Old title', updated_at: Time.now - 1)
+          obj.title = obj.title
+
+          expect { obj.save }.not_to change { obj.updated_at }
+        end
       end
     end
 
@@ -2119,6 +2148,15 @@ describe Dynamoid::Persistence do
         expect do
           obj.update_attribute(:title, 'New title')
         end.not_to raise_error
+      end
+
+      it 'does not change updated_at if attributes were assigned the same values' do
+        obj = klass.create(title: 'Old title', updated_at: Time.now - 1)
+        obj.title = obj.title
+
+        expect do
+          obj.update_attribute(:title, 'Old title')
+        end.not_to change { obj.updated_at }
       end
     end
 
@@ -2270,6 +2308,15 @@ describe Dynamoid::Persistence do
         expect do
           obj.update_attributes(title: 'New title')
         end.not_to raise_error
+      end
+
+      it 'does not change updated_at if attributes were assigned the same values' do
+        obj = klass.create(title: 'Old title', updated_at: Time.now - 1)
+        obj.title = obj.title
+
+        expect do
+          obj.update_attributes(title: 'Old title')
+        end.not_to change { obj.updated_at }
       end
     end
 
@@ -2426,6 +2473,15 @@ describe Dynamoid::Persistence do
         expect do
           obj.update_attributes!(title: 'New title')
         end.not_to raise_error
+      end
+
+      it 'does not change updated_at if attributes were assigned the same values' do
+        obj = klass.create(title: 'Old title', updated_at: Time.now - 1)
+        obj.title = obj.title
+
+        expect do
+          obj.update_attributes!(title: 'Old title')
+        end.not_to change { obj.updated_at }
       end
     end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -416,11 +416,6 @@ describe Dynamoid::Persistence do
       end
 
       it 'sets up TTL for table' do
-        # Run the spec when a fix in rspec-mock is released
-        # - https://github.com/rspec/rspec-mocks/issues/1306
-        # - https://github.com/rspec/rspec-mocks/pull/1385
-        skip "There is an issue with Ruby 3.0 and rspec-mocks related to keyword arguments"
-
         expect(Dynamoid.adapter).to receive(:update_time_to_live)
           .with(class_with_expiration.table_name, :ttl)
           .and_call_original

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -2100,6 +2100,39 @@ describe Dynamoid::Persistence do
   end
 
   describe '#update_attribute' do
+    it 'changes the attribute value' do
+      klass = new_class do
+        field :age, :integer
+      end
+
+      obj = klass.create(age: 18)
+
+      expect { obj.update_attribute(:age, 20) }.to change { obj.age }.from(18).to(20)
+    end
+
+    it 'persists the model' do
+      klass = new_class do
+        field :age, :integer
+      end
+
+      obj = klass.create(age: 18)
+      obj.update_attribute(:age, 20)
+
+      expect(klass.find(obj.id).age).to eq(20)
+    end
+
+    it 'skips validation and saves not valid models' do
+      klass = new_class do
+        field :age, :integer
+        validates :age, numericality: { greater_than: 0 }
+      end
+
+      obj = klass.create(age: 18)
+      obj.update_attribute(:age, -1)
+
+      expect(klass.find(obj.id).age).to eq(-1)
+    end
+
     describe 'type casting' do
       it 'type casts attributes' do
         klass = new_class do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -2932,6 +2932,15 @@ describe Dynamoid::Persistence do
           obj.update { |d| d.set(title: 'New title') }
         end.not_to raise_error
       end
+
+      it 'does not set updated_at if Config.timestamps=true and table timestamps=false', config: { timestamps: true } do
+        klass.table timestamps: false
+
+        obj = klass.create(title: 'Old title')
+        obj.update { |d| d.set(title: 'New title') }
+
+        expect(obj.reload.attributes).to_not have_key(:updated_at)
+      end
     end
 
     context ':raw field' do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -2664,7 +2664,7 @@ describe Dynamoid::Persistence do
     end
   end
 
-  describe '#decrement' do
+  describe '#decrement!' do
     let(:document_class) do
       new_class do
         field :age, :integer
@@ -2717,9 +2717,13 @@ describe Dynamoid::Persistence do
     end
   end
 
-  context 'update' do
+  context '#update!' do
+    # TODO: add some specs
+  end
+
+  describe '#update' do
     before :each do
-      @tweet = Tweet.create(tweet_id: 1, group: 'abc', count: 5, tags: Set.new(%w[db sql]), user_name: 'john')
+      @tweet = Tweet.create(tweet_id: 1, group: 'abc', count: 5, tags: Set.new(%w[db sql]), user_name: 'John')
     end
 
     it 'runs before_update callbacks when doing #update' do
@@ -2738,14 +2742,16 @@ describe Dynamoid::Persistence do
       end
     end
 
-    it 'support add/delete operation on a field' do
+    it 'supports add/delete/set operations on a field' do
       @tweet.update do |t|
         t.add(count: 3)
         t.delete(tags: Set.new(['db']))
+        t.set(user_name: 'Alex')
       end
 
       expect(@tweet.count).to eq(8)
       expect(@tweet.tags.to_a).to eq(['sql'])
+      expect(@tweet.user_name).to eq ('Alex')
     end
 
     it 'checks the conditions on update' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,13 +3,6 @@
 # Standard Libs
 # N/A
 
-# Engine Conditional Libs
-if RUBY_ENGINE == 'jruby'
-  # Workaround for JRuby CI failure https://github.com/jruby/jruby/issues/6547#issuecomment-774104996
-  require 'i18n/backend'
-  require 'i18n/backend/simple'
-end
-
 # Third Party Libs
 # https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support
 require 'active_support'


### PR DESCRIPTION
Changes:
- fixed `#update!`/`#update` methods - handling of a table-specific `timestamps` option
- fixed `#update_attribute` - skip validation
- return `self` in some public methods to enable methods chaining
- updated Readme.md and rubydoc comments
- minor refactoring
- run specs on CI against JRuby again