### PR TITLE
Fix field names with special characters in where conditions

### DIFF
--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/filter_expression_convertor.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/filter_expression_convertor.rb
@@ -22,36 +22,42 @@ module Dynamoid
         def build
           clauses = @conditions.map do |name, attribute_conditions|
             attribute_conditions.map do |operator, value|
-              name_or_placeholder = name_or_placeholder_for(name)
+              # replace attribute names with placeholders unconditionally to support
+              # - special characters (e.g. '.', ':', and '#') and
+              # - leading '_'
+              # See
+              # - https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.NamingRules
+              # - https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html#Expressions.ExpressionAttributeNames.AttributeNamesContainingSpecialCharacters
+              name_placeholder = name_placeholder_for(name)
 
               case operator
               when :eq
-                "#{name_or_placeholder} = #{value_placeholder_for(value)}"
+                "#{name_placeholder} = #{value_placeholder_for(value)}"
               when :ne
-                "#{name_or_placeholder} <> #{value_placeholder_for(value)}"
+                "#{name_placeholder} <> #{value_placeholder_for(value)}"
               when :gt
-                "#{name_or_placeholder} > #{value_placeholder_for(value)}"
+                "#{name_placeholder} > #{value_placeholder_for(value)}"
               when :lt
-                "#{name_or_placeholder} < #{value_placeholder_for(value)}"
+                "#{name_placeholder} < #{value_placeholder_for(value)}"
               when :gte
-                "#{name_or_placeholder} >= #{value_placeholder_for(value)}"
+                "#{name_placeholder} >= #{value_placeholder_for(value)}"
               when :lte
-                "#{name_or_placeholder} <= #{value_placeholder_for(value)}"
+                "#{name_placeholder} <= #{value_placeholder_for(value)}"
               when :between
-                "#{name_or_placeholder} BETWEEN #{value_placeholder_for(value[0])} AND #{value_placeholder_for(value[1])}"
+                "#{name_placeholder} BETWEEN #{value_placeholder_for(value[0])} AND #{value_placeholder_for(value[1])}"
               when :begins_with
-                "begins_with (#{name_or_placeholder}, #{value_placeholder_for(value)})"
+                "begins_with (#{name_placeholder}, #{value_placeholder_for(value)})"
               when :in
                 list = value.map(&method(:value_placeholder_for)).join(' , ')
-                "#{name_or_placeholder} IN (#{list})"
+                "#{name_placeholder} IN (#{list})"
               when :contains
-                "contains (#{name_or_placeholder}, #{value_placeholder_for(value)})"
+                "contains (#{name_placeholder}, #{value_placeholder_for(value)})"
               when :not_contains
-                "NOT contains (#{name_or_placeholder}, #{value_placeholder_for(value)})"
+                "NOT contains (#{name_placeholder}, #{value_placeholder_for(value)})"
               when :null
-                "attribute_not_exists (#{name_or_placeholder})"
+                "attribute_not_exists (#{name_placeholder})"
               when :not_null
-                "attribute_exists (#{name_or_placeholder})"
+                "attribute_exists (#{name_placeholder})"
               end
             end
           end.flatten
@@ -59,9 +65,7 @@ module Dynamoid
           @expression = clauses.join(' AND ')
         end
 
-        def name_or_placeholder_for(name)
-          return name unless name.upcase.in?(Dynamoid::AdapterPlugin::AwsSdkV3::RESERVED_WORDS)
-
+        def name_placeholder_for(name)
           placeholder = @name_placeholder_sequence.call
           @name_placeholders[placeholder] = name
           placeholder

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/projection_expression_convertor.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/projection_expression_convertor.rb
@@ -21,13 +21,15 @@ module Dynamoid
           return if @names.nil? || @names.empty?
 
           clauses = @names.map do |name|
-            if name.upcase.in?(Dynamoid::AdapterPlugin::AwsSdkV3::RESERVED_WORDS)
-              placeholder = @name_placeholder_sequence.call
-              @name_placeholders[placeholder] = name
-              placeholder
-            else
-              name.to_s
-            end
+            # replace attribute names with placeholders unconditionally to support
+            # - special characters (e.g. '.', ':', and '#') and
+            # - leading '_'
+            # See
+            # - https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.NamingRules
+            # - https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html#Expressions.ExpressionAttributeNames.AttributeNamesContainingSpecialCharacters
+            placeholder = @name_placeholder_sequence.call
+            @name_placeholders[placeholder] = name
+            placeholder
           end
 
           @expression = clauses.join(' , ')


### PR DESCRIPTION
Fix using fields with special characters in `where` conditions. It's a regression introduced in #655 (v3.10.0).

Examples:
```ruby
User.where(_sortKey: 'a')
User.where('last:name': 'a')
```

Errors:
```
Invalid KeyConditionExpression: Syntax error; token: "_", near: "AND _sortKey"
Invalid FilterExpression: Syntax error; token: ":name", near: "last:name ="
```

The following characters are considered special in attribute names ([according to the DynamoDB documentation][1]) - `:`, `#`, `.`, `-`.

The dot (`.`) still is not supported by Dynamoid in `where` conditions.

Close #808

[1]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.NamingRules