### PR TITLE
Add key_type option to table method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,8 +7,10 @@ inherit_from:
   - .rubocop_todo.yml
 
 require:
-  - rubocop-md
   - rubocop-packaging
+
+plugins:
+  - rubocop-md
   - rubocop-performance
   - rubocop-rake
   - rubocop-rspec
@@ -97,7 +99,9 @@ Style/DateTime:
   Enabled: false
 Style/MissingRespondToMissing:
   Enabled: false
-Naming/PredicateName:
+Naming/PredicatePrefix:
+  Enabled: false
+Naming/PredicateMethod:
   Enabled: false
 Security/YAMLLoad:
   Enabled: false

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -197,6 +197,15 @@ module Dynamoid
       #     field :id, :integer
       #   end
       #
+      # To declare a new attribute with not-default type as a table hash key a
+      # :key_type option can be used:
+      #
+      #   class User
+      #     include Dynamoid::Document
+      #
+      #     table key: :user_id, key_type: :integer
+      #   end
+      #
       # @param options [Hash] options to override default table settings
       # @option options [Symbol] :name name of a table
       # @option options [Symbol] :key name of a hash key attribute

--- a/lib/dynamoid/fields.rb
+++ b/lib/dynamoid/fields.rb
@@ -200,6 +200,7 @@ module Dynamoid
       # @param options [Hash] options to override default table settings
       # @option options [Symbol] :name name of a table
       # @option options [Symbol] :key name of a hash key attribute
+      # @option options [Symbol] :key_type type of a hash key attribute
       # @option options [Symbol] :inheritance_field name of an attribute used for STI
       # @option options [Symbol] :capacity_mode table billing mode - either +provisioned+ or +on_demand+
       # @option options [Integer] :write_capacity table write capacity units
@@ -210,11 +211,11 @@ module Dynamoid
       # @since 0.4.0
       def table(options)
         self.options = options
-
         # a default 'id' column is created when Dynamoid::Document is included
         unless attributes.key? hash_key
           remove_field :id
-          field(hash_key)
+          key_type = options[:key_type] || :string
+          field(hash_key, key_type)
         end
 
         # The created_at/updated_at fields are declared in the `included` callback first.

--- a/spec/app/models/address.rb
+++ b/spec/app/models/address.rb
@@ -3,7 +3,7 @@
 class Address
   include Dynamoid::Document
 
-  field :city
+  field :city, :string, alias: :CityName
   field :options, :serialized
   field :deliverable, :boolean
   field :latitude, :number

--- a/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
+++ b/spec/dynamoid/adapter_plugin/aws_sdk_v3_spec.rb
@@ -1023,7 +1023,7 @@ describe Dynamoid::AdapterPlugin::AwsSdkV3 do
     it_behaves_like 'range queries'
 
     describe 'query' do
-      include_examples 'correctly handling limits', :query
+      it_behaves_like 'correctly handling limits', :query
     end
 
     # Scan

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -6,7 +6,197 @@ require 'fixtures/fields'
 describe Dynamoid::Fields do
   let(:address) { Address.new }
 
