### PR TITLE
Add configuration option to persist empty strings as is

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
     - name: Start dynamodb-local
       run: |
-        docker-compose up -d
+        docker compose up -d
 
     - name: Run RSpec tests
       run: |
@@ -164,4 +164,4 @@ jobs:
 
     - name: Stop dynamodb-local
       run: |
-        docker-compose down
+        docker compose down

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Start dynamodb-local
         run: |
-          docker-compose up -d
+          docker compose up -d
 
       - name: Run RSpec tests
         run: |
@@ -74,7 +74,7 @@ jobs:
 
       - name: Stop dynamodb-local
         run: |
-          docker-compose down
+          docker compose down
 
       - name: CodeClimate Post-build Notification
         run: cc-test-reporter after-build

--- a/.rubocop_rspec.yml
+++ b/.rubocop_rspec.yml
@@ -31,6 +31,9 @@ RSpec/NestedGroups:
 RSpec/ExpectInHook:
   Enabled: false
 
+RSpec/ExpectInLet:
+  Enabled: false
+
 # NOTE: for many tests of equality `eql` works, while `be` does not, because
 #        expected #<Fixnum:...> => 101
 #            got #<BigDecimal:...> => 101.0 (0.101e3)

--- a/.rubocop_rspec.yml
+++ b/.rubocop_rspec.yml
@@ -1,4 +1,7 @@
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
+  Enabled: false
+
+RSpec/SpecFilePathSuffix:
   Enabled: false
 
 RSpec/MultipleExpectations:

--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ Listed below are all configuration options.
   fields in ISO 8601 string format. Default is `false`
 * `store_date_as_string` - if `true` then Dynamoid stores :date fields
   in ISO 8601 string format. Default is `false`
+* `store_empty_string_as_nil` - store attribute's empty String value as NULL. Default is `true`
 * `store_boolean_as_native` - if `true` Dynamoid stores boolean fields
   as native DynamoDB boolean values. Otherwise boolean fields are stored
   as string values `'t'` and `'f'`. Default is `true`

--- a/dynamoid.gemspec
+++ b/dynamoid.gemspec
@@ -51,9 +51,9 @@ Gem::Specification.new do |spec|
   spec.metadata['wiki_uri'] = 'https://github.com/Dynamoid/dynamoid/wiki'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_runtime_dependency 'activemodel', '>=4'
-  spec.add_runtime_dependency 'aws-sdk-dynamodb', '~> 1.0'
-  spec.add_runtime_dependency 'concurrent-ruby', '>= 1.0'
+  spec.add_dependency 'activemodel', '>=4'
+  spec.add_dependency 'aws-sdk-dynamodb', '~> 1.0'
+  spec.add_dependency 'concurrent-ruby', '>= 1.0'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -667,7 +667,7 @@ module Dynamoid
         store_attribute_with_nil_value = config_value.nil? ? false : !!config_value
 
         attributes.reject do |_, v|
-            (!store_attribute_with_nil_value && v.nil?)
+          !store_attribute_with_nil_value && v.nil?
         end.transform_values do |v|
           v.is_a?(Hash) ? v.stringify_keys : v
         end

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -667,7 +667,8 @@ module Dynamoid
         store_attribute_with_nil_value = config_value.nil? ? false : !!config_value
 
         attributes.reject do |_, v|
-          ((v.is_a?(Set) || v.is_a?(String)) && v.empty?) ||
+          (v.is_a?(Set) && v.empty?) ||
+            (v.is_a?(String) && v.empty? && Config.store_empty_string_as_nil) ||
             (!store_attribute_with_nil_value && v.nil?)
         end.transform_values do |v|
           v.is_a?(Hash) ? v.stringify_keys : v

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -667,8 +667,6 @@ module Dynamoid
         store_attribute_with_nil_value = config_value.nil? ? false : !!config_value
 
         attributes.reject do |_, v|
-          (v.is_a?(Set) && v.empty?) ||
-            (v.is_a?(String) && v.empty? && Config.store_empty_string_as_nil) ||
             (!store_attribute_with_nil_value && v.nil?)
         end.transform_values do |v|
           v.is_a?(Hash) ? v.stringify_keys : v

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
@@ -108,7 +108,7 @@ module Dynamoid
               v.stringify_keys
             elsif v.is_a?(Set) && v.empty?
               nil
