### PR TITLE
Support condition expressions with `#where`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,13 +175,13 @@ jobs:
             gemfile: rails_8_0
 
         include:
-          - ruby: "jruby-9.3.9.0"
+          - ruby: "jruby-9.3.15.0"
             gemfile: rails_4_2
-          - ruby: "jruby-9.3.9.0"
+          - ruby: "jruby-9.3.15.0"
             gemfile: rails_5_0
-          - ruby: "jruby-9.3.9.0"
+          - ruby: "jruby-9.3.15.0"
             gemfile: rails_5_1
-          - ruby: "jruby-9.3.9.0"
+          - ruby: "jruby-9.3.15.0"
             gemfile: rails_5_2
 
     name: ${{ matrix.gemfile }}, Ruby ${{ matrix.ruby }}

--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ users = User.import([{ name: 'Josh' }, { name: 'Nick' }])
 
 ### Querying
 
-Querying can be done in one of three ways:
+Querying can be done in one of the following ways:
 
 ```ruby
 Address.find(address.id)              # Find directly by ID.
@@ -727,6 +727,27 @@ Address.where(city: 'Chicago').all    # Find by any number of matching criteria.
                                       # Though presently only "where" is supported.
 Address.find_by_city('Chicago')       # The same as above, but using ActiveRecord's older syntax.
 ```
+
+There is also a way to `#where` with a condition expression:
+
+```ruby
+Address.where('city = :c', c: 'Chicago')
+```
+
+A condition expression may contain operators (e.g. `<`, `>=`, `<>`),
+keywords (e.g. `AND`, `OR`, `BETWEEN`) and built-in functions (e.g.
+`begins_with`, `contains`) (see (documentation
+)[https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html]
+for full syntax description).
+
+**Warning:** Values (specified for a String condition expression) are
+sent as is so Dynamoid field types that aren't supported natively by
+DynamoDB (e.g. `datetime` and `date`) require explicit casting.
+
+**Warning:** String condition expressions will be used by DynamoDB only
+at filtering, so conditions on key attributes should be specified as a
+Hash to perform Query operation instead of Scan. Don't use key
+attributes in `#where`'s String condition expressions.
 
 And you can also query on associations:
 

--- a/lib/dynamoid/adapter.rb
+++ b/lib/dynamoid/adapter.rb
@@ -118,7 +118,7 @@ module Dynamoid
     # @param [Hash] query a hash of attributes: matching records will be returned by the scan
     #
     # @since 0.2.0
-    def scan(table, query = {}, opts = {})
+    def scan(table, query = [], opts = {})
       benchmark('Scan', table, query) { adapter.scan(table, query, opts) }
     end
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3.rb
@@ -517,7 +517,7 @@ module Dynamoid
       # @since 1.0.0
       #
       # @todo Provide support for various other options http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#query-instance_method
-      def query(table_name, key_conditions, non_key_conditions = {}, options = {})
+      def query(table_name, key_conditions, non_key_conditions = [], options = {})
         Enumerator.new do |yielder|
           table = describe_table(table_name)
 
@@ -550,7 +550,7 @@ module Dynamoid
       # @since 1.0.0
       #
       # @todo: Provide support for various options http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#scan-instance_method
-      def scan(table_name, conditions = {}, options = {})
+      def scan(table_name, conditions = [], options = {})
         Enumerator.new do |yielder|
           table = describe_table(table_name)
 
@@ -563,7 +563,7 @@ module Dynamoid
         end
       end
 
-      def scan_count(table_name, conditions = {}, options = {})
+      def scan_count(table_name, conditions = [], options = {})
         table = describe_table(table_name)
         options[:select] = 'COUNT'
 

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/query.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/query.rb
@@ -69,7 +69,7 @@ module Dynamoid
           limit = [record_limit, scan_limit, batch_size].compact.min
 
           # key condition expression
-          convertor = FilterExpressionConvertor.new(@key_conditions, name_placeholders, value_placeholders, name_placeholder_sequence, value_placeholder_sequence)
+          convertor = FilterExpressionConvertor.new([@key_conditions], name_placeholders, value_placeholders, name_placeholder_sequence, value_placeholder_sequence)
           key_condition_expression = convertor.expression
           value_placeholders = convertor.value_placeholders
           name_placeholders = convertor.name_placeholders

