### PR TITLE
Fix type annotation of arg `options`

### DIFF
--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -164,7 +164,7 @@ module Dynamoid
       #
       # @param name [Symbol] a range key attribute name
       # @param type [Symbol] a range key type (optional)
-      # @param options [Symbol] type options (optional)
+      # @param options [Hash] type options (optional)
       def range(name, type = :string, options = {})
         field(name, type, options)
         self.range_key = name


### PR DESCRIPTION
Hello. Thank you for your maintenance.

This PR fixes the type annotation of the argument `options` in the method that sets range key.