### PR TITLE
Fix save(touch: false)

### DIFF
--- a/lib/dynamoid/persistence/save.rb
+++ b/lib/dynamoid/persistence/save.rb
@@ -20,7 +20,7 @@ module Dynamoid
 
         @model.created_at ||= DateTime.now.in_time_zone(Time.zone) if @model.class.timestamps_enabled?
 
-        if @model.class.timestamps_enabled? && @model.changed? && !@model.updated_at_changed? && @touch != false
+        if @model.class.timestamps_enabled? && !@model.updated_at_changed? && !(@touch == false && @model.persisted?)
           @model.updated_at = DateTime.now.in_time_zone(Time.zone)
         end
 

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -2450,6 +2450,13 @@ describe Dynamoid::Persistence do
 
         expect(obj.updated_at).to eq updated_at
       end
+
+      it 'sets updated_at attribute for a new record' do
+        obj = klass.new(name: 'foo')
+        obj.save(touch: false)
+
+        expect(klass.find(obj.id).updated_at).to be_present
+      end
     end
   end
 


### PR DESCRIPTION
Fix a minor Rails compatibility issue with `#save(touch: false)`. If it's a new record then set `updated_at` attribute even if `touch: false` option is passed.
