### PR TITLE
Fix `unless_exists` example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,7 +963,7 @@ To idempotently create-but-not-update a record, apply the `unless_exists` condit
 to its keys when you upsert.
 
 ```ruby
-Address.upsert(id, { city: 'Chicago' }, if: { unless_exists: [:id] })
+Address.upsert(id, { city: 'Chicago' }, { unless_exists: [:id] })
 ```
 
 ### Deleting

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -631,10 +631,7 @@ module Dynamoid
         conditions.delete(:unless_exists).try(:each) do |col|
           expected[col.to_s][:exists] = false
         end
-        conditions.delete(:if_exists).try(:each) do |col, val|
-          expected[col.to_s][:exists] = true
-          expected[col.to_s][:value] = val
-        end
+
         conditions.delete(:if).try(:each) do |col, val|
           expected[col.to_s][:value] = val
         end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -271,13 +271,20 @@ module Dynamoid
       # meets the specified conditions. Conditions can be specified as a +Hash+
       # with +:if+ key:
       #
-      #   User.update_fields('1', { age: 26 }, if: { version: 1 })
+      #   User.update_fields('1', { age: 26 }, { if: { version: 1 } })
       #
       # Here +User+ model has an integer +version+ field and the document will
       # be updated only if the +version+ attribute currently has value 1.
       #
       # If a document with specified hash and range keys doesn't exist or
       # conditions were specified and failed the method call returns +nil+.
+      #
+      # To check if some attribute (or attributes) isn't stored in a DynamoDB
+      # item (e.g. it wasn't set explicitly) there is another condition -
+      # +unless_exists+:
+      #
+      #   user = User.create(name: 'Tylor')
+      #   User.update_fields(user.id, { age: 18 }, { unless_exists: [:age] })
       #
       # +update_fields+ uses the +UpdateItem+ operation so it saves changes and
       # loads an updated document back with one HTTP request.
@@ -323,10 +330,17 @@ module Dynamoid
       # meets the specified conditions. Conditions can be specified as a +Hash+
       # with +:if+ key:
       #
-      #   User.upsert('1', { age: 26 }, if: { version: 1 })
+      #   User.upsert('1', { age: 26 }, { if: { version: 1 } })
       #
       # Here +User+ model has an integer +version+ field and the document will
       # be updated only if the +version+ attribute currently has value 1.
+      #
+      # To check if some attribute (or attributes) isn't stored in a DynamoDB
+      # item (e.g. it wasn't set explicitly) there is another condition -
+      # +unless_exists+:
+      #
+      #   user = User.create(name: 'Tylor')
+      #   User.upsert(user.id, { age: 18 }, { unless_exists: [:age] })
       #
       # If conditions were specified and failed the method call returns +nil+.
       #
@@ -621,6 +635,15 @@ module Dynamoid
     #     t.add(age: 1)
     #   end
     #
+    # To check if some attribute (or attributes) isn't stored in a DynamoDB
+    # item (e.g. it wasn't set explicitly) there is another condition -
+    # +unless_exists+:
+    #
+    #   user = User.create(name: 'Tylor')
+    #   user.update!(unless_exists: [:age]) do |t|
+    #     t.set(age: 18)
+    #   end
+    #
     # If a document doesn't meet conditions it raises
     # +Dynamoid::Errors::StaleObjectError+ exception.
     #
@@ -715,6 +738,15 @@ module Dynamoid
     #
     #   user.update(if: { age: 20 }) do |t|
     #     t.add(age: 1)
+    #   end
+    #
+    # To check if some attribute (or attributes) isn't stored in a DynamoDB
+    # item (e.g. it wasn't set explicitly) there is another condition -
+    # +unless_exists+:
+    #
+    #   user = User.create(name: 'Tylor')
+    #   user.update(unless_exists: [:age]) do |t|
+    #     t.set(age: 18)
     #   end
     #
     # If a document doesn't meet conditions it just returns +false+. Otherwise it returns +true+.

--- a/lib/dynamoid/persistence/save.rb
+++ b/lib/dynamoid/persistence/save.rb
@@ -89,8 +89,8 @@ module Dynamoid
         end
 
         conditions = {}
-        conditions[:if_exists] ||= {}
-        conditions[:if_exists][@model.class.hash_key] = @model.hash_key
+        conditions[:if] ||= {}
+        conditions[:if][@model.class.hash_key] = @model.hash_key
 
         # Add an optimistic locking check if the lock_version column exists
         if @model.class.attributes[:lock_version]

--- a/lib/dynamoid/persistence/update_fields.rb
+++ b/lib/dynamoid/persistence/update_fields.rb
@@ -54,8 +54,8 @@ module Dynamoid
         end
 
         conditions = @conditions.deep_dup
-        conditions[:if_exists] ||= {}
-        conditions[:if_exists][@model_class.hash_key] = @partition_key
+        conditions[:if] ||= {}
+        conditions[:if][@model_class.hash_key] = @partition_key
         options[:conditions] = conditions
 
         options


### PR DESCRIPTION
Close #657

Changes:
- fixed example in the README file
- document `unless_exists` option of persisting methods
- refactor and remove `if_exists` option, that was available but is an implementation detail and isn't documented