### PR TITLE
Fix #increment! and #decrement! methods to behave similar to the Rails' ActiveRecord methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
           - rails_6_1
           - rails_7_0
         rubygems:
-          - latest
+          - default
         bundler:
-          - latest
+          - default
         ruby:
           - "2.3"
           - "2.4"

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -798,9 +798,7 @@ module Dynamoid
     # @param by [Numeric] value to subtract (optional)
     # @return [Dynamoid::Document] self
     def decrement(attribute, by = 1)
-      self[attribute] ||= 0
-      self[attribute] -= by
-      self
+      increment(attribute, -by)
     end
 
     # Change numeric attribute value and save a model.
@@ -828,11 +826,7 @@ module Dynamoid
     # @param touch [true | Symbol | Array[Symbol]] to update update_at attribute and optionally the specified ones
     # @return [Dynamoid::Document] self
     def decrement!(attribute, by = 1, touch: nil)
-      decrement(attribute, by)
-      change = read_attribute(attribute) - (attribute_was(attribute) || 0)
-      self.class.inc(hash_key, range_value, attribute => change, touch: touch)
-      clear_attribute_changes(attribute)
-      self
+      increment!(attribute, -by, touch: touch)
     end
 
     # Delete a model.

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -815,13 +815,22 @@ module Dynamoid
     # modified attributes will still be dirty. Validations and callbacks are
     # skipped.
     #
+    # When `:touch` option is passed the timestamp columns are updating. If
+    # attribute names are passed, they are updated along with updated_at
+    # attribute:
+    #
+    #   user.decrement!(:followers_count, touch: true)
+    #   user.decrement!(:followers_count, touch: :viewed_at)
+    #   user.decrement!(:followers_count, touch: [:viewed_at, :accessed_at])
+    #
     # @param attribute [Symbol] attribute name
     # @param by [Numeric] value to subtract (optional)
+    # @param touch [true | Symbol | Array[Symbol]] to update update_at attribute and optionally the specified ones
     # @return [Dynamoid::Document] self
-    def decrement!(attribute, by = 1)
+    def decrement!(attribute, by = 1, touch: nil)
       decrement(attribute, by)
       change = read_attribute(attribute) - (attribute_was(attribute) || 0)
-      self.class.inc(hash_key, range_value, attribute => change)
+      self.class.inc(hash_key, range_value, attribute => change, touch: touch)
       clear_attribute_changes(attribute)
       self
     end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -766,13 +766,22 @@ module Dynamoid
     # modified attributes will still be dirty. Validations and callbacks are
     # skipped.
     #
+    # When `:touch` option is passed the timestamp columns are updating. If
+    # attribute names are passed, they are updated along with updated_at
+    # attribute:
+    #
+    #   user.increment!(:followers_count, touch: true)
+    #   user.increment!(:followers_count, touch: :viewed_at)
+    #   user.increment!(:followers_count, touch: [:viewed_at, :accessed_at])
+    #
     # @param attribute [Symbol] attribute name
     # @param by [Numeric] value to add (optional)
+    # @param touch [true | Symbol | Array[Symbol]] to update update_at attribute and optionally the specified ones
     # @return [Dynamoid::Document] self
-    def increment!(attribute, by = 1)
+    def increment!(attribute, by = 1, touch: nil)
       increment(attribute, by)
       change = read_attribute(attribute) - (attribute_was(attribute) || 0)
-      self.class.inc(hash_key, range_value, attribute => change)
+      self.class.inc(hash_key, range_value, attribute => change, touch: touch)
       clear_attribute_changes(attribute)
       self
     end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -736,14 +736,19 @@ module Dynamoid
     #   user.increment!(:followers_count)
     #   user.increment!(:followers_count, 2)
     #
-    # Returns +true+ if a model was saved and +false+ otherwise.
+    # Only `attribute` is saved. The model itself is not saved. So any other
+    # modified attributes will still be dirty. Validations and callbacks are
+    # skipped.
     #
     # @param attribute [Symbol] attribute name
     # @param by [Numeric] value to add (optional)
-    # @return [true|false] whether saved model successfully
+    # @return [Dynamoid::Document] self
     def increment!(attribute, by = 1)
       increment(attribute, by)
-      save
+      change = read_attribute(attribute) - (attribute_was(attribute) || 0)
+      self.class.inc(hash_key, range_value, attribute => change)
+      clear_attribute_changes(attribute)
+      self
     end
 
     # Change numeric attribute value.

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -776,14 +776,19 @@ module Dynamoid
     #   user.decrement!(:followers_count)
     #   user.decrement!(:followers_count, 2)
     #
-    # Returns +true+ if a model was saved and +false+ otherwise.
+    # Only `attribute` is saved. The model itself is not saved. So any other
+    # modified attributes will still be dirty. Validations and callbacks are
+    # skipped.
     #
     # @param attribute [Symbol] attribute name
     # @param by [Numeric] value to subtract (optional)