-            elsif v.is_a?(String) && v.empty?
+            elsif v.is_a?(String) && v.empty? && Config.store_empty_string_as_nil
               nil
             else
               v

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/item_updater.rb
@@ -97,10 +97,11 @@ module Dynamoid
 
         private
 
-        # Keep in sync with AwsSdkV3.sanitize_item.
+        # It's a single low level component available in a public API (with
+        # Document#update/#update! methods). So duplicate sanitizing to some
+        # degree.
         #
-        # The only difference is that to update item we need to track whether
-        # attribute value is nil or not.
+        # Keep in sync with AwsSdkV3.sanitize_item.
         def sanitize_attributes(attributes)
           # rubocop:disable Lint/DuplicateBranch
           attributes.transform_values do |v|

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -48,6 +48,7 @@ module Dynamoid
     option :dynamodb_timezone, default: :utc # available values - :utc, :local, time zone name like "Hawaii"
     option :store_datetime_as_string, default: false # store Time fields in ISO 8601 string format
     option :store_date_as_string, default: false # store Date fields in ISO 8601 string format
+    option :store_empty_string_as_nil, default: true # store attribute's empty String value as null
     option :store_boolean_as_native, default: true
     option :backoff, default: nil # callable object to handle exceeding of table throughput limit
     option :backoff_strategies, default: {

--- a/lib/dynamoid/dumping.rb
+++ b/lib/dynamoid/dumping.rb
@@ -90,6 +90,7 @@ module Dynamoid
       def process(string)
         return nil if string.nil?
         return nil if string.empty? && Config.store_empty_string_as_nil
+
         string
       end
     end

--- a/lib/dynamoid/dumping.rb
+++ b/lib/dynamoid/dumping.rb
@@ -107,6 +107,8 @@ module Dynamoid
       ALLOWED_TYPES = %i[string integer number date datetime serialized].freeze
 
       def process(set)
+        return nil if set.is_a?(Set) && set.empty?
+
         if @options.key?(:of)
           process_typed_collection(set)
         else

--- a/lib/dynamoid/errors.rb
+++ b/lib/dynamoid/errors.rb
@@ -16,7 +16,7 @@ module Dynamoid
     class InvalidIndex < Error
       def initialize(item)
         if item.is_a? String
-          super(item)
+          super
         else
           super("Validation failed: #{item.errors.full_messages.join(', ')}")
         end

--- a/lib/dynamoid/persistence/item_updater_with_casting_and_dumping.rb
+++ b/lib/dynamoid/persistence/item_updater_with_casting_and_dumping.rb
@@ -4,7 +4,6 @@ module Dynamoid
   module Persistence
     # @private
     class ItemUpdaterWithCastingAndDumping
-
       def initialize(model_class, item_updater)
         @model_class = model_class
         @item_updater = item_updater

--- a/lib/dynamoid/persistence/item_updater_with_casting_and_dumping.rb
+++ b/lib/dynamoid/persistence/item_updater_with_casting_and_dumping.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module Persistence
+    # @private
+    class ItemUpdaterWithCastingAndDumping
+
+      def initialize(model_class, item_updater)
+        @model_class = model_class
+        @item_updater = item_updater
+      end
+
+      def add(attributes)
+        @item_updater.add(cast_and_dump(attributes))
+      end
+
+      def set(attributes)
+        @item_updater.set(cast_and_dump(attributes))
+      end
+
+      private
+
+      def cast_and_dump(attributes)
+        casted_and_dumped = {}
+
+        attributes.each do |name, value|
+          value_casted = TypeCasting.cast_field(value, @model_class.attributes[name])
+          value_dumped = Dumping.dump_field(value_casted, @model_class.attributes[name])
+
+          casted_and_dumped[name] = value_dumped
+        end
+
+        casted_and_dumped
+      end
+    end
+  end
+end

--- a/lib/dynamoid/persistence/item_updater_with_dumping.rb
+++ b/lib/dynamoid/persistence/item_updater_with_dumping.rb
@@ -4,7 +4,6 @@ module Dynamoid
   module Persistence
     # @private
     class ItemUpdaterWithDumping
-
       def initialize(model_class, item_updater)
         @model_class = model_class
         @item_updater = item_updater
@@ -32,4 +31,3 @@ module Dynamoid
     end
   end
 end
-

--- a/lib/dynamoid/persistence/item_updater_with_dumping.rb
+++ b/lib/dynamoid/persistence/item_updater_with_dumping.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module Persistence
+    # @private
+    class ItemUpdaterWithDumping
+
+      def initialize(model_class, item_updater)
+        @model_class = model_class
+        @item_updater = item_updater
+      end
+
+      def add(attributes)
+        @item_updater.add(dump(attributes))
+      end
+
+      def set(attributes)
+        @item_updater.set(dump(attributes))
+      end
+
+      private
+
+      def dump(attributes)
+        dumped = {}
+
+        attributes.each do |name, value|
+          dumped[name] = Dumping.dump_field(value, @model_class.attributes[name])
+        end
+
+        dumped
+      end
+    end
+  end
+end
+

--- a/lib/dynamoid/persistence/save.rb
+++ b/lib/dynamoid/persistence/save.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'item_updater_with_dumping'
+
 module Dynamoid
   module Persistence
     # @private
@@ -36,9 +38,10 @@ module Dynamoid
           attributes_to_persist = @model.attributes.slice(*@model.changed.map(&:to_sym))
 
           Dynamoid.adapter.update_item(@model.class.table_name, @model.hash_key, options_to_update_item) do |t|
+            item_updater = ItemUpdaterWithDumping.new(@model.class, t)
+
             attributes_to_persist.each do |name, value|
-              value_dumped = Dumping.dump_field(value, @model.class.attributes[name])
-              t.set(name => value_dumped)
+              item_updater.set(name => value)
             end
           end
         end

--- a/lib/dynamoid/persistence/update_fields.rb
+++ b/lib/dynamoid/persistence/update_fields.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'item_updater_with_casting_and_dumping'
+
 module Dynamoid
   module Persistence
     # @private
@@ -32,10 +34,10 @@ module Dynamoid
 
       def update_item
         Dynamoid.adapter.update_item(@model_class.table_name, @partition_key, options_to_update_item) do |t|
+          item_updater = ItemUpdaterWithCastingAndDumping.new(@model_class, t)
+
           @attributes.each do |k, v|
-            value_casted = TypeCasting.cast_field(v, @model_class.attributes[k])
-            value_dumped = Dumping.dump_field(value_casted, @model_class.attributes[k])
-            t.set(k => value_dumped)
+            item_updater.set(k => v)
           end
         end
       end

--- a/lib/dynamoid/persistence/upsert.rb
+++ b/lib/dynamoid/persistence/upsert.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'item_updater_with_casting_and_dumping'
+
 module Dynamoid
   module Persistence
     # @private
@@ -32,11 +34,10 @@ module Dynamoid
 
       def update_item
         Dynamoid.adapter.update_item(@model_class.table_name, @partition_key, options_to_update_item) do |t|
-          @attributes.each do |k, v|
-            value_casted = TypeCasting.cast_field(v, @model_class.attributes[k])
-            value_dumped = Dumping.dump_field(value_casted, @model_class.attributes[k])
+          item_updater = ItemUpdaterWithCastingAndDumping.new(@model_class, t)
 
-            t.set(k => value_dumped)
+          @attributes.each do |k, v|
+            item_updater.set(k => v)
           end
         end
       end

--- a/lib/dynamoid/transaction_write/update_upsert.rb
+++ b/lib/dynamoid/transaction_write/update_upsert.rb
@@ -6,7 +6,7 @@ module Dynamoid
   class TransactionWrite
     class UpdateUpsert < Action
       def initialize(model_or_model_class, attributes = {}, options = {}, &block)
-        super(model_or_model_class, attributes, options, &block)
+        super
 
         write_attributes_to_model
       end

--- a/lib/dynamoid/transaction_write/upsert.rb
+++ b/lib/dynamoid/transaction_write/upsert.rb
@@ -9,7 +9,7 @@ module Dynamoid
       # No callbacks.
       def initialize(model_or_model_class, attributes, options = {})
         options = options.reverse_merge(skip_existence_check: true)
-        super(model_or_model_class, attributes, options)
+        super
         raise Dynamoid::Errors::MissingHashKey unless hash_key.present?
         raise Dynamoid::Errors::MissingRangeKey unless !model_class.range_key? || range_key.present?
       end

--- a/lib/dynamoid/validations.rb
+++ b/lib/dynamoid/validations.rb
@@ -24,7 +24,7 @@ module Dynamoid
     # @since 0.2.0
     def valid?(context = nil)
       context ||= (new_record? ? :create : :update)
-      super(context)
+      super
     end
 
     # Raise an error unless this object is valid.

--- a/spec/dynamoid/criteria_new_spec.rb
+++ b/spec/dynamoid/criteria_new_spec.rb
@@ -43,10 +43,10 @@ describe Dynamoid::Criteria do
     klass = new_class do
       range :name
     end
+    objects = klass.create([{ name: 'Alex' }, { name: 'Bob' }])
 
     result = []
-    objects = klass.create([{ name: 'Alex' }, { name: 'Bob' }])
-    klass.each { |obj| result << obj }
+    klass.each { |obj| result << obj } # rubocop:disable Style/MapIntoArray
 
     expect(result).to match_array(objects)
   end

--- a/spec/dynamoid/dumping_spec.rb
+++ b/spec/dynamoid/dumping_spec.rb
@@ -505,11 +505,25 @@ describe 'Dumping' do
           expect(raw_attributes(obj)[:values]).to eql(Set.new(%w[a b c]))
         end
 
-        it 'removes empty strings' do
+        it 'removes empty strings by default' do
           obj = class_with_typed_set.create(values: Set.new(['a', '', 'c']))
 
           expect(reload(obj).values).to eql(Set.new(%w[a c]))
           expect(raw_attributes(obj)[:values]).to eql(Set.new(%w[a c]))
+        end
+
+        it 'removes empty strings if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+          obj = class_with_typed_set.create(values: Set.new(['a', '', 'c']))
+
+          expect(reload(obj).values).to eql(Set.new(%w[a c]))
+          expect(raw_attributes(obj)[:values]).to eql(Set.new(%w[a c]))
+        end
+
+        it 'keeps empty strings as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+          obj = class_with_typed_set.create(values: Set.new(['a', '', 'c']))
+
+          expect(reload(obj).values).to eql(Set.new(['a', '', 'c']))
+          expect(raw_attributes(obj)[:values]).to eql(Set.new(['a', '', 'c']))
         end
       end
 
@@ -788,11 +802,25 @@ describe 'Dumping' do
           expect(raw_attributes(obj)[:values]).to eql(%w[a b c])
         end
 
-        it 'removes empty strings' do
+        it 'removes empty strings by default' do
           obj = class_with_typed_array.create(values: ['a', '', 'c'])
 
           expect(reload(obj).values).to eql(%w[a c])
           expect(raw_attributes(obj)[:values]).to eql(%w[a c])
+        end
+
+        it 'removes empty strings if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+          obj = class_with_typed_array.create(values: ['a', '', 'c'])
+
+          expect(reload(obj).values).to eql(%w[a c])
+          expect(raw_attributes(obj)[:values]).to eql(%w[a c])
+        end
+
+        it 'keeps empty strings as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+          obj = class_with_typed_array.create(values: ['a', '', 'c'])
+
+          expect(reload(obj).values).to eql(['a', '', 'c'])
+          expect(raw_attributes(obj)[:values]).to eql(['a', '', 'c'])
         end
       end
 
@@ -1056,11 +1084,26 @@ describe 'Dumping' do
         expect(reload(obj).settings).to eql(foo: nil)
       end
 
-      it 'replaces empty string with nil in Hash' do
+      it 'replaces empty string with nil in Hash by default' do
         settings = { 'foo' => '' }
         obj = klass.create(settings: settings)
 
         expect(reload(obj).settings).to eql(foo: nil)
+      end
+
+      it 'replaces empty string with nil in Hash if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+        settings = { 'foo' => '' }
+        obj = klass.create(settings: settings)
+
+        expect(reload(obj).settings).to eql(foo: nil)
+      end
+
+      it 'keeps empty string as is in Hash if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+        settings = { 'foo' => '' }
+        obj = klass.create(settings: settings)
+
+        expect(reload(obj).settings).to eql(foo: '')
+        expect(raw_attributes(obj)[:settings]).to eql("foo" => '')
       end
 
       it 'replaces empty set with nil in nested Array' do
@@ -1070,11 +1113,26 @@ describe 'Dumping' do
         expect(reload(obj).settings).to eql(foo: [1, 2, nil])
       end
 
-      it 'replaces empty string with nil in nested Array' do
+      it 'replaces empty string with nil in nested Array by default' do
         settings = { 'foo' => [1, 2, ''] }
         obj = klass.create(settings: settings)
 
         expect(reload(obj).settings).to eql(foo: [1, 2, nil])
+      end
+
+      it 'replaces empty string with nil in nested Array if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+        settings = { 'foo' => [1, 2, ''] }
+        obj = klass.create(settings: settings)
+
+        expect(reload(obj).settings).to eql(foo: [1, 2, nil])
+      end
+
+      it 'keeps empty string as is in nested Array if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+        settings = { 'foo' => [1, 2, ''] }
+        obj = klass.create(settings: settings)
+
+        expect(reload(obj).settings).to eql(foo: [1, 2, ''])
+        expect(raw_attributes(obj)[:settings]).to eql("foo" => [1, 2, ''])
       end
 
       it 'processes nested Hash and Array' do
@@ -1098,7 +1156,7 @@ describe 'Dumping' do
       expect(raw_attributes(obj)[:name]).to eql('Matthew')
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       klass = new_class do
         field :name, :string
       end
@@ -1107,6 +1165,28 @@ describe 'Dumping' do
 
       expect(reload(obj).name).to eql(nil)
       expect(raw_attributes(obj)[:name]).to eql(nil)
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      klass = new_class do
+        field :name, :string
+      end
+
+      obj = klass.create(name: '')
+
+      expect(reload(obj).name).to eql(nil)
+      expect(raw_attributes(obj)[:name]).to eql(nil)
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      klass = new_class do
+        field :name, :string
+      end
+
+      obj = klass.create(name: '')
+
+      expect(reload(obj).name).to eql('')
+      expect(raw_attributes(obj)[:name]).to eql('')
     end
 
     it 'is used as default field type' do
@@ -1207,11 +1287,26 @@ describe 'Dumping' do
         expect(reload(obj).config).to eql(foo: nil)
       end
 
-      it 'replaces empty string with nil in Hash' do
+      it 'replaces empty string with nil in Hash by default' do
         config = { 'foo' => '' }
         obj = klass.create(config: config)
 
         expect(reload(obj).config).to eql(foo: nil)
+      end
+
+      it 'replaces empty string with nil in Hash if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+        config = { 'foo' => '' }
+        obj = klass.create(config: config)
+
+        expect(reload(obj).config).to eql(foo: nil)
+      end
+
+      it 'keeps empty string as is in Hash if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+        config = { 'foo' => '' }
+        obj = klass.create(config: config)
+
+        expect(reload(obj).config).to eql(foo: '')
+        expect(raw_attributes(obj)[:config]).to eql("foo" => '')
       end
 
       it 'replaces empty set with nil in Array' do
@@ -1221,11 +1316,26 @@ describe 'Dumping' do
         expect(reload(obj).config).to eql([1, 2, nil])
       end
 
-      it 'replaces empty string with nil in Array' do
+      it 'replaces empty string with nil in Array by default' do
         config = [1, 2, '']
         obj = klass.create(config: config)
 
         expect(reload(obj).config).to eql([1, 2, nil])
+      end
+
+      it 'replaces empty string with nil in Array if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+        config = [1, 2, '']
+        obj = klass.create(config: config)
+
+        expect(reload(obj).config).to eql([1, 2, nil])
+      end
+
+      it 'keeps empty string as is in Array if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+        config = [1, 2, '']
+        obj = klass.create(config: config)
+
+        expect(reload(obj).config).to eql([1, 2, ''])
+        expect(raw_attributes(obj)[:config]).to eql([1, 2, ''])
       end
 
       it 'processes nested Hash and Array' do

--- a/spec/dynamoid/dumping_spec.rb
+++ b/spec/dynamoid/dumping_spec.rb
@@ -1103,7 +1103,7 @@ describe 'Dumping' do
         obj = klass.create(settings: settings)
 
         expect(reload(obj).settings).to eql(foo: '')
-        expect(raw_attributes(obj)[:settings]).to eql("foo" => '')
+        expect(raw_attributes(obj)[:settings]).to eql('foo' => '')
       end
 
       it 'replaces empty set with nil in nested Array' do
@@ -1132,7 +1132,7 @@ describe 'Dumping' do
         obj = klass.create(settings: settings)
 
         expect(reload(obj).settings).to eql(foo: [1, 2, ''])
-        expect(raw_attributes(obj)[:settings]).to eql("foo" => [1, 2, ''])
+        expect(raw_attributes(obj)[:settings]).to eql('foo' => [1, 2, ''])
       end
 
       it 'processes nested Hash and Array' do
@@ -1306,7 +1306,7 @@ describe 'Dumping' do
         obj = klass.create(config: config)
 
         expect(reload(obj).config).to eql(foo: '')
-        expect(raw_attributes(obj)[:config]).to eql("foo" => '')
+        expect(raw_attributes(obj)[:config]).to eql('foo' => '')
       end
 
       it 'replaces empty set with nil in Array' do

--- a/spec/dynamoid/persistence_spec.rb
+++ b/spec/dynamoid/persistence_spec.rb
@@ -733,11 +733,26 @@ describe Dynamoid::Persistence do
       expect(obj_loaded.tags).to eql nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       obj = klass.create(city: '')
       obj_loaded = klass.find(obj.id)
 
       expect(obj_loaded.city).to eql nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      obj = klass.create(city: '')
+      obj_loaded = klass.find(obj.id)
+
+      expect(obj_loaded.city).to eql nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      obj = klass.create(city: '')
+      obj_loaded = klass.find(obj.id)
+
+      expect(obj_loaded.city).to eql ''
+      expect(raw_attributes(obj)[:city]).to eql ''
     end
 
     describe 'callbacks' do
@@ -1094,7 +1109,7 @@ describe Dynamoid::Persistence do
       expect(obj_loaded.tags).to eql nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       klass_with_string = new_class do
         field :name
       end
@@ -1104,6 +1119,31 @@ describe Dynamoid::Persistence do
       obj_loaded = klass_with_string.find(obj.id)
 
       expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'alex')
