### PR TITLE
TransactionWrite sanitizes items

### DIFF
--- a/lib/dynamoid/transaction_write/base.rb
+++ b/lib/dynamoid/transaction_write/base.rb
@@ -42,6 +42,18 @@ module Dynamoid
       def action_request
         raise 'Not implemented'
       end
+
+      # copied from aws_sdk_v3
+      def sanitize_item(attributes)
+        config_value = Dynamoid.config.store_attribute_with_nil_value
+        store_attribute_with_nil_value = config_value.nil? ? false : !!config_value
+
+        attributes.reject do |_, v|
+          !store_attribute_with_nil_value && v.nil?
+        end.transform_values do |v|
+          v.is_a?(Hash) ? v.stringify_keys : v
+        end
+      end
     end
   end
 end

--- a/lib/dynamoid/transaction_write/save.rb
+++ b/lib/dynamoid/transaction_write/save.rb
@@ -97,6 +97,7 @@ module Dynamoid
         touch_model_timestamps(skip_created_at: false)
 
         attributes_dumped = Dynamoid::Dumping.dump_attributes(@model.attributes, @model_class.attributes)
+        attributes_dumped = sanitize_item(attributes_dumped)
 
         # require primary key not to exist yet
         condition = "attribute_not_exists(#{@model_class.hash_key})"
@@ -119,6 +120,7 @@ module Dynamoid
         # changed attributes to persist
         changes = @model.attributes.slice(*@model.changed.map(&:to_sym))
         changes_dumped = Dynamoid::Dumping.dump_attributes(changes, @model_class.attributes)
+        changes_dumped = sanitize_item(changes_dumped)
 
         # primary key to look up an item to update
         key = { @model_class.hash_key => @model.hash_key }

--- a/lib/dynamoid/transaction_write/update_fields.rb
+++ b/lib/dynamoid/transaction_write/update_fields.rb
@@ -53,6 +53,7 @@ module Dynamoid
         changes = @attributes.dup
         changes = add_timestamps(changes, skip_created_at: true)
         changes_dumped = Dynamoid::Dumping.dump_attributes(changes, @model_class.attributes)
+        changes_dumped = sanitize_item(changes_dumped)
 
         builder.set_attributes(changes_dumped)
 

--- a/lib/dynamoid/transaction_write/upsert.rb
+++ b/lib/dynamoid/transaction_write/upsert.rb
@@ -42,6 +42,7 @@ module Dynamoid
         changes = @attributes.dup
         changes = add_timestamps(changes, skip_created_at: true)
         changes_dumped = Dynamoid::Dumping.dump_attributes(changes, @model_class.attributes)
+        changes_dumped = sanitize_item(changes_dumped)
 
         # primary key to look up an item to update
         key = { @model_class.hash_key => @hash_key }

--- a/spec/dynamoid/transaction_write/indexes_spec.rb
+++ b/spec/dynamoid/transaction_write/indexes_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Dynamoid::Indexes do
+  let(:klass_with_gsi) do
+    new_class(class_name: 'Ferret') do
+      field :name
+      field :age, :number
+      global_secondary_index hash_key: :name, range_key: :age, projected_attributes: :all, name: "str_num"
+    end
+  end
+
+  before do
+    klass_with_gsi.create_table
+  end
+
+  describe '.global_secondary_index' do
+
+    it 'can save in transaction' do
+      doc = klass_with_gsi.new(name: 'abc', age: 1)
+      Dynamoid::TransactionWrite.execute do |txn|
+        txn.save! doc
+      end
+      expect(doc).to be_persisted
+    end
+
+    it 'can create in transaction' do
+      doc = klass_with_gsi.new
+      doc.name = 'abc'
+      doc.age = nil
+      Dynamoid::TransactionWrite.execute do |txn|
+        txn.save! doc
+      end
+      expect(doc).to be_persisted
+    end
+
+    it 'can update in transaction' do
+      doc = klass_with_gsi.new
+      doc.name = 'abc'
+      doc.age = 1
+      doc.save!
+      doc.age = nil
+      Dynamoid::TransactionWrite.execute do |txn|
+        txn.save! doc
+      end
+      expect(doc).to be_persisted
+    end
+
+    it 'can update_field in transaction' do
+      doc = klass_with_gsi.new
+      doc.name = 'abc'
+      doc.age = 1
+      doc.save!
+      Dynamoid::TransactionWrite.execute do |txn|
+        txn.update_fields klass_with_gsi, doc.id, age: nil
+      end
+      expect(doc).to be_persisted
+    end
+
+    it 'can upsert in transaction' do
+      doc = klass_with_gsi.new
+      doc.name = 'abc'
+      doc.age = 1
+      doc.save!
+      Dynamoid::TransactionWrite.execute do |txn|
+        txn.upsert klass_with_gsi, doc.id, age: nil
+      end
+      expect(doc).to be_persisted
+    end
+  end
+end


### PR DESCRIPTION
TransactionWrite should call sanitize_item so that nils are not persisted. Otherwise GSI will fail with a nil range key.