+  describe '.table' do
+    it 'follows any table options provided to it' do
+      tweet = Tweet.create(group: 12_345)
+
+      expect { tweet.id }.to raise_error(NoMethodError)
+      expect(tweet.tweet_id).not_to be_nil
+      expect(Tweet.table_name).to eq 'dynamoid_tests_twitters'
+      expect(Tweet.hash_key).to eq :tweet_id
+      expect(Tweet.read_capacity).to eq 200
+      expect(Tweet.write_capacity).to eq 200
+    end
+
+    it 'has default table options' do
+      address = Address.create
+
+      expect(address.id).not_to be_nil
+      expect(Address.table_name).to eq 'dynamoid_tests_addresses'
+      expect(Address.hash_key).to eq :id
+      expect(Address.read_capacity).to eq 100
+      expect(Address.write_capacity).to eq 20
+      expect(Address.inheritance_field).to eq :type
+    end
+
+    describe 'TTL (Time to Live)' do
+      let(:model) do
+        new_class do
+          table expires: { field: :expired_at, after: 30 * 60 }
+
+          field :expired_at, :integer
+        end
+      end
+
+      let(:model_with_wrong_field_name) do
+        new_class do
+          table expires: { field: :foo, after: 30 * 60 }
+
+          field :expired_at, :integer
+        end
+      end
+
+      it 'sets default value at the creation' do
+        travel 1.hour do
+          obj = model.create
+          expect(obj.expired_at).to eq(Time.now.to_i + (30 * 60))
+        end
+      end
+
+      it 'sets default value at the updating' do
+        obj = model.create
+
+        travel 1.hour do
+          obj.update_attributes(expired_at: nil)
+          expect(obj.expired_at).to eq(Time.now.to_i + (30 * 60))
+        end
+      end
+
+      it 'does not override already existing value' do
+        obj = model.create(expired_at: 1024)
+        expect(obj.expired_at).to eq 1024
+
+        obj.update_attributes(expired_at: 512)
+        expect(obj.expired_at).to eq 512
+      end
+
+      it 'raises an error if specified wrong field name' do
+        # error messages may very on different Ruby versions and use either ` or '.
+        expect do
+          model_with_wrong_field_name.create
+        end.to raise_error(NoMethodError, /undefined method (`|')foo='/)
+      end
+    end
+
+    context 'when specify key option and key_type' do
+      it 'hash_key attribute is defined by key_type type' do
+        klass = new_class do
+          table key: :hash_key, key_type: :integer
+        end
+
+        expect(klass.attributes[:hash_key][:type]).to eq(:integer)
+      end
+    end
+  end
+
   describe '.field' do
+    it 'declares a read method' do
+      expect(address.city).to be_nil
+    end
+
+    it 'declares a write method' do
+      address.city = 'Chicago'
+      expect(address.city).to eq 'Chicago'
+    end
+
+    it 'declares a predicate method' do
+      expect(address).not_to be_city
+      address.city = 'Chicago'
+      expect(address).to be_city
+    end
+
+    describe 'write methods' do
+      it 'allow interception of #write_attribute on load' do
+        klass = new_class do
+          field :city
+
+          def city=(value)
+            self[:city] = value.downcase
+          end
+        end
+        expect(klass.new(city: 'Chicago').city).to eq 'chicago'
+      end
+    end
+
+    describe 'predicate methods' do
+      it 'return false when boolean attributes are nil or false' do
+        address.deliverable = nil
+        expect(address).not_to be_deliverable
+
+        address.deliverable = false
+        expect(address).not_to be_deliverable
+      end
+
+      it 'return true when boolean attributes are true' do
+        address.deliverable = true
+        expect(address).to be_deliverable
+      end
+    end
+
+    context 'default values for fields' do
+      let(:doc_class) do
+        new_class do
+          field :name, :string, default: 'x'
+          field :uid, :integer, default: -> { 42 }
+          field :config, :serialized, default: {}
+          field :version, :integer, default: 1
+          field :hidden, :boolean, default: false
+        end
+      end
+
+      it 'returns default value specified as object' do
+        expect(doc_class.new.name).to eq('x')
+      end
+
+      it 'returns default value specified as lamda/block (callable object)' do
+        expect(doc_class.new.uid).to eq(42)
+      end
+
+      it 'returns default value as is for serializable field' do
+        expect(doc_class.new.config).to eq({})
+      end
+
+      it 'supports `false` as default value' do
+        expect(doc_class.new.hidden).to eq(false)
+      end
+
+      it 'can modify default value independently for every instance' do
+        doc = doc_class.new
+        doc.name << 'y'
+        expect(doc_class.new.name).to eq('x')
+      end
+
+      it 'returns default value specified as object even if value cannot be duplicated' do
+        expect(doc_class.new.version).to eq(1)
+      end
+
+      it 'saves default values' do
+        doc = doc_class.create!
+        doc = doc_class.find(doc.id)
+        expect(doc.name).to eq('x')
+        expect(doc.uid).to eq(42)
+        expect(doc.config).to eq({})
+        expect(doc.version).to eq(1)
+        expect(doc.hidden).to be false
+      end
+
+      it 'does not use default value if nil value assigns explicitly' do
+        doc = doc_class.new(name: nil)
+        expect(doc.name).to eq nil
+      end
+
+      it 'supports default value for custom type' do
+        model_class = new_class do
+          field :user, FieldsSpecs::User, default: FieldsSpecs::User.new('Mary')
+        end
+
+        model = model_class.create
+        model = model_class.find(model.id)
+
+        expect(model.user).to eql FieldsSpecs::User.new('Mary')
+      end
+    end
+
     context 'when :alias option specified' do
       let(:klass) do
         new_class do
@@ -37,6 +227,38 @@ describe Dynamoid::Fields do
 
         expect(object.name).to eq 'Alex'
         expect(object.name_before_type_cast).to eq :Alex
+      end
+    end
+
+    context 'an extention overrides field accessors' do
+      let(:klass) do
+        extention = Module.new do
+          def name
+            super.upcase
+          end
+
+          def name=(str)
+            super(str.try(:downcase))
+          end
+        end
+
+        new_class do
+          include extention
+
+          field :name
+        end
+      end
+
+      it 'can access new setter' do
+        address = klass.new
+        address.name = 'AB cd'
+        expect(address[:name]).to eq('ab cd')
+      end
+
+      it 'can access new getter' do
+        address = klass.new
+        address.name = 'ABcd'
+        expect(address.name).to eq('ABCD')
       end
     end
 
@@ -119,126 +341,52 @@ describe Dynamoid::Fields do
         end
       end
     end
-  end
 
-  it 'declares read attributes' do
-    expect(address.city).to be_nil
-  end
-
-  it 'declares write attributes' do
-    address.city = 'Chicago'
-    expect(address.city).to eq 'Chicago'
-  end
-
-  it 'declares a query attribute' do # rubocop:disable Lint/EmptyBlock, RSpec/NoExpectationExample
-  end
-
-  it 'automatically declares id' do
-    expect { address.id }.not_to raise_error
-  end
-
-  it 'allows range key serializers' do
-    serializer = Class.new do
-      def self.dump(val)
-        val&.strftime('%m/%d/%Y')
+    describe 'deprecated :float field type' do
+      let(:doc) do
+        new_class do
+          field :distance_m, :float
+        end.new
       end
 
-      def self.load(val)
-        val && DateTime.strptime(val, '%m/%d/%Y').to_date
+      it 'acts as a :number field' do
+        # NOTE: Set as string to avoid error on JRuby 9.4.0.0:
+        #         Aws::DynamoDB::Errors::ValidationException:
+        #           DynamoDB only supports precision up to 38 digits
+        doc.distance_m = '5.33'
+        doc.save!
+        doc.reload
+        expect(doc.distance_m).to eq 5.33
+      end
+
+      it 'warns' do
+        expect(Dynamoid.logger).to receive(:warn).with(/deprecated/)
+        doc
       end
     end
-
-    klass = new_class do
-      range :special_date, :serialized, serializer: serializer
-    end
-
-    date = '2019-02-24'.to_date
-    model = klass.create!(special_date: date)
-    model_loaded = klass.find(model.id, range_key: model.special_date)
-    expect(model_loaded.special_date).to eq date
   end
 
-  context 'query attributes' do
-    it 'are declared' do
-      expect(address).not_to be_city
+  describe '.range' do
+    it 'allows range key serializers' do
+      serializer = Class.new do
+        def self.dump(val)
+          val&.strftime('%m/%d/%Y')
+        end
 
-      address.city = 'Chicago'
+        def self.load(val)
+          val && DateTime.strptime(val, '%m/%d/%Y').to_date
+        end
+      end
 
-      expect(address).to be_city
+      klass = new_class do
+        range :special_date, :serialized, serializer: serializer
+      end
+
+      date = '2019-02-24'.to_date
+      model = klass.create!(special_date: date)
+      model_loaded = klass.find(model.id, range_key: model.special_date)
+      expect(model_loaded.special_date).to eq date
     end
-
-    it 'return false when boolean attributes are nil or false' do
-      address.deliverable = nil
-      expect(address).not_to be_deliverable
-
-      address.deliverable = false
-      expect(address).not_to be_deliverable
-    end
-
-    it 'return true when boolean attributes are true' do
-      address.deliverable = true
-      expect(address).to be_deliverable
-    end
-  end
-
-  context 'with a saved address' do
-    let(:address) { Address.create(deliverable: true) }
-    let(:original_id) { address.id }
-
-    it 'writes an attribute correctly' do
-      address.write_attribute(:city, 'Chicago')
-      expect(address.read_attribute(:city)).to eq 'Chicago'
-    end
-
-    it 'writes an attribute with an alias' do
-      address[:city] = 'Chicago'
-      expect(address.read_attribute(:city)).to eq 'Chicago'
-    end
-
-    it 'reads a written attribute' do
-      address.city = 'Chicago'
-      expect(address.read_attribute(:city)).to eq 'Chicago'
-    end
-
-    it 'reads a written attribute with the alias' do
-      address.write_attribute(:city, 'Chicago')
-      expect(address[:city]).to eq 'Chicago'
-    end
-
-    it 'updates one attribute' do
-      expect(address).to receive(:save).once.and_return(true)
-      address.update_attribute(:city, 'Chicago')
-      expect(address[:city]).to eq 'Chicago'
-      expect(address.id).to eq original_id
-    end
-
-    it 'adds in dirty methods for attributes' do
-      address.city = 'Chicago'
-      address.save
-
-      address.city = 'San Francisco'
-
-      expect(address.city_was).to eq 'Chicago'
-    end
-
-    it 'returns all attributes' do
-      expect(Address.attributes).to eq(id: { type: :string },
-                                       created_at: { type: :datetime },
-                                       updated_at: { type: :datetime },
-                                       city: { type: :string },
-                                       options: { type: :serialized },
-                                       deliverable: { type: :boolean },
-                                       latitude: { type: :number },
-                                       config: { type: :raw },
-                                       registered_on: { type: :date },
-                                       lock_version: { type: :integer })
-    end
-  end
-
-  it 'raises an exception when items size exceeds 400kb' do
-    expect do
-      Address.create(city: 'Ten chars ' * 500_000)
-    end.to raise_error(Aws::DynamoDB::Errors::ValidationException, 'Item size has exceeded the maximum allowed size')
   end
 
   describe '.remove_field' do
@@ -266,122 +414,18 @@ describe Dynamoid::Fields do
     end
   end
 
-  context 'default values for fields' do
-    let(:doc_class) do
-      new_class do
-        field :name, :string, default: 'x'
-        field :uid, :integer, default: -> { 42 }
-        field :config, :serialized, default: {}
-        field :version, :integer, default: 1
-        field :hidden, :boolean, default: false
-      end
-    end
-
-    it 'returns default value specified as object' do
-      expect(doc_class.new.name).to eq('x')
-    end
-
-    it 'returns default value specified as lamda/block (callable object)' do
-      expect(doc_class.new.uid).to eq(42)
-    end
-
-    it 'returns default value as is for serializable field' do
-      expect(doc_class.new.config).to eq({})
-    end
-
-    it 'supports `false` as default value' do
-      expect(doc_class.new.hidden).to eq(false)
-    end
-
-    it 'can modify default value independently for every instance' do
-      doc = doc_class.new
-      doc.name << 'y'
-      expect(doc_class.new.name).to eq('x')
-    end
-
-    it 'returns default value specified as object even if value cannot be duplicated' do
-      expect(doc_class.new.version).to eq(1)
-    end
-
-    it 'saves default values' do
-      doc = doc_class.create!
-      doc = doc_class.find(doc.id)
-      expect(doc.name).to eq('x')
-      expect(doc.uid).to eq(42)
-      expect(doc.config).to eq({})
-      expect(doc.version).to eq(1)
-      expect(doc.hidden).to be false
-    end
-
-    it 'does not use default value if nil value assigns explicitly' do
-      doc = doc_class.new(name: nil)
-      expect(doc.name).to eq nil
-    end
-
-    it 'supports default value for custom type' do
-      model_class = new_class do
-        field :user, FieldsSpecs::User, default: FieldsSpecs::User.new('Mary')
-      end
-
-      model = model_class.create
-      model = model_class.find(model.id)
-
-      expect(model.user).to eql FieldsSpecs::User.new('Mary')
-    end
-  end
-
-  describe 'deprecated :float field type' do
-    let(:doc) do
-      new_class do
-        field :distance_m, :float
-      end.new
-    end
-
-    it 'acts as a :number field' do
-      # NOTE: Set as string to avoid error on JRuby 9.4.0.0:
-      #         Aws::DynamoDB::Errors::ValidationException:
-      #           DynamoDB only supports precision up to 38 digits
-      doc.distance_m = '5.33'
-      doc.save!
-      doc.reload
-      expect(doc.distance_m).to eq 5.33
-    end
-
-    it 'warns' do
-      expect(Dynamoid.logger).to receive(:warn).with(/deprecated/)
-      doc
-    end
-  end
-
-  context 'extention overrides field accessors' do
-    let(:klass) do
-      extention = Module.new do
-        def name
-          super.upcase
-        end
-
-        def name=(str)
-          super(str.try(:downcase))
-        end
-      end
-
-      new_class do
-        include extention
-
-        field :name
-      end
-    end
-
-    it 'can access new setter' do
-      address = klass.new
-      address.name = 'AB cd'
-      expect(address[:name]).to eq('ab cd')
-    end
-
-    it 'can access new getter' do
-      address = klass.new
-      address.name = 'ABcd'
-      expect(address.name).to eq('ABCD')
+  describe '.attributes' do
+    it 'returns all attributes' do
+      expect(Address.attributes).to eq(id: { type: :string },
+                                       created_at: { type: :datetime },
+                                       updated_at: { type: :datetime },
+                                       city: { alias: :CityName, type: :string },
+                                       options: { type: :serialized },
+                                       deliverable: { type: :boolean },
+                                       latitude: { type: :number },
+                                       config: { type: :raw },
+                                       registered_on: { type: :date },
+                                       lock_version: { type: :integer })
     end
   end
 
@@ -404,6 +448,12 @@ describe Dynamoid::Fields do
       obj = klass.new
       result = obj.write_attribute(:count, 10)
       expect(result).to eql(obj)
+    end
+
+    it 'writes an attribute with an alias' do
+      skip "should be fixed"
+      address[:CityName] = 'Chicago'
+      expect(address.city).to eq 'Chicago'
     end
 
     describe 'type casting' do
@@ -449,14 +499,71 @@ describe Dynamoid::Fields do
     end
   end
 
-  describe '.table' do
-    context 'when specify key option and key_type' do
-      it 'hash_key attribute is defined by key_type type' do
-        klass = new_class do
-          table key: :hash_key, key_type: :integer
-        end
+  describe '#read_attribute' do
+    let(:address) { Address.create(deliverable: true) }
+    let(:original_id) { address.id }
 
-        expect(klass.attributes[:hash_key][:type]).to eq(:integer)
+
+    it 'reads a written attribute' do
+      address.city = 'Chicago'
+      expect(address.read_attribute(:city)).to eq 'Chicago'
+    end
+
+    it 'reads a written attribute with the alias' do
+      skip "should be fixed"
+      address.write_attribute(:city, 'Chicago')
+      expect(address[:CityName]).to eq 'Chicago'
+    end
+  end
+
+  context 'implicitly declared attribute' do
+    it 'automatically declares id' do
+      expect { address.id }.not_to raise_error
+    end
+
+    describe 'timestamps fields `created_at` and `updated_at`' do
+      let(:class_with_timestamps_true) do
+        new_class do
+          table timestamps: true
+        end
+      end
+
+      let(:class_with_timestamps_false) do
+        new_class do
+          table timestamps: false
+        end
+      end
+
+      it 'declares timestamps when Dynamoid::Config.timestamps = true', config: { timestamps: true } do
+        expect(new_class.attributes).to have_key(:created_at)
+        expect(new_class.attributes).to have_key(:updated_at)
+
+        expect(new_class.new).to respond_to(:created_at)
+        expect(new_class.new).to respond_to(:updated_at)
+      end
+
+      it 'does not declare timestamps when Dynamoid::Config.timestamps = false', config: { timestamps: false } do
+        expect(new_class.attributes).not_to have_key(:created_at)
+        expect(new_class.attributes).not_to have_key(:updated_at)
+
+        expect(new_class.new).not_to respond_to(:created_at)
+        expect(new_class.new).not_to respond_to(:updated_at)
+      end
+
+      it 'does not declare timestamps when Dynamoid::Config.timestamps = true but table timestamps = false', config: { timestamps: true } do
+        expect(class_with_timestamps_false.attributes).not_to have_key(:created_at)
+        expect(class_with_timestamps_false.attributes).not_to have_key(:updated_at)
+
+        expect(class_with_timestamps_false.new).not_to respond_to(:created_at)
+        expect(class_with_timestamps_false.new).not_to respond_to(:updated_at)
+      end
+
+      it 'declares timestamps when Dynamoid::Config.timestamps = false but table timestamps = true', config: { timestamps: false } do
+        expect(class_with_timestamps_true.attributes).to have_key(:created_at)
+        expect(class_with_timestamps_true.attributes).to have_key(:updated_at)
+
+        expect(class_with_timestamps_true.new).to respond_to(:created_at)
+        expect(class_with_timestamps_true.new).to respond_to(:updated_at)
       end
     end
   end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -462,7 +462,7 @@ describe Dynamoid::Fields do
     end
 
     it 'writes an attribute with an alias' do
-      skip "should be fixed"
+      skip 'should be fixed'
       address[:CityName] = 'Chicago'
       expect(address.city).to eq 'Chicago'
     end
@@ -514,14 +514,13 @@ describe Dynamoid::Fields do
     let(:address) { Address.create(deliverable: true) }
     let(:original_id) { address.id }
 
-
     it 'reads a written attribute' do
       address.city = 'Chicago'
       expect(address.read_attribute(:city)).to eq 'Chicago'
     end
 
     it 'reads a written attribute with the alias' do
-      skip "should be fixed"
+      skip 'should be fixed'
       address.write_attribute(:city, 'Chicago')
       expect(address[:CityName]).to eq 'Chicago'
     end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -448,4 +448,16 @@ describe Dynamoid::Fields do
       expect(obj.name_changed?).to eq false
     end
   end
+
+  describe '.table' do
+    context 'when specify key option and key_type' do
+      it 'hash_key attribute is defined by key_type type' do
+        klass = new_class do
+          table key: :hash_key, key_type: :integer
+        end
+
+        expect(klass.attributes[:hash_key][:type]).to eq(:integer)
+      end
+    end
+  end
 end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -78,13 +78,24 @@ describe Dynamoid::Fields do
       end
     end
 
-    context 'when specify key option and key_type' do
-      it 'hash_key attribute is defined by key_type type' do
+    context 'when :key and :key_type options specified' do
+      it 'changes a hash key attribute declared type' do
         klass = new_class do
           table key: :hash_key, key_type: :integer
         end
 
         expect(klass.attributes[:hash_key][:type]).to eq(:integer)
+      end
+
+      it 'changes a hash key attribute actual type' do
+        klass = new_class do
+          table key: :hash_key, key_type: :integer
+          field :name
+        end
+
+        klass.create!(hash_key: 42, name: 'Alex')
+        obj = klass.find(42)
+        expect(obj.name).to eq 'Alex'
       end
     end
   end


### PR DESCRIPTION
My project uses `integer` type hash key.

Currently, if we specify integer key to hash key, we need to do below process on dynamoid
1. define hash key with `table` method
2. override hash key type by `field` method

```ruby
class Model
  include Dynamoid::Document
  
  table key: :hash_key # hash_key define as string type

  field :hash_key, :integer # override hash_key type to integer from string
end
```

But, when we override attribute, dynamoid notice us warning message like 
```
'Method hash_key= generated for the field hash_key overrides already existing method'
'Method hash_key generated for the field hash_key overrides already existing method'
``` 

So, I'd like to add key_type option to specify type to hash key on table method to avoid warning message.