+      klass_with_string.update!(obj.id, name: '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'alex')
+      klass_with_string.update!(obj.id, name: '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql ''
+      expect(raw_attributes(obj)[:name]).to eql ''
     end
 
     describe 'timestamps' do
@@ -1444,7 +1484,7 @@ describe Dynamoid::Persistence do
       expect(obj_loaded.tags).to eql nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       klass_with_string = new_class do
         field :name
       end
@@ -1454,6 +1494,31 @@ describe Dynamoid::Persistence do
       obj_loaded = klass_with_string.find(obj.id)
 
       expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'alex')
+      klass_with_string.update(obj.id, name: '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'alex')
+      klass_with_string.update(obj.id, name: '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql ''
+      expect(raw_attributes(obj)[:name]).to eql ''
     end
 
     describe 'timestamps' do
@@ -1689,7 +1754,7 @@ describe Dynamoid::Persistence do
       expect(obj_loaded.tags).to eql nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       klass_with_string = new_class do
         field :name
       end
@@ -1699,6 +1764,31 @@ describe Dynamoid::Persistence do
       obj_loaded = klass_with_string.find(obj.id)
 
       expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      klass_with_string.update_fields(obj.id, name: '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      klass_with_string.update_fields(obj.id, name: '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql ''
+      expect(raw_attributes(obj)[:name]).to eql ''
     end
 
     describe 'timestamps' do
@@ -1964,7 +2054,7 @@ describe Dynamoid::Persistence do
       expect(obj_loaded.tags).to eql nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       klass_with_string = new_class do
         field :name
       end
@@ -1974,6 +2064,31 @@ describe Dynamoid::Persistence do
       obj_loaded = klass_with_string.find(obj.id)
 
       expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      klass_with_string.upsert(obj.id, name: '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      klass_with_string.upsert(obj.id, name: '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql ''
+      expect(raw_attributes(obj)[:name]).to eql ''
     end
 
     describe 'timestamps' do
@@ -2316,7 +2431,7 @@ describe Dynamoid::Persistence do
       expect(obj_loaded.tags).to eql nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       klass_with_string = new_class do
         field :name
       end
@@ -2327,6 +2442,33 @@ describe Dynamoid::Persistence do
       obj_loaded = klass_with_string.find(obj.id)
 
       expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      obj.name = ''
+      obj.save
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      obj.name = ''
+      obj.save
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql ''
+      expect(raw_attributes(obj)[:name]).to eql ''
     end
 
     it 'does not make a request to persist a model if there is no any changed attribute' do
@@ -3036,7 +3178,7 @@ describe Dynamoid::Persistence do
       expect(obj_loaded.tags).to eql nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       klass_with_string = new_class do
         field :name
       end
@@ -3046,6 +3188,31 @@ describe Dynamoid::Persistence do
       obj_loaded = klass_with_string.find(obj.id)
 
       expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      obj.update_attribute(:name, '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      obj.update_attribute(:name, '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql ''
+      expect(raw_attributes(obj)[:name]).to eql ''
     end
 
     describe 'type casting' do
@@ -3521,7 +3688,7 @@ describe Dynamoid::Persistence do
       expect(obj_loaded.tags).to eql nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       klass_with_string = new_class do
         field :name
       end
@@ -3531,6 +3698,31 @@ describe Dynamoid::Persistence do
       obj_loaded = klass_with_string.find(obj.id)
 
       expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      obj.update_attributes!(name: '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      obj.update_attributes!(name: '')
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql ''
+      expect(raw_attributes(obj)[:name]).to eql ''
     end
 
     describe 'type casting' do
@@ -4211,7 +4403,7 @@ describe Dynamoid::Persistence do
       expect(obj_loaded.tags).to eql nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       klass_with_string = new_class do
         field :name
       end
@@ -4221,6 +4413,31 @@ describe Dynamoid::Persistence do
       obj_loaded = klass_with_string.find(obj.id)
 
       expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      obj.update! { |t| t.set(name: '') }
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      obj.update! { |t| t.set(name: '') }
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql ''
+      expect(raw_attributes(obj)[:name]).to eql ''
     end
   end
 
@@ -4372,7 +4589,7 @@ describe Dynamoid::Persistence do
       expect(obj_loaded.tags).to eql nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       klass_with_string = new_class do
         field :name
       end
@@ -4382,6 +4599,31 @@ describe Dynamoid::Persistence do
       obj_loaded = klass_with_string.find(obj.id)
 
       expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      obj.update { |t| t.set(name: '') }
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      klass_with_string = new_class do
+        field :name
+      end
+
+      obj = klass_with_string.create!(name: 'Alex')
+      obj.update { |t| t.set(name: '') }
+      obj_loaded = klass_with_string.find(obj.id)
+
+      expect(obj_loaded.name).to eql ''
+      expect(raw_attributes(obj)[:name]).to eql ''
     end
 
     describe 'timestamps' do
@@ -4859,11 +5101,26 @@ describe Dynamoid::Persistence do
       expect(tweet.tags).to eq nil
     end
 
-    it 'saves empty string as nil' do
+    it 'saves empty string as nil by default' do
       users = User.import([{ name: '' }])
 
       user = User.find(users[0].id)
       expect(user.name).to eq nil
+    end
+
+    it 'saves empty string as nil if store_empty_string_as_nil config option is true', config: { store_empty_string_as_nil: true } do
+      users = User.import([{ name: '' }])
+
+      user = User.find(users[0].id)
+      expect(user.name).to eq nil
+    end
+
+    it 'saves empty string as is if store_empty_string_as_nil config option is false', config: { store_empty_string_as_nil: false } do
+      users = User.import([{ name: '' }])
+
+      user = User.find(users[0].id)
+      expect(user.name).to eq ''
+      expect(raw_attributes(user)[:name]).to eql ''
     end
 
     it 'saves attributes with nil value' do

--- a/spec/dynamoid/transaction_write/save_spec.rb
+++ b/spec/dynamoid/transaction_write/save_spec.rb
@@ -183,7 +183,7 @@ describe Dynamoid::TransactionWrite, '.save' do # 'save' is an update or create
           described_class.execute do |txn|
             txn.save! klass_with_callbacks.new(name: 'two'), skip_callbacks: true, skip_validation: true
           end
-        }.to output('').to_stdout
+        }.not_to output.to_stdout
       end
     end
   end


### PR DESCRIPTION
Add `Config.store_empty_string_as_nil` options that is true by default. If it's true - empty strings will be persisted as nil otherwise as is. DynamoDB added support of storing empty strings so this logic isn't required anymore.

Close #788