### PR TITLE
transactions multi-table MVP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dynamoid (3.9.0)
+    dynamoid (3.10.0)
       activemodel (>= 4)
       aws-sdk-dynamodb (~> 1.0)
       concurrent-ruby (>= 1.0)

--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,11 @@ resolving the fields with a second query against the table since a query
 against GSI then a query on base table is still likely faster than scan
 on the base table*
 
+### Transaction Writes
+
+Multiple write actions can be grouped together and submitted as an all-or-nothing operation.
+See the [transation documentation](README_transact.md).
+
 ### PartiQL
 
 To run PartiQL statements `Dynamoid.adapter.execute` method should be
@@ -1350,6 +1355,7 @@ just as accessible to the Ruby world as MongoDB.
 Also, without contributors the project wouldn't be nearly as awesome. So
 many thanks to:
 
+* [Chris Hobbs](https://github.com/ckhsponge)
 * [Logan Bowers](https://github.com/loganb)
 * [Lane LaRue](https://github.com/luxx)
 * [Craig Heneveld](https://github.com/cheneveld)

--- a/README_transact.md
+++ b/README_transact.md
@@ -1,0 +1,118 @@
+# Transactions in Dynamoid
+
+Synchronous write operations are supported in Dynamoid using transactions.
+If any action in the transaction fails they all fail.
+The following actions are supported:
+
+* Create - add a new item if it does not already exist
+* Upsert - add a new item or update an existing item, no callbacks
+* Update - modifies one or more attributes from an existig item
+* Delete - remove an item without callbacks, validations nor existence check
+* Destroy - remove an item, fails if item does not exist
+
+## Examples
+
+
+
+### Save models
+Models can be saved in a transaction.
+New records are created otherwise the model is updated.
+Save, create, update, validate and destroy callbacks are called around the transaction as appropriate.
+Validation failures will throw Dynamoid::Errors::DocumentNotValid.
+
+```ruby
+user = User.find(1)
+article = Article.new(body: 'New article text', user_id: user.id)
+Dynamoid::TransactionWrite.execute do |txn|
+  txn.save!(article)
+  user.last_article_id = article.id
+  txn.save!(user)
+end
+```
+
+### Create items
+Items can be created inside of a transaction.
+The hash key and range key, if applicable, are used to determine uniqueness.
+Creating will fail with Aws::DynamoDB::Errors::TransactionCanceledException if an item already exists unless skip_existence_check is true.
+This example creates a user with a  unique id and unique email address by creating 2 items.
+An additional item is upserted in the same transaction.
+Upserts will update updated_at but will not create created_at.
+
+```ruby
+user_id = SecureRandom.uuid
+email = 'bob@bob.bob'
+Dynamoid::TransactionWrite.execute do |txn|
+  txn.create!(User, id: user_id)
+  txn.create!(UserEmail, id: "UserEmail##{email}", user_id: user_id)
+  txn.create!(Address, { id: 'A#2', street: '456' }, { skip_existence_check: true })
+  txn.upsert!(Address, id: 'A#1', street: '123')
+end
+```
+
+### Destroy or delete items
+Models can be used or the model class and key can be specified.
+When the key is a single column it is specified as a single value or a hash
+with the name of the hash key.
+When using a composite key the key must be a hash with the hash key and range key.
+destroy() uses callbacks and validations and fails if the item does not exist.
+Use delete() to skip callbacks, validations and the existence check.
+
+```ruby
+article = Article.find(1)
+tag = article.tag
+Dynamoid::TransactionWrite.execute do |txn|
+  txn.destroy!(article)
+  txn.destroy!(Article, 2) # performs find() automatically and then runs destroy callbacks
+  txn.destroy!(tag)
+  txn.delete(Tag, 2) # delete record with hash key '2' if it exists
+  txn.delete(Tag, id: 2) # equivalent of the above if the hash key column is 'id'
+  txn.delete(Tag, id: 'key#abcd', my_sort_key: 'range#1') # when range key is required
+end
+```
+
+### Skipping callbacks and validations
+Validations and callbacks can be skipped per action.
+Validation failures will throw Dynamoid::Errors::DocumentNotValid when using the bang! methods.
+Note that validation callbacks are run when validation happens even if skipping callbacks here.
+Skipping callbacks and validation guarantees no callbacks.
+
+```ruby
+user = User.find(1)
+user.red = true
+Dynamoid::TransactionWrite.execute do |txn|
+  txn.save!(user, skip_callbacks: true)
+  txn.create!(User, { name: 'bob' }, { skip_callbacks: true })
+end
+Dynamoid::TransactionWrite.execute do |txn|
+  txn.save!(user, skip_validation: true)
+  txn.create!(User, { name: 'bob' }, { skip_validation: true })
+end
+```
+
+### Validation failures that don't raise
+All of the transaction methods can be called without the bang! which results in
+false instead of a raised exception when validation fails.
+Ignoring validation failures can lead to confusion or bugs so always check return status when not using a bang!
+
+```ruby
+user = User.find(1)
+user.red = true
+Dynamoid::TransactionWrite.execute do |txn|
+  if txn.save(user) # won't raise validation exception
+    txn.update(UserCount, id: 'UserCount#Red', count: 5)
+  else
+    puts 'ALERT: user not valid, skipping'
+  end
+end
+```
+
+### Incrementally building a transaction
+Transactions can also be built without a block.
+
+```ruby
+transaction = Dynamoid::TransactionWrite.new
+transaction.create!(User, id: user_id)
+transaction.create!(UserEmail, id: "UserEmail##{email}", user_id: user_id)
+transaction.upsert!(Address, id: 'A#1', street: '123')
+transaction.commit
+```

--- a/lib/dynamoid.rb
+++ b/lib/dynamoid.rb
@@ -35,6 +35,7 @@ require 'dynamoid/loadable'
 require 'dynamoid/components'
 require 'dynamoid/document'
 require 'dynamoid/adapter'
+require 'dynamoid/transaction_write'
 
 require 'dynamoid/tasks/database'
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -8,6 +8,7 @@ require_relative 'aws_sdk_v3/batch_get_item'
 require_relative 'aws_sdk_v3/item_updater'
 require_relative 'aws_sdk_v3/table'
 require_relative 'aws_sdk_v3/until_past_table_status'
+require_relative 'aws_sdk_v3/transact'
 
 module Dynamoid
   # @private
@@ -287,6 +288,10 @@ module Dynamoid
         end
       rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException => e
         raise Dynamoid::Errors::ConditionalCheckFailedException, e
+      end
+
+      def transact_write_items(items)
+        Transact.new(client).transact_write_items(items)
       end
 
       # Create a table on DynamoDB. This usually takes a long time to complete.

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/transact.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/transact.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Prepare all the actions of the transaction for sending to the AWS SDK.
+module Dynamoid
+  module AdapterPlugin
+    class AwsSdkV3
+      class Transact
+        attr_reader :client
+
+        def initialize(client)
+          @client = client
+        end
+
+        # Perform all of the item actions in a single transaction.
+        #
+        # @param [Array] items of type Dynamoid::Transaction::Action or
+        # any other object whose to_h is a transact_item hash
+        #
+        def transact_write_items(items)
+          transact_items = items.map(&:to_h)
+          params = {
+            transact_items: transact_items,
+            return_consumed_capacity: 'TOTAL',
+            return_item_collection_metrics: 'SIZE'
+          }
+          client.transact_write_items(params) # returns this
+        end
+      end
+    end
+  end
+end

--- a/lib/dynamoid/errors.rb
+++ b/lib/dynamoid/errors.rb
@@ -6,6 +6,7 @@ module Dynamoid
     # Generic Dynamoid error
     class Error < StandardError; end
 
+    class MissingHashKey < Error; end
     class MissingRangeKey < Error; end
 
     class MissingIndex < Error; end

--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -18,8 +18,9 @@ module Dynamoid
   module Persistence
     extend ActiveSupport::Concern
 
-    attr_accessor :new_record
+    attr_accessor :new_record, :destroyed
     alias new_record? new_record
+    alias destroyed? destroyed
 
     # @private
     UNIX_EPOCH_DATE = Date.new(1970, 1, 1).freeze

--- a/lib/dynamoid/transaction_write.rb
+++ b/lib/dynamoid/transaction_write.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'dynamoid/transaction_write/action'
+require 'dynamoid/transaction_write/create'
+require 'dynamoid/transaction_write/delete'
+require 'dynamoid/transaction_write/destroy'
+require 'dynamoid/transaction_write/update_upsert'
+require 'dynamoid/transaction_write/update'
+require 'dynamoid/transaction_write/upsert'
+
+module Dynamoid
+  class TransactionWrite
+    attr_accessor :action_inputs, :models
+
+    def initialize(_options = {})
+      @action_inputs = []
+      @models = []
+    end
+
+    def self.execute(options = {})
+      transaction = new(options)
+      yield(transaction)
+      transaction.commit
+    end
+
+    def commit
+      return unless @action_inputs.present? # nothing to commit
+
+      Dynamoid.adapter.transact_write_items(@action_inputs)
+      models.each { |model| model.new_record = false }
+    end
+
+    def save!(model, options = {})
+      save(model, options.reverse_merge(raise_validation_error: true))
+    end
+
+    def save(model, options = {})
+      model.new_record? ? create(model, {}, options) : update(model, {}, options)
+    end
+
+    def create!(model_or_model_class, attributes = {}, options = {})
+      create(model_or_model_class, attributes, options.reverse_merge(raise_validation_error: true))
+    end
+
+    def create(model_or_model_class, attributes = {}, options = {})
+      add_action_and_validate Dynamoid::TransactionWrite::Create.new(model_or_model_class, attributes, options)
+    end
+
+    # upsert! does not exist because upserting instances that can raise validation errors is not officially supported
+
+    def upsert(model_or_model_class, attributes = {}, options = {})
+      add_action_and_validate Dynamoid::TransactionWrite::Upsert.new(model_or_model_class, attributes, options)
+    end
+
+    def update!(model_or_model_class, attributes = {}, options = {})
+      update(model_or_model_class, attributes, options.reverse_merge(raise_validation_error: true))
+    end
+
+    def update(model_or_model_class, attributes = {}, options = {})
+      add_action_and_validate Dynamoid::TransactionWrite::Update.new(model_or_model_class, attributes, options)
+    end
+
+    def delete(model_or_model_class, key_or_attributes = {}, options = {})
+      add_action_and_validate Dynamoid::TransactionWrite::Delete.new(model_or_model_class, key_or_attributes, options)
+    end
+
+    def destroy!(model_or_model_class, key_or_attributes = {}, options = {})
+      destroy(model_or_model_class, key_or_attributes, options.reverse_merge(raise_validation_error: true))
+    end
+
+    def destroy(model_or_model_class, key_or_attributes = {}, options = {})
+      add_action_and_validate Dynamoid::TransactionWrite::Destroy.new(model_or_model_class, key_or_attributes, options)
+    end
+
+    private
+
+    # validates unless validations are skipped
+    # runs callbacks unless callbacks are skipped
+    # raise validation error or returns false if not valid
+    # otherwise adds hash of action to list in preparation for committing
+    def add_action_and_validate(action)
+      if !action.skip_validation? && !action.valid?
+        raise Dynamoid::Errors::DocumentNotValid, action.model if action.raise_validation_error?
+
+        return false
+      end
+
+      if action.skip_callbacks?
+        @action_inputs << action.to_h
+      else
+        action.run_callbacks do
+          @action_inputs << action.to_h
+        end
+      end
+      action.changes_applied # action has been processed and added to queue so mark as applied
+      models << action.model if action.model
+
+      action.model || true # return model if it exists
+    end
+  end
+end

--- a/lib/dynamoid/transaction_write/action.rb
+++ b/lib/dynamoid/transaction_write/action.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  class TransactionWrite
+    class Action
+      VALID_OPTIONS = %i[skip_callbacks skip_validation raise_validation_error skip_existence_check].freeze
+      attr_accessor :model, :attributes, :options
+
+      def initialize(model_or_model_class, attributes = {}, options = {})
+        if model_or_model_class.is_a?(Dynamoid::Document)
+          self.model = model_or_model_class
+        else
+          @model_class = model_or_model_class
+        end
+        self.attributes = attributes
+        self.options = options || {}
+        invalid_keys = self.options.keys - VALID_OPTIONS
+        raise ArgumentError, "Invalid options found: '#{invalid_keys}'" if invalid_keys.present?
+      end
+
+      def model_class
+        model&.class || @model_class
+      end
+
+      # returns hash_key from the model if it exists or first element from id
+      def hash_key
+        return model.hash_key if model
+
+        attributes[model_class.hash_key]
+      end
+
+      # returns range_key from the model if it exists or second element from id, or nil
+      def range_key
+        return nil unless model_class.range_key?
+        return model.attributes[model_class.range_key] if model
+
+        attributes[model_class.range_key]
+      end
+
+      def find_from_attributes(model_or_model_class, attributes)
+        model_class = model_or_model_class.is_a?(Dynamoid::Document) ? model_or_model_class.class : model_or_model_class
+        if attributes.is_a?(Hash)
+          raise Dynamoid::Errors::MissingHashKey unless attributes[model_class.hash_key].present?
+
+          model_class.find(attributes[model_class.hash_key],
+                           range_key: model_class.range_key? ? attributes[model_class.range_key] : nil,
+                           consistent_read: true)
+        else
+          model_class.find(attributes, consistent_read: true)
+        end
+      end
+
+      def skip_callbacks?
+        !!options[:skip_callbacks]
+      end
+
+      def skip_validation?
+        !!options[:skip_validation]
+      end
+
+      def valid?
+        model&.valid?
+      end
+
+      def raise_validation_error?
+        !!options[:raise_validation_error]
+      end
+
+      def run_callbacks
+        yield if block_given?
+      end
+
+      def changes_applied
+        !!model&.changes_applied
+      end
+
+      def add_timestamps(attributes, skip_created_at: false)
+        return attributes if options[:skip_timestamps] || !model_class&.timestamps_enabled?
+
+        result = attributes.clone
+        timestamp = DateTime.now.in_time_zone(Time.zone)
+        result[:created_at] ||= timestamp unless skip_created_at
+        result[:updated_at] ||= timestamp
+        result
+      end
+
+      def touch_model_timestamps(skip_created_at: false)
+        return if !model || options[:skip_timestamps] || !model_class.timestamps_enabled?
+
+        timestamp = DateTime.now.in_time_zone(Time.zone)
+        model.updated_at = timestamp
+        model.created_at ||= timestamp unless skip_created_at
+      end
+
+      def write_attributes_to_model
+        return unless model && attributes.present?
+
+        attributes.each { |attribute, value| model.write_attribute(attribute, value) }
+      end
+
+      # copied from the protected method in AwsSdkV3
+      def sanitize_item(attributes)
+        config_value = Dynamoid.config.store_attribute_with_nil_value
+        store_attribute_with_nil_value = config_value.nil? ? false : !!config_value
+
+        attributes.reject do |_, v|
+          ((v.is_a?(Set) || v.is_a?(String)) && v.empty?) ||
+            (!store_attribute_with_nil_value && v.nil?)
+        end.transform_values do |v|
+          v.is_a?(Hash) ? v.stringify_keys : v
+        end
+      end
+
+      def to_h
+        raise 'override me'
+      end
+    end
+  end
+end

--- a/lib/dynamoid/transaction_write/create.rb
+++ b/lib/dynamoid/transaction_write/create.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+
+module Dynamoid
+  class TransactionWrite
+    class Create < Action
+      # model is created if not otherwise specified so callbacks can be run
+      def initialize(model_or_model_class, attributes = {}, options = {})
+        model = if model_or_model_class.is_a?(Dynamoid::Document)
+                  model_or_model_class
+                else
+                  model_or_model_class.new(attributes)
+                end
+        super(model, attributes, options)
+
+        # don't initialize hash key here, callbacks haven't run yet
+      end
+
+      def run_callbacks
+        # model always exists
+        model.run_callbacks(:save) do
+          model.run_callbacks(:create) do
+            model.run_callbacks(:validate) do
+              yield if block_given?
+            end
+          end
+        end
+      end
+
+      def to_h
+        model.hash_key = SecureRandom.uuid if model.hash_key.blank?
+        write_attributes_to_model
+        touch_model_timestamps
+        # model always exists
+        item = Dynamoid::Dumping.dump_attributes(model.attributes, model_class.attributes)
+
+        condition = "attribute_not_exists(#{model_class.hash_key})"
+        condition += " and attribute_not_exists(#{model_class.range_key})" if model_class.range_key? # needed?
+        result = {
+          put: {
+            item: sanitize_item(item),
+            table_name: model_class.table_name,
+          }
+        }
+        result[:put][:condition_expression] = condition unless options[:skip_existence_check]
+
+        result
+      end
+    end
+  end
+end

--- a/lib/dynamoid/transaction_write/delete.rb
+++ b/lib/dynamoid/transaction_write/delete.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+
+module Dynamoid
+  class TransactionWrite
+    class Delete < Action
+      # a model is not needed since callbacks are not run
+      def initialize(model_or_model_class, key_or_attributes = {}, options = {})
+        options = options.reverse_merge(skip_validation: true)
+        super(model_or_model_class, {}, options)
+        self.attributes = if key_or_attributes.is_a?(Hash)
+                            key_or_attributes
+                          else
+                            {
+                              model_class.hash_key => key_or_attributes
+                            }
+                          end
+        raise Dynamoid::Errors::MissingHashKey unless hash_key.present?
+        raise Dynamoid::Errors::MissingRangeKey unless !model_class.range_key? || range_key.present?
+      end
+
+      def to_h
+        key = { model_class.hash_key => hash_key }
+        key[model_class.range_key] = range_key if model_class.range_key?
+        {
+          delete: {
+            key: key,
+            table_name: model_class.table_name
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/dynamoid/transaction_write/destroy.rb
+++ b/lib/dynamoid/transaction_write/destroy.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+
+module Dynamoid
+  class TransactionWrite
+    class Destroy < Action
+      # model is found if not otherwise specified so callbacks can be run
+      def initialize(model_or_model_class, key_or_attributes = {}, options = {})
+        model = if model_or_model_class.is_a?(Dynamoid::Document)
+                  model_or_model_class
+                else
+                  find_from_attributes(model_or_model_class, key_or_attributes)
+                end
+        super(model, {}, options)
+        raise Dynamoid::Errors::MissingHashKey unless hash_key.present?
+        raise Dynamoid::Errors::MissingRangeKey unless !model_class.range_key? || range_key.present?
+      end
+
+      def run_callbacks
+        model.run_callbacks(:destroy) do
+          yield if block_given?
+        end
+      end
+
+      # destroy defaults to not using validation
+      def skip_validation?
+        options[:skip_validation] != false
+      end
+
+      def to_h
+        model.destroyed = true
+        key = { model_class.hash_key => hash_key }
+        key[model_class.range_key] = range_key if model_class.range_key?
+        # force fast fail i.e. won't retry if record is missing
+        condition_expression = "attribute_exists(#{model_class.hash_key})"
+        condition_expression += " and attribute_exists(#{model_class.range_key})" if model_class.range_key? # needed?
+        result = {
+          delete: {
+            key: key,
+            table_name: model_class.table_name
+          }
+        }
+        result[:delete][:condition_expression] = condition_expression unless options[:skip_existence_check]
+        result
+      end
+    end
+  end
+end

--- a/lib/dynamoid/transaction_write/update.rb
+++ b/lib/dynamoid/transaction_write/update.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+
+module Dynamoid
+  class TransactionWrite
+    class Update < UpdateUpsert
+      # model is found if not otherwise specified so callbacks can be run
+      def initialize(model_or_model_class, attributes, options = {})
+        model = if model_or_model_class.is_a?(Dynamoid::Document)
+                  model_or_model_class
+                else
+                  find_from_attributes(model_or_model_class, attributes)
+                end
+        super(model, attributes, options)
+      end
+
+      def run_callbacks
+        unless model
+          yield if block_given?
+          return
+        end
+        model.run_callbacks(:save) do
+          model.run_callbacks(:update) do
+            model.run_callbacks(:validate) do
+              yield if block_given?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dynamoid/transaction_write/update_upsert.rb
+++ b/lib/dynamoid/transaction_write/update_upsert.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+
+module Dynamoid
+  class TransactionWrite
+    class UpdateUpsert < Action
+      def initialize(model_or_model_class, attributes = {}, options = {})
+        super(model_or_model_class, attributes, options)
+
+        write_attributes_to_model
+      end
+
+      # shared by Update and Upsert
+      def to_h
+        if model
+          # model.hash_key = SecureRandom.uuid if model.hash_key.blank?
+          touch_model_timestamps(skip_created_at: true)
+          changes = model.changes.map { |k, v| [k.to_sym, v[1]] }.to_h # hash of dirty attributes
+        else
+          changes = attributes.clone || {}
+          # changes[model_class.hash_key] = SecureRandom.uuid
+          changes = add_timestamps(changes, skip_created_at: true)
+        end
+        changes.delete(model_class.hash_key) # can't update id!
+        changes.delete(model_class.range_key) if model_class.range_key?
+        item = Dynamoid::Dumping.dump_attributes(changes, model_class.attributes)
+
+        # set 'key' that is used to look up record for updating
+        key = { model_class.hash_key => hash_key }
+        key[model_class.range_key] = range_key if model_class.range_key?
+
+        # e.g. "SET #updated_at = :updated_at ADD record_count :i"
+        item_keys = item.keys
+        update_expression = "SET #{item_keys.each_with_index.map { |_k, i| "#_n#{i} = :_s#{i}" }.join(', ')}"
+
+        # e.g. {":updated_at" => 1645453.234, ":i" => 1}
+        expression_attribute_values = item_keys.each_with_index.map { |k, i| [":_s#{i}", item[k]] }.to_h
+
+        if options[:add] # not yet documented or supported, may change in a future release
+          # ADD statements can be used to increment a counter:
+          # txn.update!(UserCount, "UserCount#Red", {}, options: {add: {record_count: 1}})
+          add_keys = options[:add].keys
+          update_expression += " ADD #{add_keys.each_with_index.map { |k, i| "#{k} :_a#{i}" }.join(', ')}"
+          add_keys.each_with_index { |k, i| expression_attribute_values[":_a#{i}"] = options[:add][k] }
+        end
+
+        # only alias names for fields in models, other values such as for ADD do not have them
+        # e.g. {"#updated_at" => "updated_at"}
+        # attribute_keys_in_model = item_keys.intersection(model_class.attributes.keys)
+        # expression_attribute_names = attribute_keys_in_model.map{|k| ["##{k}","#{k}"]}.to_h
+        expression_attribute_names = item_keys.each_with_index.map { |k, i| ["#_n#{i}", k.to_s] }.to_h
+
+        condition_expression = "attribute_exists(#{model_class.hash_key})" # fail if record is missing
+        condition_expression += " and attribute_exists(#{model_class.range_key})" if model_class.range_key? # needed?
+
+        result = {
+          update: {
+            key: key,
+            table_name: model_class.table_name,
+            update_expression: update_expression,
+            expression_attribute_values: expression_attribute_values
+          }
+        }
+        result[:update][:expression_attribute_names] = expression_attribute_names if expression_attribute_names.present?
+        result[:update][:condition_expression] = condition_expression unless options[:skip_existence_check]
+
+        result
+      end
+    end
+  end
+end

--- a/lib/dynamoid/transaction_write/upsert.rb
+++ b/lib/dynamoid/transaction_write/upsert.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'action'
+
+module Dynamoid
+  class TransactionWrite
+    class Upsert < UpdateUpsert
+      # Upsert is just like Update buts skips the existence check so a new record can be created when it's missing.
+      # No callbacks.
+      def initialize(model_or_model_class, attributes, options = {})
+        options = options.reverse_merge(skip_existence_check: true)
+        super(model_or_model_class, attributes, options)
+        raise Dynamoid::Errors::MissingHashKey unless hash_key.present?
+        raise Dynamoid::Errors::MissingRangeKey unless !model_class.range_key? || range_key.present?
+      end
+
+      # no callbacks are run
+
+      # only run validations if a model has been provided
+      def valid?
+        model ? model.valid? : true
+      end
+    end
+  end
+end

--- a/spec/dynamoid/transaction_write/action_spec.rb
+++ b/spec/dynamoid/transaction_write/action_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'context'
+
+# Dynamoid.config.logger.level = :debug
+
+describe Dynamoid::TransactionWrite, '.action' do
+  include_context 'transaction_write'
+
+  context 'incrementally builds' do
+    it 'executes' do
+      klass.create_table
+      klass_with_composite_key.create_table
+      transaction = described_class.new
+      obj1 = transaction.create!(klass, { name: 'one' })
+      obj2_id = SecureRandom.uuid
+      transaction.upsert(klass_with_composite_key, { id: obj2_id, age: 2, name: 'two' })
+      expect(klass).not_to exist(obj1.id)
+      expect(klass).not_to exist(obj2_id)
+      transaction.commit
+
+      obj1_found = klass.find(obj1.id)
+      obj2_found = klass_with_composite_key.find(obj2_id, range_key: 2)
+      expect(obj1_found).to eql(obj1)
+      expect(obj2_found.id).to eql(obj2_id)
+      expect(obj1_found.name).to eql('one')
+      expect(obj2_found.name).to eql('two')
+    end
+  end
+end

--- a/spec/dynamoid/transaction_write/context.rb
+++ b/spec/dynamoid/transaction_write/context.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Dynamoid.config.logger.level = :debug
+
+RSpec.shared_context 'transaction_write' do
+  let(:klass) do
+    new_class(class_name: 'Document') do
+      field :name
+    end
+  end
+
+  let(:klass_with_composite_key) do
+    new_class(class_name: 'Cat') do
+      range :age, :integer
+      field :name
+    end
+  end
+
+  let(:klass_with_callbacks) do
+    new_class(class_name: 'Dog') do
+      field :name
+
+      before_save { print 'saving ' }
+      after_save { print 'saved ' }
+      before_create { print 'creating ' }
+      after_create { print 'created ' }
+      before_update { print 'updating ' }
+      after_update { print 'updated ' }
+      before_destroy { print 'destroying ' }
+      after_destroy { print 'destroyed ' }
+      before_validation { print 'validating ' }
+      after_validation { print 'validated ' }
+    end
+  end
+
+  let(:klass_with_around_callbacks) do
+    new_class(class_name: 'Mouse') do
+      field :name
+
+      around_save :around_save_callback
+      around_create :around_create_callback
+      around_update :around_update_callback
+      around_destroy :around_destroy_callback
+      # no around_validation callback exists
+
+      def around_save_callback
+        print 'saving '
+        yield
+        print 'saved '
+      end
+
+      def around_create_callback
+        print 'creating '
+        yield
+        print 'created '
+      end
+
+      def around_update_callback
+        print 'updating '
+        yield
+        print 'updated '
+      end
+
+      def around_destroy_callback
+        print 'destroying '
+        yield
+        print 'destroyed '
+      end
+    end
+  end
+
+  let(:klass_with_validation) do
+    new_class do
+      field :name
+      validates :name, length: { minimum: 4 }
+    end
+  end
+end

--- a/spec/dynamoid/transaction_write/create_spec.rb
+++ b/spec/dynamoid/transaction_write/create_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'context'
+
+# Dynamoid.config.logger.level = :debug
+
+describe Dynamoid::TransactionWrite, '.create' do
+  include_context 'transaction_write'
+
+  context 'creates' do
+    context 'simple primary key' do
+      before do
+        klass.create_table
+      end
+
+      it 'with attribute in constructor' do
+        obj1 = klass.new(name: 'one')
+        expect(obj1.persisted?).to eql(false)
+        described_class.execute do |txn|
+          txn.create! obj1
+        end
+        expect(obj1.persisted?).to eql(true)
+        obj1_found = klass.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('one')
+      end
+
+      it 'with attribute in transaction' do
+        obj2 = klass.new
+        described_class.execute do |txn|
+          txn.create! obj2, name: 'two'
+        end
+        obj2_found = klass.find(obj2.id)
+        expect(obj2_found).to eql(obj2)
+        expect(obj2_found.name).to eql('two')
+      end
+
+      it 'with class constructed in transaction' do
+        obj3 = nil
+        described_class.execute do |txn|
+          obj3 = txn.create! klass, name: 'three'
+        end
+        obj3_found = klass.find(obj3.id)
+        expect(obj3_found).to eql(obj3)
+        expect(obj3_found.name).to eql('three')
+      end
+    end
+
+    context 'composite key' do
+      before do
+        klass_with_composite_key.create_table
+      end
+
+      it 'with attribute in constructor' do
+        obj1 = klass_with_composite_key.new(name: 'one', age: 1)
+        described_class.execute do |txn|
+          txn.create! obj1
+        end
+        obj1_found = klass_with_composite_key.find(obj1.id, range_key: 1)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('one')
+      end
+
+      it 'with attribute in transaction' do
+        obj2 = klass_with_composite_key.new
+        described_class.execute do |txn|
+          txn.create! obj2, name: 'two', age: 2
+        end
+        obj2_found = klass_with_composite_key.find(obj2.id, range_key: 2)
+        expect(obj2_found).to eql(obj2)
+        expect(obj2_found.name).to eql('two')
+      end
+
+      it 'with class constructed in transaction' do
+        obj3 = nil
+        described_class.execute do |txn|
+          obj3 = txn.create! klass_with_composite_key, name: 'three', age: 3
+        end
+        obj3_found = klass_with_composite_key.find(obj3.id, range_key: 3)
+        expect(obj3_found).to eql(obj3)
+        expect(obj3_found.name).to eql('three')
+      end
+    end
+
+    it 'creates timestamps' do
+      klass.create_table
+      obj1 = klass.new(name: 'one')
+      expect(obj1.created_at).to be_nil
+      expect(obj1.updated_at).to be_nil
+      described_class.execute do |txn|
+        txn.create! obj1
+      end
+      obj1_found = klass.find(obj1.id)
+      expect(obj1_found.created_at.to_f).to be_within(1.seconds).of Time.now.to_f
+      expect(obj1_found.updated_at.to_f).to be_within(1.seconds).of Time.now.to_f
+    end
+
+    context 'validates' do
+      before do
+        klass_with_validation.create_table
+      end
+
+      it 'does not create when invalid' do
+        obj1 = klass_with_validation.new(name: 'one')
+        described_class.execute do |txn|
+          expect(txn.create(obj1)).to eql(false)
+        end
+        expect(obj1.id).to be_nil
+      end
+
+      it 'rolls back when invalid' do
+        obj1 = klass_with_validation.new(name: 'one')
+        obj2 = klass_with_validation.new(name: 'twotwo')
+        described_class.execute do |txn|
+          expect(txn.create(obj1)).to eql(false)
+          expect(txn.create(obj2)).to be_present
+        end
+        expect(obj1.id).to be_nil
+        expect(klass_with_validation).to exist(obj2.id)
+      end
+
+      it 'succeeds when valid' do
+        obj1 = klass_with_validation.new(name: 'oneone')
+        described_class.execute do |txn|
+          expect(txn.create(obj1)).to be_present
+        end
+
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone')
+      end
+
+      it 'raises DocumentNotValid when not valid' do
+        obj1 = klass_with_validation.new(name: 'one')
+        expect {
+          described_class.execute do |txn|
+            txn.create! obj1
+          end
+        }.to raise_error(Dynamoid::Errors::DocumentNotValid)
+        expect(obj1.id).to be_nil # hash key should NOT be auto-generated if validation fails
+      end
+
+      it 'rolls back and raises DocumentNotValid when not valid' do
+        obj1 = klass_with_validation.new(name: 'one')
+        obj2 = klass_with_validation.new(name: 'twotwo')
+        expect {
+          described_class.execute do |txn|
+            txn.create! obj2
+            txn.create! obj1
+          end
+        }.to raise_error(Dynamoid::Errors::DocumentNotValid)
+        expect(obj1.id).to be_nil
+        expect(obj2.id).to be_present
+        expect(klass_with_validation).not_to exist(obj2.id)
+      end
+
+      it 'does not raise exception when valid' do
+        obj1 = klass_with_validation.new(name: 'oneone')
+        described_class.execute do |txn|
+          txn.create!(obj1)
+        end
+
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone')
+      end
+
+      it 'does not raise exception when skipping validation' do
+        obj1 = klass_with_validation.new(name: 'one')
+        described_class.execute do |txn|
+          # this use is infrequent, normal entry is from save!(obj, options)
+          txn.create!(obj1, {}, skip_validation: true)
+        end
+
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('one')
+      end
+    end
+
+    it 'uses callbacks' do
+      klass_with_callbacks.create_table
+      expect {
+        described_class.execute do |txn|
+          txn.create! klass_with_callbacks.new(name: 'two')
+        end
+      }.to output('validating validated saving creating created saved ').to_stdout
+    end
+
+    it 'uses around callbacks' do
+      klass_with_around_callbacks.create_table
+      expect {
+        described_class.execute do |txn|
+          txn.create! klass_with_around_callbacks.new(name: 'two')
+        end
+      }.to output('saving creating created saved ').to_stdout
+    end
+  end
+end

--- a/spec/dynamoid/transaction_write/delete_spec.rb
+++ b/spec/dynamoid/transaction_write/delete_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'context'
+
+# Dynamoid.config.logger.level = :debug
+
+describe Dynamoid::TransactionWrite, '.delete' do
+  include_context 'transaction_write'
+
+  context 'deletes' do
+    context 'simple primary key' do
+      before do
+        klass.create_table
+      end
+
+      it 'with instance' do
+        obj1 = klass.create!(name: 'one')
+        obj1_found = klass.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        described_class.execute do |txn|
+          txn.delete obj1
+        end
+        expect(klass).not_to exist(obj1.id)
+      end
+
+      it 'with id' do
+        obj2 = klass.create!(name: 'two')
+        obj2_found = klass.find(obj2.id)
+        expect(obj2_found).to eql(obj2)
+        described_class.execute do |txn|
+          txn.delete klass, obj2.id
+        end
+        expect(klass).not_to exist(obj2.id)
+      end
+    end
+
+    context 'composite key' do
+      before do
+        klass_with_composite_key.create_table
+      end
+
+      it 'with instance' do
+        obj1 = klass_with_composite_key.create!(name: 'one', age: 1)
+        obj1_found = klass_with_composite_key.find(obj1.id, range_key: 1)
+        expect(obj1_found).to eql(obj1)
+        described_class.execute do |txn|
+          txn.delete obj1
+        end
+        expect(klass_with_composite_key).not_to exist({ id: obj1.id, age: 1 })
+      end
+
+      it 'with id' do
+        obj2 = klass_with_composite_key.create!(name: 'two', age: 2)
+        obj2_found = klass_with_composite_key.find(obj2.id, range_key: 2)
+        expect(obj2_found).to eql(obj2)
+        described_class.execute do |txn|
+          txn.delete klass_with_composite_key, id: obj2.id, age: 2
+        end
+        expect(klass_with_composite_key).not_to exist({ id: obj2.id, age: 2 })
+      end
+
+      it 'requires hash key' do
+        expect {
+          described_class.execute do |txn|
+            txn.delete klass_with_composite_key, age: 5
+          end
+        }.to raise_exception(Dynamoid::Errors::MissingHashKey)
+      end
+
+      it 'requires range key' do
+        expect {
+          described_class.execute do |txn|
+            txn.delete klass_with_composite_key, id: 'bananas'
+          end
+        }.to raise_exception(Dynamoid::Errors::MissingRangeKey)
+      end
+    end
+  end
+end

--- a/spec/dynamoid/transaction_write/destroy_spec.rb
+++ b/spec/dynamoid/transaction_write/destroy_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'context'
+
+# Dynamoid.config.logger.level = :debug
+
+describe Dynamoid::TransactionWrite, '.destroy' do
+  include_context 'transaction_write'
+
+  context 'destroys' do
+    context 'simple primary key' do
+      before do
+        klass.create_table
+      end
+
+      it 'with instance' do
+        obj1 = klass.create!(name: 'one')
+        obj1_found = klass.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1.persisted?).to eql(true)
+        expect(obj1).not_to be_destroyed
+        described_class.execute do |txn|
+          txn.destroy! obj1
+        end
+        expect(obj1.destroyed?).to eql(true)
+        expect(obj1.persisted?).to eql(false)
+        expect(klass).not_to exist(obj1.id)
+      end
+
+      it 'with id' do
+        obj2 = klass.create!(name: 'two')
+        obj2_found = klass.find(obj2.id)
+        expect(obj2_found).to eql(obj2)
+        described_class.execute do |txn|
+          txn.destroy! klass, obj2.id
+        end
+        expect(klass).not_to exist(obj2.id)
+      end
+    end
+
+    context 'composite key' do
+      before do
+        klass_with_composite_key.create_table
+      end
+
+      it 'with instance' do
+        obj1 = klass_with_composite_key.create!(name: 'one', age: 1)
+        obj2 = klass_with_composite_key.create!(name: 'two', age: 2)
+        obj1_found = klass_with_composite_key.find(obj1.id, range_key: 1)
+        expect(obj1_found).to eql(obj1)
+        described_class.execute do |txn|
+          txn.destroy! obj1
+        end
+        expect(klass_with_composite_key).not_to exist({ id: obj1.id, age: 1 })
+      end
+
+      it 'with id' do
+        obj2 = klass_with_composite_key.create!(name: 'two', age: 2)
+        obj2_found = klass_with_composite_key.find(obj2.id, range_key: 2)
+        expect(obj2_found).to eql(obj2)
+        described_class.execute do |txn|
+          txn.destroy! klass_with_composite_key, { id: obj2.id, age: 2 }
+        end
+        expect(klass_with_composite_key).not_to exist({ id: obj2.id, age: 1 })
+      end
+
+      it 'requires hash key' do
+        expect {
+          described_class.execute do |txn|
+            txn.destroy! klass_with_composite_key, age: 5
+          end
+        }.to raise_exception(Dynamoid::Errors::MissingHashKey) # not ArgumentError
+      end
+
+      it 'requires range key' do
+        expect {
+          described_class.execute do |txn|
+            txn.destroy! klass_with_composite_key, id: 'bananas'
+          end
+        }.to raise_exception(Dynamoid::Errors::MissingRangeKey) # not ArgumentError
+      end
+    end
+
+    it 'uses callbacks' do
+      klass_with_callbacks.create_table
+      obj1 = klass_with_callbacks.create!(name: 'one')
+      expect {
+        described_class.execute do |txn|
+          txn.destroy! obj1
+        end
+      }.to output('destroying destroyed ').to_stdout
+    end
+
+    it 'uses around callbacks' do
+      klass_with_around_callbacks.create_table
+      obj1 = klass_with_around_callbacks.create!(name: 'one')
+      expect {
+        described_class.execute do |txn|
+          txn.destroy! obj1
+        end
+      }.to output('destroying destroyed ').to_stdout
+    end
+
+    # TODO: test destroy! vs. destroy i.e. when an :abort is raised in a callback
+  end
+end

--- a/spec/dynamoid/transaction_write/put_spec.rb
+++ b/spec/dynamoid/transaction_write/put_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'context'
+
+# Dynamoid.config.logger.level = :debug
+
+describe Dynamoid::TransactionWrite, '.put' do # 'put' is actually an update
+  include_context 'transaction_write'
+
+  # a 'put' is a create that overwrites existing records if present
+  context 'puts' do
+    context 'simple primary key' do
+      before do
+        klass.create_table
+      end
+
+      it 'fails without skip_existence_check' do
+        obj1 = klass.create!(name: 'one')
+        expect {
+          described_class.execute do |txn|
+            txn.create! klass, id: obj1.id, name: 'oneo'
+          end
+        }.to raise_exception(Aws::DynamoDB::Errors::TransactionCanceledException)
+      end
+
+      it 'can overwrite with attributes' do
+        obj1 = klass.create!(name: 'one')
+        expect(klass.find(obj1.id)).to eql(obj1) # it was created
+        described_class.execute do |txn|
+          txn.create! klass, { id: obj1.id, name: 'oneone' }, { skip_existence_check: true }
+        end
+        obj1_found = klass.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone') # overwritten
+      end
+
+      it 'can overwrite with instance' do
+        obj1 = klass.create!(name: 'one')
+        expect(klass.find(obj1.id)).to eql(obj1) # it was created
+        described_class.execute do |txn|
+          # this use is infrequent, normal entry is from save!(obj, options)
+          txn.create! klass.new(id: obj1.id, name: 'oneone'), {}, { skip_existence_check: true }
+        end
+        obj1_found = klass.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone') # overwritten
+      end
+    end
+
+    context 'composite key' do
+      before do
+        klass_with_composite_key.create_table
+      end
+
+      it 'fails without skip_existence_check' do
+        obj1 = klass_with_composite_key.create!(name: 'one', age: 1)
+        expect {
+          described_class.execute do |txn|
+            txn.create! klass_with_composite_key, id: obj1.id, age: 1, name: 'oneo'
+          end
+        }.to raise_exception(Aws::DynamoDB::Errors::TransactionCanceledException)
+      end
+
+      it 'can overwrite with attributes' do
+        obj1 = klass_with_composite_key.create!(name: 'one', age: 1)
+        obj2 = nil
+        described_class.execute do |txn|
+          txn.create! klass_with_composite_key, { id: obj1.id, age: 1, name: 'oneone' },
+                      { skip_existence_check: true }
+          obj2 = txn.create! klass_with_composite_key, id: obj1.id, age: 2, name: 'two'
+        end
+        obj1_found = klass_with_composite_key.find(obj1.id, range_key: 1)
+        obj2_found = klass_with_composite_key.find(obj1.id, range_key: 2)
+        expect(obj1_found).to eql(obj1)
+        expect(obj2_found).to eql(obj2)
+        expect(obj1_found.name).to eql('oneone')
+        expect(obj2_found.name).to eql('two')
+      end
+
+      it 'can overwrite with instance' do
+        obj1 = klass_with_composite_key.create!(name: 'one', age: 1)
+        obj2 = nil
+        described_class.execute do |txn|
+          # this use is infrequent, normal entry is from save!(obj, options)
+          txn.create! klass_with_composite_key.new(id: obj1.id, age: 1, name: 'oneone'), {},
+                      { skip_existence_check: true }
+          obj2 = txn.create! klass_with_composite_key.new(id: obj1.id, age: 2, name: 'two')
+        end
+        obj1_found = klass_with_composite_key.find(obj1.id, range_key: 1)
+        obj2_found = klass_with_composite_key.find(obj1.id, range_key: 2)
+        expect(obj1_found).to eql(obj1)
+        expect(obj2_found).to eql(obj2)
+        expect(obj1_found.name).to eql('oneone')
+        expect(obj2_found.name).to eql('two')
+      end
+    end
+  end
+end

--- a/spec/dynamoid/transaction_write/save_spec.rb
+++ b/spec/dynamoid/transaction_write/save_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'context'
+
+# Dynamoid.config.logger.level = :debug
+
+describe Dynamoid::TransactionWrite, '.save' do # 'save' is an update or create
+  include_context 'transaction_write'
+
+  # a 'save' does an update or create depending on if the record is new or not
+  context 'saves' do
+    context 'simple primary key' do
+      before do
+        klass.create_table
+      end
+
+      it 'with an update' do
+        obj1 = klass.create!(name: 'one')
+        described_class.execute do |txn|
+          obj1.name = 'oneone'
+          txn.save! obj1
+        end
+        obj1_found = klass.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone')
+      end
+
+      it 'with a create' do
+        obj2 = klass.new(name: 'two')
+        described_class.execute do |txn|
+          txn.save! obj2
+        end
+        obj2_found = klass.find(obj2.id)
+        expect(obj2_found).to eql(obj2)
+        expect(obj2_found.name).to eql('two')
+      end
+    end
+
+    context 'composite key' do
+      before do
+        klass_with_composite_key.create_table
+      end
+
+      it 'with an update' do
+        obj1 = klass_with_composite_key.create!(name: 'one', age: 1)
+        described_class.execute do |txn|
+          obj1.name = 'oneone'
+          txn.save! obj1
+        end
+        obj1_found = klass_with_composite_key.find(obj1.id, range_key: 1)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone')
+      end
+
+      it 'with a create' do
+        obj2 = klass_with_composite_key.new(name: 'two', age: 2)
+        described_class.execute do |txn|
+          txn.save! obj2
+        end
+        obj2_found = klass_with_composite_key.find(obj2.id, range_key: 2)
+        expect(obj2_found).to eql(obj2)
+        expect(obj2_found.name).to eql('two')
+      end
+    end
+
+    context 'validates' do
+      before do
+        klass_with_validation.create_table
+      end
+
+      it 'does not save when invalid' do
+        obj1 = klass_with_validation.new(name: 'one')
+        described_class.execute do |txn|
+          expect(txn.save(obj1)).to eql(false)
+        end
+        expect(obj1.id).to be_nil
+      end
+
+      it 'allows partial save when a record in the transaction is invalid' do
+        obj1 = klass_with_validation.new(name: 'one')
+        obj2 = klass_with_validation.create!(name: 'twolong')
+        obj2.name = 'twotwo'
+        described_class.execute do |txn|
+          expect(txn.save(obj2)).to be_truthy
+          expect(txn.save(obj1)).to eql(false)
+        end
+        expect(obj1.id).to be_nil
+        obj2_found = klass_with_validation.find(obj2.id)
+        expect(obj2_found.name).to eql('twotwo')
+      end
+
+      it 'saves when valid' do
+        obj1 = klass_with_validation.new(name: 'oneone')
+        described_class.execute do |txn|
+          expect(txn.save(obj1)).to be_present
+        end
+
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone')
+      end
+
+      it 'raises DocumentNotValid when not valid' do
+        obj1 = klass_with_validation.new(name: 'one')
+        expect {
+          described_class.execute do |txn|
+            txn.save! obj1
+          end
+        }.to raise_error(Dynamoid::Errors::DocumentNotValid)
+        expect(obj1.id).to be_nil
+      end
+
+      it 'rolls back and raises DocumentNotValid when not valid' do
+        obj1 = klass_with_validation.new(name: 'one')
+        obj2 = klass_with_validation.create!(name: 'twolong')
+        obj2.name = 'twotwo'
+        expect {
+          described_class.execute do |txn|
+            txn.save! obj2
+            txn.save! obj1
+          end
+        }.to raise_error(Dynamoid::Errors::DocumentNotValid)
+        expect(obj1.id).to be_nil
+        obj2_found = klass_with_validation.find(obj2.id)
+        expect(obj2_found.name).to eql('twolong')
+      end
+
+      it 'does not raise exception when valid' do
+        obj1 = klass_with_validation.new(name: 'oneone')
+        described_class.execute do |txn|
+          txn.save!(obj1)
+        end
+
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone')
+      end
+
+      it 'does not raise exception when skipping validation' do
+        obj1 = klass_with_validation.new(name: 'one')
+        described_class.execute do |txn|
+          txn.save!(obj1, skip_validation: true)
+        end
+
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('one')
+      end
+    end
+
+    context 'callabacks' do
+      it 'uses callbacks' do
+        klass_with_callbacks.create_table
+        expect {
+          described_class.execute do |txn|
+            txn.save! klass_with_callbacks.new(name: 'two')
+          end
+        }.to output('validating validated saving creating created saved ').to_stdout
+      end
+
+      it 'uses around callbacks' do
+        klass_with_around_callbacks.create_table
+        expect {
+          described_class.execute do |txn|
+            txn.save! klass_with_around_callbacks.new(name: 'two')
+          end
+        }.to output('saving creating created saved ').to_stdout
+      end
+
+      it 'cak skip callbacks' do
+        klass_with_callbacks.create_table
+        expect {
+          described_class.execute do |txn|
+            txn.save! klass_with_callbacks.new(name: 'two'), skip_callbacks: true
+          end
+        }.to output('validating validated ').to_stdout # ActiveModel runs validation callbacks when we validate
+      end
+
+      it 'cak skip callbacks and validation' do
+        klass_with_callbacks.create_table
+        expect {
+          described_class.execute do |txn|
+            txn.save! klass_with_callbacks.new(name: 'two'), skip_callbacks: true, skip_validation: true
+          end
+        }.to output('').to_stdout
+      end
+    end
+  end
+end

--- a/spec/dynamoid/transaction_write/update_spec.rb
+++ b/spec/dynamoid/transaction_write/update_spec.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'context'
+
+# Dynamoid.config.logger.level = :debug
+
+describe Dynamoid::TransactionWrite, '.update' do
+  include_context 'transaction_write'
+
+  context 'updates' do
+    context 'simple primary key' do
+      before do
+        klass.create_table
+      end
+
+      it 'with attribute outside transaction' do
+        obj1 = klass.create!(name: 'one')
+        obj1.name = 'oneone'
+        described_class.execute do |txn|
+          txn.update! obj1
+        end
+        obj1_found = klass.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone')
+      end
+
+      it 'with attribute in transaction' do
+        obj2 = klass.create!(name: 'two')
+        described_class.execute do |txn|
+          txn.update! obj2,  { name: 'twotwo' }
+        end
+        obj2_found = klass.find(obj2.id)
+        expect(obj2_found).to eql(obj2)
+        expect(obj2_found.name).to eql('twotwo')
+      end
+
+      it 'with class updates in transaction' do
+        obj3 = klass.create!(name: 'three')
+        described_class.execute do |txn|
+          txn.update! klass, { id: obj3.id, name: 'threethree' }
+        end
+        obj3_found = klass.find(obj3.id)
+        expect(obj3_found).to eql(obj3)
+        expect(obj3_found.name).to eql('threethree')
+      end
+    end
+
+    context 'composite key' do
+      before do
+        klass_with_composite_key.create_table
+      end
+
+      it 'with attribute outside transaction' do
+        obj1 = klass_with_composite_key.create!(name: 'one', age: 1)
+        obj1.name = 'oneone'
+        described_class.execute do |txn|
+          txn.update! obj1
+        end
+        obj1_found = klass_with_composite_key.find(obj1.id, range_key: 1)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone')
+      end
+
+      it 'with attribute in transaction' do
+        obj2 = klass_with_composite_key.create!(name: 'two', age: 2)
+
+        described_class.execute do |txn|
+          txn.update! obj2, { name: 'twotwo' }
+        end
+        obj2_found = klass_with_composite_key.find(obj2.id, range_key: 2)
+        expect(obj2_found).to eql(obj2)
+        expect(obj2_found.name).to eql('twotwo')
+      end
+
+      it 'with class updates in transaction' do
+        obj3 = klass_with_composite_key.create!(name: 'three', age: 3)
+        described_class.execute do |txn|
+          txn.update! klass_with_composite_key, { id: obj3.id, age: 3, name: 'threethree' }
+        end
+        obj3_found = klass_with_composite_key.find(obj3.id, range_key: 3)
+        expect(obj3_found).to eql(obj3)
+        expect(obj3_found.name).to eql('threethree')
+      end
+    end
+
+    it 'updates timestamps of instance' do
+      klass.create_table
+      obj1 = klass.create!(name: 'one', created_at: Time.now - 48.hours, updated_at: Time.now - 24.hours)
+      obj1.name = 'oneone'
+      described_class.execute do |txn|
+        txn.update! obj1
+      end
+      obj1_found = klass.find(obj1.id)
+      expect(obj1_found.created_at.to_f).to be < (Time.now - 47.hours).to_f
+      expect(obj1_found.updated_at.to_f).to be_within(1.seconds).of Time.now.to_f
+    end
+
+    it 'updates timestamps by class' do
+      klass.create_table
+      obj3 = klass.create!(name: 'three', created_at: Time.now - 48.hours, updated_at: Time.now - 24.hours)
+      described_class.execute do |txn|
+        txn.update! klass, { id: obj3.id, name: 'threethree' }
+      end
+      obj3_found = klass.find(obj3.id)
+      expect(obj3_found.created_at.to_f).to be < (Time.now - 47.hours).to_f
+      expect(obj3_found.updated_at.to_f).to be_within(1.seconds).of Time.now.to_f
+    end
+
+    context 'validates' do
+      before do
+        klass_with_validation.create_table
+      end
+
+      it 'does not update when invalid' do
+        obj1 = klass_with_validation.create!(name: 'onelong')
+        described_class.execute do |txn|
+          obj1.name = 'one'
+          expect(txn.update(obj1)).to eql(false)
+        end
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found.name).to eql('onelong')
+      end
+
+      it 'allows partial update when a record in the transaction is invalid' do
+        obj1 = klass_with_validation.create!(name: 'onelong')
+        obj2 = klass_with_validation.create!(name: 'twolong')
+        described_class.execute do |txn|
+          obj1.name = 'one'
+          expect(txn.update(obj1)).to eql(false)
+          obj2.name = 'twotwo'
+          expect(txn.update(obj2)).to be_truthy
+        end
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found.name).to eql('onelong')
+        obj2_found = klass_with_validation.find(obj2.id)
+        expect(obj2_found.name).to eql('twotwo')
+      end
+
+      it 'succeeds when valid' do
+        obj1 = klass_with_validation.create!(name: 'onelong')
+        described_class.execute do |txn|
+          obj1.name = 'oneone'
+          expect(txn.update(obj1)).to be_present
+        end
+
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone')
+      end
+
+      it 'raises DocumentNotValid when not valid' do
+        obj1 = klass_with_validation.create!(name: 'onelong')
+        expect {
+          described_class.execute do |txn|
+            obj1.name = 'one'
+            txn.update! obj1
+          end
+        }.to raise_error(Dynamoid::Errors::DocumentNotValid)
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found.name).to eql('onelong')
+      end
+
+      it 'rolls back and raises DocumentNotValid when not valid' do
+        obj1 = klass_with_validation.create!(name: 'onelong')
+        obj2 = klass_with_validation.create!(name: 'twolong')
+        expect {
+          described_class.execute do |txn|
+            obj2.name = 'twotwo'
+            txn.update! obj2
+            obj1.name = 'one'
+            txn.update! obj1
+          end
+        }.to raise_error(Dynamoid::Errors::DocumentNotValid)
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found.name).to eql('onelong')
+        obj2_found = klass_with_validation.find(obj2.id)
+        expect(obj2_found.name).to eql('twolong')
+      end
+
+      it 'does not raise exception when valid' do
+        obj1 = klass_with_validation.create!(name: 'onelong')
+        described_class.execute do |txn|
+          obj1.name = 'oneone'
+          txn.update! obj1
+        end
+
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('oneone')
+      end
+
+      it 'does not raise exception when skipping validation' do
+        obj1 = klass_with_validation.create!(name: 'onelong')
+        described_class.execute do |txn|
+          obj1.name = 'one'
+          # this use is infrequent, normal entry is from save!(obj, options)
+          txn.update! obj1, {}, { skip_validation: true }
+        end
+
+        obj1_found = klass_with_validation.find(obj1.id)
+        expect(obj1_found).to eql(obj1)
+        expect(obj1_found.name).to eql('one')
+      end
+
+      it 'uses callbacks' do
+        klass_with_callbacks.create_table
+        obj1 = klass_with_callbacks.create!(name: 'one')
+        expect {
+          described_class.execute do |txn|
+            obj1.name = 'oneone'
+            txn.update! obj1
+          end
+        }.to output('validating validated saving updating updated saved ').to_stdout
+      end
+
+      it 'uses around callbacks' do
+        klass_with_around_callbacks.create_table
+        obj1 = klass_with_around_callbacks.create!(name: 'one')
+        expect {
+          described_class.execute do |txn|
+            obj1.name = 'oneone'
+            txn.update! obj1
+          end
+        }.to output('saving updating updated saved ').to_stdout
+      end
+    end
+  end
+end

--- a/spec/dynamoid/transaction_write/upsert_spec.rb
+++ b/spec/dynamoid/transaction_write/upsert_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'context'
+
+# Dynamoid.config.logger.level = :debug
+
+describe Dynamoid::TransactionWrite, '.upsert' do
+  include_context 'transaction_write'
+
+  context 'upserts' do
+    context 'simple primary key' do
+      before do
+        klass.create_table
+      end
+
+      it 'with class constructed in transaction' do
+        obj3_id = SecureRandom.uuid
+        described_class.execute do |txn|
+          txn.upsert klass, { id: obj3_id, name: 'threethree' }
+        end
+        obj3_found = klass.find(obj3_id)
+        expect(obj3_found.id).to eql(obj3_id)
+        expect(obj3_found.name).to eql('threethree')
+      end
+
+      it 'requires hash key in class' do
+        expect {
+          described_class.execute do |txn|
+            txn.upsert klass, { name: 'threethree' }
+          end
+        }.to raise_exception(Dynamoid::Errors::MissingHashKey)
+      end
+    end
+
+    context 'composite key' do
+      before do
+        klass_with_composite_key.create_table
+      end
+
+      it 'with class constructed in transaction' do
+        obj3_id = SecureRandom.uuid
+        described_class.execute do |txn|
+          txn.upsert klass_with_composite_key, { id: obj3_id, age: 3, name: 'threethree' }
+        end
+        obj3_found = klass_with_composite_key.find(obj3_id, range_key: 3)
+        expect(obj3_found.id).to eql(obj3_id)
+        expect(obj3_found.name).to eql('threethree')
+      end
+
+      it 'with class constructed in transaction with return value' do
+        obj4_written = false
+        described_class.execute do |txn|
+          obj4_written = txn.upsert klass_with_composite_key, { id: SecureRandom.uuid, age: 4, name: 'fourfour' }
+        end
+        expect(obj4_written).to be true
+      end
+
+      it 'requires hash key in class' do
+        expect {
+          described_class.execute do |txn|
+            txn.upsert klass_with_composite_key, { name: 'threethree' }
+          end
+        }.to raise_exception(Dynamoid::Errors::MissingHashKey)
+      end
+
+      it 'requires range key in class' do
+        expect {
+          described_class.execute do |txn|
+            txn.upsert klass_with_composite_key, { id: 'bananas', name: 'threethree' }
+          end
+        }.to raise_exception(Dynamoid::Errors::MissingRangeKey)
+      end
+    end
+
+    it 'updates timestamps by class when existing' do
+      klass.create_table
+      obj3 = klass.create!(name: 'three', created_at: Time.now - 48.hours, updated_at: Time.now - 24.hours)
+      described_class.execute do |txn|
+        txn.upsert klass, { id: obj3.id, name: 'threethree' }
+      end
+      obj3_found = klass.find(obj3.id)
+      expect(obj3_found.created_at.to_f).to be < (Time.now - 47.hours).to_f
+      expect(obj3_found.updated_at.to_f).to be_within(1.seconds).of Time.now.to_f
+    end
+
+    it 'updates timestamps by class when not existing' do
+      klass.create_table
+      obj3_id = SecureRandom.uuid
+      described_class.execute do |txn|
+        txn.upsert klass, { id: obj3_id, name: 'threethree' }
+      end
+      obj3_found = klass.find(obj3_id)
+      expect(obj3_found.created_at).to be_nil
+      expect(obj3_found.updated_at.to_f).to be_within(1.seconds).of Time.now.to_f
+    end
+  end
+end


### PR DESCRIPTION
This is a first attempt at dynamodb transactions that can span tables. Create, update, upsert and delete are supported. See README_transact.md for examples of the proposed API.

Tests have not yet been implemented.