### PR TITLE
Fix Dirty API to compare objects of custom type using dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,27 @@ method, which would return either `:string` or `:number`.
 DynamoDB may support some other attribute types that are not yet
 supported by Dynamoid.
 
+If a custom type implements `#==` method you can specify `comparable:
+true` option in a field declaration to specify that an object is safely
+comparable for the purpose of detecting changes. By default old and new
+objects will be compared by their serialized representation.
+
+```ruby
+class Money
+  # ...
+
+  def ==(other)
+    # comparison logic
+  end
+end
+
+class User
+  # ...
+
+  field :balance, Money, comparable: true
+end
+```
+
 ### Sort key
 
 Along with partition key table may have a sort key. In order to declare

--- a/spec/fixtures/dirty.rb
+++ b/spec/fixtures/dirty.rb
@@ -12,20 +12,30 @@ module DirtySpec
       @name
     end
 
+    def self.dynamoid_load(string)
+      new(string.to_s)
+    end
+  end
+
+  class UserWithEquality < User
     def eql?(other)
+      if ScratchPad.recorded.is_a? Array
+        ScratchPad << ['eql?', self, other]
+      end
+
       @name == other.name
     end
 
     def ==(other)
+      if ScratchPad.recorded.is_a? Array
+        ScratchPad << ['==', self, other]
+      end
+
       @name == other.name
     end
 
     def hash
       @name.hash
-    end
-
-    def self.dynamoid_load(string)
-      new(string.to_s)
     end
   end
 end

--- a/spec/fixtures/dumping.rb
+++ b/spec/fixtures/dumping.rb
@@ -37,14 +37,6 @@ module DumpingSpecs
       "#{name} (dumped with #dynamoid_dump)"
     end
 
-    def eql?(other)
-      name == other.name
-    end
-
-    def hash
-      name.hash
-    end
-
     def self.dynamoid_dump(user)
       "#{user.name} (dumped with .dynamoid_dump)"
     end


### PR DESCRIPTION
Changes:
- fix Dirty API and don't require custom type to implement `#==` method
- add field's option `:comparable`
- change the way of duplicating objects of custom type (for Dirty API) - switch from Dynamoid's dumping mechanism (with `dynamoid_dump`/`dynamoid_load` methods) to `Marshal.dump`/`Marshal.load`

The option `:comparable` affects how old and new objects of custom type are compared - by comparing their dumps or using `#==` method. If it is true - objects are compared with `#==`. They are compared by comparing dumps otherwise.

Example:

```ruby
field :amount, Money, comparable: true
```

Close #848