### PR TITLE
Fix dumping of custom type that mixes adapter interface

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,7 +23,7 @@ jobs:
         bundler:
           - latest
         ruby:
-          - "3.3"
+          - "3.4"
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/style.gemfile

--- a/.rubocop_thread_safety.yml
+++ b/.rubocop_thread_safety.yml
@@ -1,6 +1,6 @@
 # It would be good to make the gem more thread safe, but at the moment it is not entirely.
 # TODO: Comment out the following to see code needing to be refactored for thread safety!
-ThreadSafety/ClassAndModuleAttributes:
-  Enabled: false
 ThreadSafety/ClassInstanceVariable:
+  Enabled: false
+ThreadSafety/ClassAndModuleAttributes:
   Enabled: false

--- a/lib/dynamoid/dumping.rb
+++ b/lib/dynamoid/dumping.rb
@@ -323,10 +323,10 @@ module Dynamoid
       def process(value)
         field_class = @options[:type]
 
-        if value.respond_to?(:dynamoid_dump)
-          value.dynamoid_dump
-        elsif field_class.respond_to?(:dynamoid_dump)
+        if field_class.respond_to?(:dynamoid_dump)
           field_class.dynamoid_dump(value)
+        elsif value.respond_to?(:dynamoid_dump)
+          value.dynamoid_dump
         else
           raise ArgumentError, "Neither #{field_class} nor #{value} supports serialization for Dynamoid."
         end

--- a/spec/dynamoid/dumping_spec.rb
+++ b/spec/dynamoid/dumping_spec.rb
@@ -1449,6 +1449,21 @@ describe 'Dumping' do
       end
     end
 
+    context 'Custom type with adapter interface provided' do
+      let(:klass) do
+        new_class do |_options|
+          field :user, DumpingSpecs::UserWithAdapterInterface
+        end
+      end
+
+      it "prefers adapter's .dynamoid_dump method over #dynamoid_dump" do
+        user = DumpingSpecs::UserWithAdapterInterface.new('John')
+        obj = klass.create(user: user)
+
+        expect(raw_attributes(obj)[:user]).to eql('John (dumped with .dynamoid_dump)')
+      end
+    end
+
     context 'DynamoDB type specified' do
       let(:klass) do
         new_class do

--- a/spec/fixtures/dumping.rb
+++ b/spec/fixtures/dumping.rb
@@ -34,7 +34,7 @@ module DumpingSpecs
     end
 
     def dynamoid_dump
-      name + ' (dumped with #dynamoid_dump)'
+      "#{name} (dumped with #dynamoid_dump)"
     end
 
     def eql?(other)
@@ -46,7 +46,7 @@ module DumpingSpecs
     end
 
     def self.dynamoid_dump(user)
-      user.name + ' (dumped with .dynamoid_dump)'
+      "#{user.name} (dumped with .dynamoid_dump)"
     end
 
     def self.dynamoid_load(string)
@@ -77,7 +77,7 @@ module DumpingSpecs
     end
 
     def self.dynamoid_load(string)
-      User.new(string.to_s)
+      UserValue.new(string.to_s)
     end
   end
 
@@ -87,8 +87,8 @@ module DumpingSpecs
     end
 
     def self.dynamoid_load(array)
-      array = array.name.split if array.is_a?(User)
-      User.new(array.join(' '))
+      array = array.name.split if array.is_a?(UserValue)
+      UserValue.new(array.join(' '))
     end
 
     def self.dynamoid_field_type

--- a/spec/fixtures/dumping.rb
+++ b/spec/fixtures/dumping.rb
@@ -25,6 +25,35 @@ module DumpingSpecs
     end
   end
 
+  # implements both #dynamoid_dump and .dynamoid_dump methods
+  class UserWithAdapterInterface
+    attr_accessor :name
+
+    def initialize(name)
+      self.name = name
+    end
+
+    def dynamoid_dump
+      name + ' (dumped with #dynamoid_dump)'
+    end
+
+    def eql?(other)
+      name == other.name
+    end
+
+    def hash
+      name.hash
+    end
+
+    def self.dynamoid_dump(user)
+      user.name + ' (dumped with .dynamoid_dump)'
+    end
+
+    def self.dynamoid_load(string)
+      new(string.to_s)
+    end
+  end
+
   # doesn't implement #dynamoid_dump/#dynamoid_load methods so requires an adapter
   class UserValue
     attr_accessor :name


### PR DESCRIPTION
Fix the following case:
- declared a field with custom type and adapter class
- assigned a value of class that implements `#dynamoid_dump` method (like a simple custom type)

A proper behaviour is to use adapter's `.dynamoid_dump` method instead of a value's `#dynamoid_dump` method.