### PR TITLE
Add after_find callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,9 +546,18 @@ model.save(validate: false)
 
 ### Callbacks
 
-Dynamoid also employs ActiveModel callbacks. Right now, callbacks are
-defined on `save`, `update`, `destroy`, which allows you to do `before_`
-or `after_` any of those.
+Dynamoid also employs ActiveModel callbacks. Right now the following
+callbacks are supported:
+- `save` (before, after, around)
+- `create` (before, after, around)
+- `update` (before, after, around)
+- `validation` (before, after)
+- `destroy` (before, after, around)
+- `after_touch`
+- `after_initialize`
+- `after_find`
+
+Example:
 
 ```ruby
 class User

--- a/lib/dynamoid/components.rb
+++ b/lib/dynamoid/components.rb
@@ -12,7 +12,7 @@ module Dynamoid
       extend ActiveModel::Callbacks
 
       define_model_callbacks :create, :save, :destroy, :update
-      define_model_callbacks :initialize, :touch, only: :after
+      define_model_callbacks :initialize, :find, :touch, only: :after
 
       before_save :set_expires_field
       after_initialize :set_inheritance_field

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -525,6 +525,7 @@ module Dynamoid
       def pages
         raw_pages.lazy.map do |items, options|
           models = items.map { |i| source.from_database(i) }
+          models.each { |m| m.run_callbacks :find }
           [models, options]
         end.each
       end

--- a/spec/dynamoid/criteria/chain_spec.rb
+++ b/spec/dynamoid/criteria/chain_spec.rb
@@ -1162,6 +1162,44 @@ describe Dynamoid::Criteria::Chain do
         expect(actual).to eq [obj]
       end
     end
+
+    describe 'callbacks' do
+      it 'runs after_initialize callback' do
+        klass_with_callback = new_class do
+          field :name
+          after_initialize { print 'run after_initialize' }
+        end
+
+        object = klass_with_callback.create!(name: 'Alex')
+
+        expect { klass_with_callback.where(name: 'Alex').to_a }.to output('run after_initialize').to_stdout
+      end
+
+      it 'runs after_find callback' do
+        klass_with_callback = new_class do
+          field :name
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!(name: 'Alex')
+
+        expect { klass_with_callback.where(name: 'Alex').to_a }.to output('run after_find').to_stdout
+      end
+
+      it 'runs callbacks in the proper order' do
+        klass_with_callback = new_class do
+          field :name
+          after_initialize { print 'run after_initialize' }
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!(name: 'Alex')
+
+        expect do
+          klass_with_callback.where(name: 'Alex').to_a
+        end.to output('run after_initialize' + 'run after_find').to_stdout
+      end
+    end
   end
 
   describe '#find_by_pages' do
@@ -1191,6 +1229,48 @@ describe Dynamoid::Criteria::Chain do
         [all(be_kind_of(model)), { last_evaluated_key: an_instance_of(Hash) }],
         [all(be_kind_of(model)), { last_evaluated_key: nil }],
       )
+    end
+
+    describe 'callbacks' do
+      it 'runs after_initialize callback' do
+        klass_with_callback = new_class do
+          field :name
+          after_initialize { print 'run after_initialize' }
+        end
+
+        object = klass_with_callback.create!(name: 'Alex')
+
+        expect do
+          klass_with_callback.where(name: 'Alex').find_by_pages { |*| }
+        end.to output('run after_initialize').to_stdout
+      end
+
+      it 'runs after_find callback' do
+        klass_with_callback = new_class do
+          field :name
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!(name: 'Alex')
+
+        expect do
+          klass_with_callback.where(name: 'Alex').find_by_pages { |*| }
+        end.to output('run after_find').to_stdout
+      end
+
+      it 'runs callbacks in the proper order' do
+        klass_with_callback = new_class do
+          field :name
+          after_initialize { print 'run after_initialize' }
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!(name: 'Alex')
+
+        expect do
+          klass_with_callback.where(name: 'Alex').find_by_pages { |*| }
+        end.to output('run after_initialize' + 'run after_find').to_stdout
+      end
     end
   end
 
@@ -1569,6 +1649,45 @@ describe Dynamoid::Criteria::Chain do
         expect(scope.first).to be_present
         expect(scope.count).to eq 3
         expect(scope.all.to_a.size).to eq 3
+      end
+    end
+
+    describe 'callbacks' do
+      it 'runs after_initialize callback' do
+        klass_with_callback = new_class do
+          after_initialize { print 'run after_initialize' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect do
+          klass_with_callback.first
+        end.to output('run after_initialize').to_stdout
+      end
+
+      it 'runs after_find callback' do
+        klass_with_callback = new_class do
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect do
+          klass_with_callback.first
+        end.to output('run after_find').to_stdout
+      end
+
+      it 'runs callbacks in the proper order' do
+        klass_with_callback = new_class do
+          after_initialize { print 'run after_initialize' }
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect do
+          klass_with_callback.first
+        end.to output('run after_initialize' + 'run after_find').to_stdout
       end
     end
   end

--- a/spec/dynamoid/document_spec.rb
+++ b/spec/dynamoid/document_spec.rb
@@ -94,10 +94,10 @@ describe Dynamoid::Document do
     describe 'callbacks' do
       it 'runs after_initialize callback' do
         klass_with_callback = new_class do
-          after_initialize { print 'run after_update' }
+          after_initialize { print 'run after_initialize' }
         end
 
-        expect { klass_with_callback.new }.to output('run after_update').to_stdout
+        expect { klass_with_callback.new }.to output('run after_initialize').to_stdout
       end
     end
   end

--- a/spec/dynamoid/finders_spec.rb
+++ b/spec/dynamoid/finders_spec.rb
@@ -348,6 +348,41 @@ describe Dynamoid::Finders do
         end
       end
     end
+
+    describe 'callbacks' do
+      it 'runs after_initialize callback' do
+        klass_with_callback = new_class do
+          after_initialize { print 'run after_initialize' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect { klass_with_callback.find(object.id) }.to output('run after_initialize').to_stdout
+      end
+
+      it 'runs after_find callback' do
+        klass_with_callback = new_class do
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect { klass_with_callback.find(object.id) }.to output('run after_find').to_stdout
+      end
+
+      it 'runs callbacks in the proper order' do
+        klass_with_callback = new_class do
+          after_initialize { print 'run after_initialize' }
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect do
+          klass_with_callback.find(object.id)
+        end.to output('run after_initialize' + 'run after_find').to_stdout
+      end
+    end
   end
 
   it 'sends consistent option to the adapter' do
@@ -442,6 +477,41 @@ describe Dynamoid::Finders do
       user_ids = [%w[1 red], %w[1 green]]
       Dynamoid.adapter.expects(:read).with(anything, user_ids, consistent_read: true)
       User.find_all(user_ids, consistent_read: true)
+    end
+
+    describe 'callbacks' do
+      it 'runs after_initialize callback' do
+        klass_with_callback = new_class do
+          after_initialize { print 'run after_initialize' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect { klass_with_callback.find_all([object.id]) }.to output('run after_initialize').to_stdout
+      end
+
+      it 'runs after_find callback' do
+        klass_with_callback = new_class do
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect { klass_with_callback.find_all([object.id]) }.to output('run after_find').to_stdout
+      end
+
+      it 'runs callbacks in the proper order' do
+        klass_with_callback = new_class do
+          after_initialize { print 'run after_initialize' }
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect do
+          klass_with_callback.find_all([object.id])
+        end.to output('run after_initialize' + 'run after_find').to_stdout
+      end
     end
   end
 

--- a/spec/dynamoid/loadable_spec.rb
+++ b/spec/dynamoid/loadable_spec.rb
@@ -66,5 +66,40 @@ describe Dynamoid::Loadable do
       expect { copy.reload }.to change { copy.new_record? }.from(true).to(false)
       expect(copy.message).to eq 'a'
     end
+
+    describe 'callbacks' do
+      it 'runs after_initialize callback' do
+        klass_with_callback = new_class do
+          after_initialize { print 'run after_initialize' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect { object.reload }.to output('run after_initialize').to_stdout
+      end
+
+      it 'runs after_find callback' do
+        klass_with_callback = new_class do
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect { object.reload }.to output('run after_find').to_stdout
+      end
+
+      it 'runs callbacks in the proper order' do
+        klass_with_callback = new_class do
+          after_initialize { print 'run after_initialize' }
+          after_find { print 'run after_find' }
+        end
+
+        object = klass_with_callback.create!
+
+        expect do
+          object.reload
+        end.to output('run after_initialize' + 'run after_find').to_stdout
+      end
+    end
   end
 end


### PR DESCRIPTION
Changes:
- added `after_find` callback
- added specs on both `after_initialize` and `after_find` callbacks

`after_find` callback works in the same way like it does in Rails. It's called after `after_initialize` at loading a model from DynamoDB.

The following methods trigger it:
- `find`
- `find_all`
- `reload`
- `where`
- `last`/`first`
- `find_by_page`

https://guides.rubyonrails.org/active_record_callbacks.html#after-initialize-and-after-find