-    # @return [true|false] whether saved model successfully
+    # @return [Dynamoid::Document] self
     def decrement!(attribute, by = 1)
       decrement(attribute, by)
-      save
+      change = read_attribute(attribute) - (attribute_was(attribute) || 0)
+      self.class.inc(hash_key, range_value, attribute => change)
+      clear_attribute_changes(attribute)
+      self
     end
 
     # Delete a model.

--- a/lib/dynamoid/persistence/inc.rb
+++ b/lib/dynamoid/persistence/inc.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module Persistence
+    # @private
+    class Inc
+      def self.call(model_class, hash_key, range_key = nil, counters)
+        new(model_class, hash_key, range_key, counters).call
+      end
+
+      # rubocop:disable Style/OptionalArguments
+      def initialize(model_class, hash_key, range_key = nil, counters)
+        @model_class = model_class
+        @hash_key = hash_key
+        @range_key = range_key
+        @counters = counters
+      end
+      # rubocop:enable Style/OptionalArguments
+
+      def call
+        touch = @counters.delete(:touch)
+
+        Dynamoid.adapter.update_item(@model_class.table_name, @hash_key, update_item_options) do |t|
+          @counters.each do |name, value|
+            t.add(name => cast_and_dump_attribute_value(name, value))
+          end
+
+          if touch
+            value = DateTime.now.in_time_zone(Time.zone)
+
+            timestamp_attributes_to_touch(touch).each do |name|
+              t.set(name => cast_and_dump_attribute_value(name, value))
+            end
+          end
+        end
+      end
+
+      private
+
+      def update_item_options
+        if @model_class.range_key
+          range_key_options = @model_class.attributes[@model_class.range_key]
+          value_casted = TypeCasting.cast_field(@range_key, range_key_options)
+          value_dumped = Dumping.dump_field(value_casted, range_key_options)
+          { range_key: value_dumped }
+        else
+          {}
+        end
+      end
+
+      def cast_and_dump_attribute_value(name, value)
+        value_casted = TypeCasting.cast_field(value, @model_class.attributes[name])
+        Dumping.dump_field(value_casted, @model_class.attributes[name])
+      end
+
+      def timestamp_attributes_to_touch(touch)
+        return [] unless touch
+
+        names = []
+        names << :updated_at if @model_class.timestamps_enabled?
+        names += Array.wrap(touch) if touch != true
+        names
+      end
+    end
+  end
+end

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -2830,48 +2830,115 @@ describe Dynamoid::Persistence do
     end
 
     it 'decrements specified attribute' do
-      obj = document_class.new(age: 21)
+      obj = document_class.create(age: 21)
 
       expect { obj.decrement!(:age) }.to change { obj.age }.from(21).to(20)
     end
 
     it 'initializes the attribute with zero if nil' do
-      obj = document_class.new(age: nil)
+      obj = document_class.create(age: nil)
 
       expect { obj.decrement!(:age) }.to change { obj.age }.from(nil).to(-1)
     end
 
     it 'adds specified optional value' do
-      obj = document_class.new(age: 21)
+      obj = document_class.create(age: 21)
 
       expect { obj.decrement!(:age, 10) }.to change { obj.age }.from(21).to(11)
     end
 
-    it 'returns true if document is valid' do
-      class_with_validation = new_class do
-        field :age, :integer
-        validates :age, numericality: { greater_than: 16 }
-      end
-      obj = class_with_validation.new(age: 20)
+    it 'persists the attribute new value' do
+      obj = document_class.create(age: 21)
+      obj.decrement!(:age, 10)
+      obj_loaded = document_class.find(obj.id)
 
-      expect(obj.decrement!(:age, 1)).to eql(true)
+      expect(obj_loaded.age).to eq 11
     end
 
-    it 'returns false if document is invalid' do
-      class_with_validation = new_class do
+    it 'does not persist other changed attributes' do
+      klass = new_class do
         field :age, :integer
-        validates :age, numericality: { greater_than: 16 }
+        field :title
       end
-      obj = class_with_validation.new(age: 20)
 
-      expect(obj.decrement!(:age, 10)).to eql(false)
-    end
-
-    it 'saves changes' do
-      obj = document_class.new(age: 21)
+      obj = klass.create!(age: 21, title: 'title')
+      obj.title = 'new title'
       obj.decrement!(:age)
 
