### PR TITLE
Allow ActiveSupport::HashWithIndifferentAccess of yaml parse

### DIFF
--- a/lib/dynamoid/undumping.rb
+++ b/lib/dynamoid/undumping.rb
@@ -256,7 +256,9 @@ module Dynamoid
           # String
           # Array
           # Hash
-          YAML.safe_load(value, permitted_classes: [Symbol, Set, Date, Time, DateTime])
+          YAML.safe_load(value, permitted_classes: [
+            Symbol, Set, Date, Time, DateTime, ActiveSupport::HashWithIndifferentAccess
+          ])
         else
           YAML.load(value)
         end


### PR DESCRIPTION
The serialized field are stored with ActiveSupport

In my model, I added this:

```ruby
  field :description, :serialized
```

![image](https://github.com/Dynamoid/dynamoid/assets/3936337/8c210c56-c9d2-478a-8c5c-dc42f3825bab)

when I read the record, I received this error:

```
Psych::DisallowedClass: Tried to load unspecified class: ActiveSupport::HashWithIndifferentAccess
```

I think, the most of the apps use rails and ActiveSupport, so I think should be a good addiction to add the support of ActiveSupport