### PR TITLE
Add YAML loading options to mirror ActiveRecord behavior

### DIFF
--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -62,6 +62,8 @@ module Dynamoid
     option :http_open_timeout, default: nil     #                                                  - default: 15
     option :http_read_timeout, default: nil     #                                                  - default: 60
     option :create_table_on_save, default: true
+    option :use_yaml_unsafe_load, default: false
+    option :yaml_column_permitted_classes, default: [Symbol, Set, Date, Time, DateTime] # classes to allow when using YAML.safe_load
 
     # The default logger for Dynamoid: either the Rails logger or just stdout.
     #


### PR DESCRIPTION
Based on discussion in https://github.com/Dynamoid/dynamoid/pull/757, adds two new options that allow YAML safe loading behavior to be customized or disabled.

Because there is a lot of different behavior between versions of the Pysch gem, we should directly check what methods are available instead of the Ruby version (particularly because newer Ruby versions can still run older versions of Pysch).