### PR TITLE
remove code sample that not exist as specifications in update method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,6 @@ validation and callbacks.
 Address.find(id).update_attributes(city: 'Chicago')
 Address.find(id).update_attribute(:city, 'Chicago')
 Address.update(id, city: 'Chicago')
-Address.update(id, { city: 'Chicago' }, if: { deliverable: true })
 ```
 
 There are also some low level methods `#update`, `.update_fields` and


### PR DESCRIPTION
※ related to #720 that closed it due to my ineptitude.

Hello, thank you for maintenance of this gem.

Probably related to issue https://github.com/Dynamoid/dynamoid/issues/657.

I found what incorrect code sample of update method in readme.md.

.update method does not accept conditions as arguments.

[dynamoid/lib/dynamoid/persistence.rb](https://github.com/Dynamoid/dynamoid/blob/6b96d1d9cb8cb6d011cc84d1ca4cc65f43d6a729/lib/dynamoid/persistence.rb#L232)

Line 232 in [6b96d1d](https://github.com/Dynamoid/dynamoid/commit/6b96d1d9cb8cb6d011cc84d1ca4cc65f43d6a729)

 def update(hash_key, range_key_value = nil, attrs) 
Therefore, the following code as shown in the sample will fail.

Address.update(id, { city: 'Chicago' }, if: { deliverable: true })
So I removed this code sample.

thank you!