--- a/lib/dynamoid/adapter_plugin/aws_sdk_v3/scan.rb
+++ b/lib/dynamoid/adapter_plugin/aws_sdk_v3/scan.rb
@@ -13,7 +13,7 @@ module Dynamoid
       class Scan
         attr_reader :client, :table, :conditions, :options
 
-        def initialize(client, table, conditions = {}, options = {})
+        def initialize(client, table, conditions = [], options = {})
           @client = client
           @table = table
           @conditions = conditions

--- a/lib/dynamoid/criteria/where_conditions.rb
+++ b/lib/dynamoid/criteria/where_conditions.rb
@@ -4,24 +4,31 @@ module Dynamoid
   module Criteria
     # @private
     class WhereConditions
+      attr_reader :string_conditions
+
       def initialize
-        @conditions = []
+        @hash_conditions = []
+        @string_conditions = []
       end
 
-      def update(hash)
-        @conditions << hash.symbolize_keys
+      def update_with_hash(hash)
+        @hash_conditions << hash.symbolize_keys
+      end
+
+      def update_with_string(query, placeholders)
+        @string_conditions << [query, placeholders]
       end
 
       def keys
-        @conditions.flat_map(&:keys)
+        @hash_conditions.flat_map(&:keys)
       end
 
       def empty?
-        @conditions.empty?
+        @hash_conditions.empty? && @string_conditions.empty?
       end
 
       def [](key)
-        hash = @conditions.find { |h| h.key?(key) }
+        hash = @hash_conditions.find { |h| h.key?(key) }
         hash[key] if hash
       end
     end

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -41,7 +41,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       { id: [[:eq, '1']] }
     end
 
-    def dynamo_request(table_name, conditions = {}, options = {})
+    def dynamo_request(table_name, conditions = [], options = {})
       if @request_type == :query
         Dynamoid.adapter.query(table_name, query_key_conditions, conditions, options).flat_map { |i| i }
       else
@@ -62,35 +62,35 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       end
 
       it 'returns correct record limit' do
-        expect(dynamo_request(test_table3, {}, { record_limit: 1 }).count).to eq(1)
-        expect(dynamo_request(test_table3, {}, { record_limit: 3 }).count).to eq(3)
+        expect(dynamo_request(test_table3, [], { record_limit: 1 }).count).to eq(1)
+        expect(dynamo_request(test_table3, [], { record_limit: 3 }).count).to eq(3)
       end
 
       it 'returns correct batch' do
         # Receives 8 times for each item and 1 more for empty page
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(9).times.and_call_original
-        expect(dynamo_request(test_table3, {}, { batch_size: 1 }).count).to eq(8)
+        expect(dynamo_request(test_table3, [], { batch_size: 1 }).count).to eq(8)
       end
 
       it 'returns correct batch and paginates in batches' do
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(3).times.and_call_original
-        expect(dynamo_request(test_table3, {}, { batch_size: 3 }).count).to eq(8)
+        expect(dynamo_request(test_table3, [], { batch_size: 3 }).count).to eq(8)
       end
 
       it 'returns correct record limit and batch' do
-        expect(dynamo_request(test_table3, {}, { record_limit: 1, batch_size: 1 }).count).to eq(1)
+        expect(dynamo_request(test_table3, [], { record_limit: 1, batch_size: 1 }).count).to eq(1)
       end
 
       it 'returns correct record limit with filter' do
         expect(
-          dynamo_request(test_table3, { name: [[:eq, 'Josh']] }, { record_limit: 1 }).count
+          dynamo_request(test_table3, [{ name: [[:eq, 'Josh']] }], { record_limit: 1 }).count
         ).to eq(1)
       end
 
       it 'obeys correct scan limit with filter' do
         expect(Dynamoid.adapter.client).to receive(request_type).once.and_call_original
         expect(
-          dynamo_request(test_table3, { name: [[:eq, 'Josh']] }, { scan_limit: 2 }).count
+          dynamo_request(test_table3, [{ name: [[:eq, 'Josh']] }], { scan_limit: 2 }).count
         ).to eq(2)
       end
 