-      expect(obj).to be_persisted
+      obj_loaded = klass.find(obj.id)
+      expect(obj_loaded.title).to eq 'title'
+    end
+
+    it 'does not restore other changed attributes persisted values' do
+      klass = new_class do
+        field :age, :integer
+        field :title
+      end
+
+      obj = klass.create!(age: 21, title: 'title')
+      obj.title = 'new title'
+      obj.decrement!(:age)
+
+      expect(obj.title).to eq 'new title'
+      expect(obj.title_changed?).to eq true
+    end
+
+    it 'returns self' do
+      obj = document_class.create(age: 21)
+      expect(obj.decrement!(:age, 10)).to eq obj
+    end
+
+    it 'marks the attribute as not changed' do
+      obj = document_class.create(age: 21)
+      obj.decrement!(:age, 10)
+
+      expect(obj.age_changed?).to eq false
+    end
+
+    it 'skips validation' do
+      class_with_validation = new_class do
+        field :age, :integer
+        validates :age, numericality: { greater_than: 16 }
+      end
+
+      obj = class_with_validation.create!(age: 20)
+      obj.decrement!(:age, 7)
+      expect(obj.valid?).to eq false
+
+      obj_loaded = class_with_validation.find(obj.id)
+      expect(obj_loaded.age).to eq 13
+    end
+
+    it 'skips callbacks' do
+      klass = new_class do
+        field :age, :integer
+        field :title
+
+        before_save :before_save_callback
+
+        def before_save_callback; end
+      end
+
+      obj = klass.new(age: 21)
+
+      expect(obj).to receive(:before_save_callback)
+      obj.save!
+
+      expect(obj).not_to receive(:before_save_callback)
+      obj.decrement!(:age, 10)
+    end
+
+    it 'works well if there is a sort key' do
+      klass_with_sort_key = new_class do
+        range :name
+        field :age, :integer
+      end
+
+      obj = klass_with_sort_key.create(name: 'Alex', age: 21)
+      obj.decrement!(:age, 10)
+      obj_loaded = klass_with_sort_key.find(obj.id, range_key: obj.name)
+
+      expect(obj_loaded.age).to eq 11
     end
   end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -2826,6 +2826,28 @@ describe Dynamoid::Persistence do
 
       expect(obj_loaded.age).to eq 31
     end
+
+    it 'updates `updated_at` attribute when touch: true option passed' do
+      obj = document_class.create(age: 21, updated_at: Time.now - 1.day)
+
+      expect { obj.increment!(:age) }.not_to change { document_class.find(obj.id).updated_at }
+      expect { obj.increment!(:age, touch: true) }.to change { document_class.find(obj.id).updated_at }
+    end
+
+    it 'updates `updated_at` and the specified attributes when touch: [<name>*] option passed' do
+      klass = new_class do
+        field :age, :integer
+        field :viewed_at, :datetime
+      end
+
+      obj = klass.create(age: 21, viewed_at: Time.now - 1.day, updated_at: Time.now - 2.days)
+
+      expect do
+        expect do
+          obj.increment!(:age, touch: [:viewed_at])
+        end.to change { klass.find(obj.id).updated_at }
+      end.to change { klass.find(obj.id).viewed_at }
+    end
   end
 
   describe '#decrement' do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -3007,6 +3007,28 @@ describe Dynamoid::Persistence do
 
       expect(obj_loaded.age).to eq 11
     end
+
+    it 'updates `updated_at` attribute when touch: true option passed' do
+      obj = document_class.create(age: 21, updated_at: Time.now - 1.day)
+
+      expect { obj.decrement!(:age) }.not_to change { document_class.find(obj.id).updated_at }
+      expect { obj.decrement!(:age, touch: true) }.to change { document_class.find(obj.id).updated_at }
+    end
+
+    it 'updates `updated_at` and the specified attributes when touch: [<name>*] option passed' do
+      klass = new_class do
+        field :age, :integer
+        field :viewed_at, :datetime
+      end
+
+      obj = klass.create(age: 21, viewed_at: Time.now - 1.day, updated_at: Time.now - 2.days)
+
+      expect do
+        expect do
+          obj.decrement!(:age, touch: [:viewed_at])
+        end.to change { klass.find(obj.id).updated_at }
+      end.to change { klass.find(obj.id).viewed_at }
+    end
   end
 
   describe '#update!' do


### PR DESCRIPTION
Changes:
- `#increment!`/`#decrement!`:
  - returns self, not boolean
  - saves only the attribute new value, not other modified attributes
  - skips callbacks and validation
  - does not reload a model
  - support a `:touch` option (similar to the Rails' `increment!` and `#decrement!` methods that is described [here](https://apidock.com/rails/ActiveRecord/CounterCache/ClassMethods/update_counters))
- `.inc`
  - support the `:touch` option similar to the equivalent Rails' method `.update_counters`
- fix CI for Ruby 2.3-2.5 and use default RubyGems and Bundler versions (see https://github.com/ruby/setup-ruby/issues/441) 

Related links:
- https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-decrement-21
- https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-increment-21
- https://api.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-update_counters