### PR TITLE
Fix .import and mark attributes of persisted models as not changed/dirty

### DIFF
--- a/lib/dynamoid/persistence/import.rb
+++ b/lib/dynamoid/persistence/import.rb
@@ -24,7 +24,10 @@ module Dynamoid
           import_with_backoff(models)
         end
 
-        models.each { |d| d.new_record = false }
+        models.each do |m|
+          m.new_record = false
+          m.clear_changes_information
+        end
         models
       end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -3819,6 +3819,17 @@ describe Dynamoid::Persistence do
       expect(raw_attributes(obj)[:count]).to eql(101)
     end
 
+    it 'marks all the attributes as not changed/dirty' do
+      klass = new_class do
+        field :count, :integer
+      end
+      klass.create_table
+
+      objects = klass.import([{ count: '101' }])
+      obj = objects[0]
+      expect(obj.changed?).to eql false
+    end
+
     context 'backoff is specified' do
       let(:backoff_strategy) do
         ->(_) { -> { @counter += 1 } }


### PR DESCRIPTION
After importing models their attributes were still marked as dirty despite the fact that the changes are saved.

Example to illustrate:

```ruby
users = User.import([{}])
users[0].changes? # => true
```