### PR TITLE
Clarify behavior of upsert when document already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,6 +961,14 @@ Address.upsert(id, city: 'Chicago')
 Address.upsert(id, { city: 'Chicago' }, if: { deliverable: true })
 ```
 
+By default, `#upsert` will update all attributes of the document if it already exists.
+To idempotently create-but-not-update a record, apply the `unless_exists` condition
+to its keys when you upsert.
+
+```ruby
+Address.upsert(id, { city: 'Chicago' }, if: {unless_exists: [:id]})
+```
+
 ### Deleting
 
 In order to delete some items `delete_all` method should be used. Any

--- a/README.md
+++ b/README.md
@@ -966,7 +966,7 @@ To idempotently create-but-not-update a record, apply the `unless_exists` condit
 to its keys when you upsert.
 
 ```ruby
-Address.upsert(id, { city: 'Chicago' }, if: {unless_exists: [:id]})
+Address.upsert(id, { city: 'Chicago' }, if: { unless_exists: [:id] })
 ```
 
 ### Deleting


### PR DESCRIPTION
This almost caused an outage in production; thankfully I tested it, but I figured others might appreciate a how-to.