### PR TITLE
Support binary type natively

### DIFF
--- a/.rubocop_thread_safety.yml
+++ b/.rubocop_thread_safety.yml
@@ -2,5 +2,5 @@
 # TODO: Comment out the following to see code needing to be refactored for thread safety!
 ThreadSafety/ClassAndModuleAttributes:
   Enabled: false
-ThreadSafety/InstanceVariableInClassMethod:
+ThreadSafety/ClassInstanceVariable:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -342,6 +342,24 @@ class Document
 end
 ```
 
+#### Note on binary type
+
+By default binary fields are persisted as DynamoDB String value encoded
+in the Base64 encoding. DynamoDB supports binary data natively. To use
+it instead of String a `store_binary_as_native` field option should be
+set:
+
+```ruby
+class Document
+  include Dynamoid::Document
+
+  field :image, :binary, store_binary_as_native: true
+end
+```
+
+There is also a global config option `store_binary_as_native` that is
+`false` by default as well.
+
 #### Magic Columns
 
 You get magic columns of `id` (`string`), `created_at` (`datetime`), and
@@ -1138,6 +1156,9 @@ Listed below are all configuration options.
 * `store_boolean_as_native` - if `true` Dynamoid stores boolean fields
   as native DynamoDB boolean values. Otherwise boolean fields are stored
   as string values `'t'` and `'f'`. Default is `true`
+* `store_binary_as_native` - if `true` Dynamoid stores binary fields
+  as native DynamoDB binary values. Otherwise binary fields are stored
+  as Base64 encoded string values. Default is `false`
 * `backoff` - is a hash: key is a backoff strategy (symbol), value is
   parameters for the strategy. Is used in batch operations. Default id
   `nil`

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -50,6 +50,7 @@ module Dynamoid
     option :store_date_as_string, default: false # store Date fields in ISO 8601 string format
     option :store_empty_string_as_nil, default: true # store attribute's empty String value as null
     option :store_boolean_as_native, default: true
+    option :store_binary_as_native, default: false
     option :backoff, default: nil # callable object to handle exceeding of table throughput limit
     option :backoff_strategies, default: {
       constant: BackoffStrategies::ConstantBackoff,

--- a/lib/dynamoid/dumping.rb
+++ b/lib/dynamoid/dumping.rb
@@ -297,10 +297,24 @@ module Dynamoid
       end
     end
 
-    # string -> string
+    # string -> StringIO
     class BinaryDumper < Base
       def process(value)
-        Base64.strict_encode64(value)
+        store_as_binary = if @options[:store_as_native_binary].nil?
+                            Dynamoid.config.store_binary_as_native
+                          else
+                            @options[:store_as_native_binary]
+                          end
+
+        if store_as_binary
+          if value.is_a?(StringIO) || value.is_a?(IO)
+            value
+          else
+            StringIO.new(value)
+          end
+        else
+          Base64.strict_encode64(value)
+        end
       end
     end
 

--- a/lib/dynamoid/type_casting.rb
+++ b/lib/dynamoid/type_casting.rb
@@ -288,7 +288,9 @@ module Dynamoid
 
     class BinaryTypeCaster < Base
       def process(value)
-        if value.is_a? String
+        if value.is_a?(StringIO) || value.is_a?(IO)
+          value
+        elsif value.is_a?(String)
           value.dup
         else
           value.to_s

--- a/lib/dynamoid/undumping.rb
+++ b/lib/dynamoid/undumping.rb
@@ -284,7 +284,17 @@ module Dynamoid
 
     class BinaryUndumper < Base
       def process(value)
-        Base64.strict_decode64(value)
+        store_as_binary = if @options[:store_as_native_binary].nil?
+                            Dynamoid.config.store_binary_as_native
+                          else
+                            @options[:store_as_native_binary]
+                          end
+
+        if store_as_binary
+          value.string # expect StringIO here
+        else
+          Base64.strict_decode64(value)
+        end
       end
     end
 

--- a/spec/dynamoid/type_casting_spec.rb
+++ b/spec/dynamoid/type_casting_spec.rb
@@ -671,12 +671,21 @@ describe 'Type casting' do
       expect(obj.image).to eql('string representation')
     end
 
-    it 'dups a string' do
-      value = 'foo'
+    it 'does not convert StringIO objects' do
+      value = StringIO.new('foo')
       obj = klass.new(image: value)
 
-      expect(obj.image).to eql(value)
-      expect(obj.image).not_to equal(value)
+      expect(obj.image).to equal(value)
+    end
+
+    it 'does not convert IO objects' do
+      Tempfile.create('image') do |value|
+        value.write('foo')
+        value.rewind
+
+        obj = klass.new(image: value)
+        expect(obj.image).to equal(value)
+      end
     end
   end
 

--- a/spec/dynamoid/type_casting_spec.rb
+++ b/spec/dynamoid/type_casting_spec.rb
@@ -274,7 +274,7 @@ describe 'Type casting' do
 
         obj = klass.new(values: Set.new([1, 1.5, '2'.to_d]))
 
-        expect(obj.values).to eql(Set.new([1, 1, 2]))
+        expect(obj.values).to eql(Set.new([1, 2]))
       end
 
       it 'type casts numbers' do


### PR DESCRIPTION
aws-sdk-dynamodb [expects](https://github.com/aws/aws-sdk-ruby/blob/46208f4875a38b55cf47c73a03a8743c5fb4d57f/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/plugins/simple_attributes.rb#L26-L45) `StringIO` object for binary and [returns back](https://github.com/aws/aws-sdk-ruby/blob/46208f4875a38b55cf47c73a03a8743c5fb4d57f/gems/aws-sdk-dynamodb/lib/aws-sdk-dynamodb/attribute_value.rb#L88) the same object type for binary values.

Current implementation incorrectly converts and stores binary values as strings that due to Base64 encoding use 33% more storage and read/write capacity.

Request Before:

```
{
  "TableName": "dynamoid_tests_documents_1732010637_594",
  "Item": {
    "image": {
      "S": "AIj/"
    },
    ...
}
```

Request After:

```
{
  "TableName": "dynamoid_tests_documents_1732010679_801",
  "Item": {
    "image": {
      "B": "AIj/"
    },
    ...
}
```