@@ -99,7 +99,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         expect(
           dynamo_request(
             test_table3,
-            { name: [[:eq, 'Josh']] },
+            [{ name: [[:eq, 'Josh']] }],
             {
               scan_limit: 2,
               record_limit: 10 # Won't be able to return more than 2 due to scan limit
@@ -111,7 +111,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       it 'obeys correct scan limit with filter with some return' do
         expect(Dynamoid.adapter.client).to receive(request_type).once.and_call_original
         expect(
-          dynamo_request(test_table3, { name: [[:eq, 'Pascal']] }, { scan_limit: 5 }).count
+          dynamo_request(test_table3, [{ name: [[:eq, 'Pascal']] }], { scan_limit: 5 }).count
         ).to eq(1)
       end
 
@@ -120,7 +120,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         expect(
           dynamo_request(
             test_table3,
-            { name: [[:eq, 'Josh']] },
+            [{ name: [[:eq, 'Josh']] }],
             {
               scan_limit: 3,
               batch_size: 2 # This would force batching of size 2 for potential of 4 results!
@@ -137,7 +137,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         expect(
           dynamo_request(
             test_table3,
-            { name: [[:eq, 'Pascal']] },
+            [{ name: [[:eq, 'Pascal']] }],
             {
               batch_size: 1,
               scan_limit: 5,
@@ -155,7 +155,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         expect(
           dynamo_request(
             test_table3,
-            { name: [[:eq, 'Pascal']] },
+            [{ name: [[:eq, 'Pascal']] }],
             {
               batch_size: 1,
               scan_limit: 10,
@@ -186,7 +186,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       end
 
       it 'returns correct for limits and scan limit' do
-        expect(dynamo_request(test_table3, {}, { scan_limit: 100 }).count).to eq(100)
+        expect(dynamo_request(test_table3, [], { scan_limit: 100 }).count).to eq(100)
       end
 
       it 'returns correct for scan limit with filtering' do
@@ -196,20 +196,20 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         pages = request_type == :query ? 1 : 2
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(pages).times.and_call_original
         expect(
-          dynamo_request(test_table3, { age: [[:gte, 90.0]] }, { scan_limit: 100 }).count
+          dynamo_request(test_table3, [{ age: [[:gte, 90.0]] }], { scan_limit: 100 }).count
         ).to eq(10)
       end
 
       it 'returns correct for record limit' do
         expect(Dynamoid.adapter.client).to receive(request_type).twice.and_call_original
         expect(
-          dynamo_request(test_table3, { age: [[:gte, 5.0]] }, { record_limit: 100 }).count
+          dynamo_request(test_table3, [{ age: [[:gte, 5.0]] }], { record_limit: 100 }).count
         ).to eq(100)
       end
 
       it 'returns correct record limit with filtering' do
         expect(
-          dynamo_request(test_table3, { age: [[:gte, 133.0]] }, { record_limit: 100 }).count
+          dynamo_request(test_table3, [{ age: [[:gte, 133.0]] }], { record_limit: 100 }).count
         ).to eq(67)
       end
 
@@ -218,7 +218,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         # which is limitation of DynamoDB and therefore batch limit is
         # restricted by this limitation as well!
         expect(Dynamoid.adapter.client).to receive(request_type).exactly(4).times.and_call_original
-        expect(dynamo_request(test_table3, {}, { batch_size: 100 }).count).to eq(200)
+        expect(dynamo_request(test_table3, [], { batch_size: 100 }).count).to eq(200)
       end
 
       it 'returns correct with batching and record limit beyond data size limit' do
@@ -226,7 +226,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         # requests for as many as we have left for our record limit.
         expect(Dynamoid.adapter.client).to receive(request_type).twice.and_call_original
         expect(
-          dynamo_request(test_table3, {}, { record_limit: 83, batch_size: 100 }).count
+          dynamo_request(test_table3, [], { record_limit: 83, batch_size: 100 }).count
         ).to eq(83)
       end
 
@@ -236,7 +236,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         expect(
           dynamo_request(
             test_table3,
-            { age: [[:gte, 5.0]] },
+            [{ age: [[:gte, 5.0]] }],
             {
               record_limit: 100,
               batch_size: 10
@@ -263,7 +263,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       expect(
         dynamo_request(
           test_table3,
-          { name: [[:eq, 'Josh']] },
+          [{ name: [[:eq, 'Josh']] }],
           {
             batch_size: 4,
             scan_limit: 5, # Scan limit would adjust requested limit to 1
@@ -308,7 +308,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
     end
 
     it 'performs query on a table and returns items based on returns correct limit' do
-      expect(Dynamoid.adapter.query(test_table3, { id: [[:eq, '1']], range: [[:gt, 0.0]] }, {}, { record_limit: 1 }).flat_map { |i| i }.count).to eq(1)
+      expect(Dynamoid.adapter.query(test_table3, { id: [[:eq, '1']], range: [[:gt, 0.0]] }, [], { record_limit: 1 }).flat_map { |i| i }.count).to eq(1)
     end
 
     it 'performs query on a table with a range and selects all items' do
@@ -332,7 +332,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
     end
 
     it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward true' do
-      query = Dynamoid.adapter.query(test_table4, { id: [[:eq, '1']], range: [[:gt, 0]] }, {}, { scan_index_forward: true }).flat_map { |i| i }.to_a
+      query = Dynamoid.adapter.query(test_table4, { id: [[:eq, '1']], range: [[:gt, 0]] }, [], { scan_index_forward: true }).flat_map { |i| i }.to_a
       expect(query[0]).to eq(id: '1', order: 1, range: BigDecimal('1'))
       expect(query[1]).to eq(id: '1', order: 2, range: BigDecimal('2'))
       expect(query[2]).to eq(id: '1', order: 3, range: BigDecimal('3'))
@@ -342,7 +342,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
     end
 
     it 'performs query on a table with a range and selects items less than that is in the correct order, scan_index_forward false' do
-      query = Dynamoid.adapter.query(test_table4, { id: [[:eq, '1']], range: [[:gt, 0]] }, {}, { scan_index_forward: false }).flat_map { |i| i }.to_a
+      query = Dynamoid.adapter.query(test_table4, { id: [[:eq, '1']], range: [[:gt, 0]] }, [], { scan_index_forward: false }).flat_map { |i| i }.to_a
       expect(query[5]).to eq(id: '1', order: 1, range: BigDecimal('1'))
       expect(query[4]).to eq(id: '1', order: 2, range: BigDecimal('2'))
       expect(query[3]).to eq(id: '1', order: 3, range: BigDecimal('3'))
@@ -1015,7 +1015,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         Dynamoid.adapter.put_item(test_table3, id: '1', range: 1)
         Dynamoid.adapter.put_item(test_table3, id: '1', range: 2)
 
-        expect(Dynamoid.adapter.query(test_table3, { id: [[:eq, '1']] }, {}, { batch_size: 1 }).flat_map { |i| i }.count).to eq 2
+        expect(Dynamoid.adapter.query(test_table3, { id: [[:eq, '1']] }, [], { batch_size: 1 }).flat_map { |i| i }.count).to eq 2
         expect(@counter).to eq 2
       end
     end
@@ -1030,14 +1030,14 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
     it 'performs scan on a table and returns items' do
       Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
 
-      expect(Dynamoid.adapter.scan(test_table1, name: { eq: 'Josh' }).to_a).to eq [[[{ id: '1', name: 'Josh' }], { last_evaluated_key: nil }]]
+      expect(Dynamoid.adapter.scan(test_table1, [name: { eq: 'Josh' }]).to_a).to eq [[[{ id: '1', name: 'Josh' }], { last_evaluated_key: nil }]]
     end
 
     it 'performs scan on a table and returns items if there are multiple items but only one match' do
       Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
       Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Justin')
 
-      expect(Dynamoid.adapter.scan(test_table1, name: { eq: 'Josh' }).to_a).to eq [[[{ id: '1', name: 'Josh' }], { last_evaluated_key: nil }]]
+      expect(Dynamoid.adapter.scan(test_table1, [name: { eq: 'Josh' }]).to_a).to eq [[[{ id: '1', name: 'Josh' }], { last_evaluated_key: nil }]]
     end
 
     it 'performs scan on a table and returns multiple items if there are multiple matches' do
@@ -1045,7 +1045,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Josh')
 
       expect(
-        Dynamoid.adapter.scan(test_table1, name: { eq: 'Josh' }).to_a
+        Dynamoid.adapter.scan(test_table1, [name: { eq: 'Josh' }]).to_a
       ).to match(
         [
           [
@@ -1060,7 +1060,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       Dynamoid.adapter.put_item(test_table1, id: '1', name: 'Josh')
       Dynamoid.adapter.put_item(test_table1, id: '2', name: 'Josh')
 
-      expect(Dynamoid.adapter.scan(test_table1, {}).flat_map { |i| i }).to include({ name: 'Josh', id: '2' }, name: 'Josh', id: '1')
+      expect(Dynamoid.adapter.scan(test_table1, []).flat_map { |i| i }).to include({ name: 'Josh', id: '2' }, name: 'Josh', id: '1')
     end
 
     it 'performs scan on a table and returns correct limit' do
@@ -1069,7 +1069,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       Dynamoid.adapter.put_item(test_table1, id: '3', name: 'Josh')
       Dynamoid.adapter.put_item(test_table1, id: '4', name: 'Josh')
 
-      expect(Dynamoid.adapter.scan(test_table1, {}, record_limit: 1).flat_map { |i| i }.count).to eq(1)
+      expect(Dynamoid.adapter.scan(test_table1, [], record_limit: 1).flat_map { |i| i }.count).to eq(1)
     end
 
     it 'performs scan on a table and returns correct batch' do
@@ -1078,7 +1078,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       Dynamoid.adapter.put_item(test_table1, id: '3', name: 'Josh')
       Dynamoid.adapter.put_item(test_table1, id: '4', name: 'Josh')
 
-      expect(Dynamoid.adapter.scan(test_table1, {}, batch_size: 1).flat_map { |i| i }.count).to eq(4)
+      expect(Dynamoid.adapter.scan(test_table1, [], batch_size: 1).flat_map { |i| i }.count).to eq(4)
     end
 
     it 'performs scan on a table and returns correct limit and batch' do
@@ -1087,7 +1087,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
       Dynamoid.adapter.put_item(test_table1, id: '3', name: 'Josh')
       Dynamoid.adapter.put_item(test_table1, id: '4', name: 'Josh')
 
-      expect(Dynamoid.adapter.scan(test_table1, {}, record_limit: 1, batch_size: 1).flat_map { |i| i }.count).to eq(1)
+      expect(Dynamoid.adapter.scan(test_table1, [], record_limit: 1, batch_size: 1).flat_map { |i| i }.count).to eq(1)
     end
 
     context 'backoff is specified' do
@@ -1111,7 +1111,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
         Dynamoid.adapter.put_item(test_table1, id: '3', name: 'Josh')
         Dynamoid.adapter.put_item(test_table1, id: '4', name: 'Josh')
 
-        expect(Dynamoid.adapter.scan(test_table1, {}, batch_size: 1).flat_map { |i| i }.count).to eq 4
+        expect(Dynamoid.adapter.scan(test_table1, [], batch_size: 1).flat_map { |i| i }.count).to eq 4
         expect(@counter).to eq 4
       end
     end

--- a/spec/dynamoid/criteria_new_spec.rb
+++ b/spec/dynamoid/criteria_new_spec.rb
@@ -60,7 +60,7 @@ describe Dynamoid::Criteria do
     actual = klass.record_limit(1).all.to_a
 
     expect(actual.size).to eq 1
-    expect(actual[0]).to satisfy { |v| v.name == 'Alex' || v.name == 'Bob' }
+    expect(actual[0]).to satisfy { |v| %w[Alex Bob].include?(v.name) }
   end
 
   it 'supports querying with .scan_limit method' do
@@ -72,7 +72,7 @@ describe Dynamoid::Criteria do
     actual = klass.scan_limit(1).all.to_a
 
     expect(actual.size).to eq 1
-    expect(actual[0]).to satisfy { |v| v.name == 'Alex' || v.name == 'Bob' }
+    expect(actual[0]).to satisfy { |v| %w[Alex Bob].include?(v.name) }
   end
 
   it 'supports querying with .batch method' do


### PR DESCRIPTION
So now `#where` can used like this way:

```ruby
User.where(
  'age > :a AND (first_name = :fn OR last_name = :ln)',
   a: 42, fn: 'Alex', ln: 'Jackson')
```

Close #640 and #825