### PR TITLE
Add #inspect method to display only attributes

### DIFF
--- a/lib/dynamoid/document.rb
+++ b/lib/dynamoid/document.rb
@@ -294,6 +294,26 @@ module Dynamoid
       end
     end
 
+    def inspect
+      # attributes order is:
+      # - partition key
+      # - sort key
+      # - user defined attributes
+      # - timestamps - created_at/updated_at
+      names = [self.class.hash_key]
+      names << self.class.range_key if self.class.range_key
+      names += self.class.attributes.keys - names - %i[created_at updated_at]
+      names << :created_at if self.class.attributes.key?(:created_at)
+      names << :updated_at if self.class.attributes.key?(:updated_at)
+
+      inspection = names.map do |name|
+        value = read_attribute(name)
+        "#{name}: #{value.inspect}"
+      end.join(', ')
+
+      "#<#{self.class.name} #{inspection}>"
+    end
+
     private
 
     def dumped_range_value

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -389,4 +389,28 @@ describe Dynamoid::Document do
       expect(class_with_timestamps_true.new).to respond_to(:updated_at)
     end
   end
+
+  describe '#inspect' do
+    it 'returns a String containing a model class name and a list of attributes and values' do
+      klass = new_class(class_name: 'Person') do
+        field :name
+        field :age, :integer
+      end
+
+      object = klass.new(name: 'Alex', age: 21)
+      puts object.attributes
+      expect(object.inspect).to eql '#<Person id: nil, name: "Alex", age: 21, created_at: nil, updated_at: nil>'
+    end
+
+    it 'puts partition and sort keys on the first place' do
+      klass = new_class(class_name: 'Person') do
+        field :name
+        field :age, :integer
+        range :city
+      end
+
+      object = klass.new(city: 'Kyiv')
+      expect(object.inspect).to eql '#<Person id: nil, city: "Kyiv", name: nil, age: nil, created_at: nil, updated_at: nil>'
+    end
+  end
 end


### PR DESCRIPTION
Problem - there are a lot of "system" instance variables in a model that mostly come from the Dirty module. Here we hide this internal details like Rails does.

```ruby
u = User.create(name: 'Andrii', age: 37)
u.inspect
# => "#<User id: \"ff500e9a-4120-449a-aca3-0aad3ac39198\", name: \"Andrii\", age: 37, created_at: Sun, 05 Feb 2023 22:30:17 +0200, updated_at: Sun, 05 Feb 2023 22:30:17 +0200>"
```