### PR TITLE
add config to error on scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1303,6 +1303,7 @@ Listed below are all configuration options.
 * `write_capacity` - is used at table or indices creation. Default is 20
   (units)
 * `warn_on_scan` - log warnings when scan table. Default is `true`
+* `error_on_scan` - raises an error when scan table. Default is `false`
 * `endpoint` - if provided, it communicates with the DynamoDB listening
   at the endpoint. This is useful for testing with
   [DynamoDB Local](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html)

--- a/lib/dynamoid/config.rb
+++ b/lib/dynamoid/config.rb
@@ -36,6 +36,7 @@ module Dynamoid
     option :read_capacity, default: 100
     option :write_capacity, default: 20
     option :warn_on_scan, default: true
+    option :error_on_scan, default: false
     option :endpoint, default: nil
     option :identity_map, default: false
     option :timestamps, default: true

--- a/lib/dynamoid/criteria/chain.rb
+++ b/lib/dynamoid/criteria/chain.rb
@@ -563,7 +563,7 @@ module Dynamoid
         if @key_fields_detector.key_present?
           raw_pages_via_query
         else
-          issue_scan_warning if Dynamoid::Config.warn_on_scan && !@where_conditions.empty?
+          validate_scan_conditions
           raw_pages_via_scan
         end
       end
@@ -596,6 +596,12 @@ module Dynamoid
             y.yield items, options
           end
         end
+      end
+
+      def validate_scan_conditions
+        raise Dynamoid::Errors::ScanProhibited if Dynamoid::Config.error_on_scan && !@where_conditions.empty?
+
+        issue_scan_warning if Dynamoid::Config.warn_on_scan && !@where_conditions.empty?
       end
 
       def issue_scan_warning

--- a/lib/dynamoid/errors.rb
+++ b/lib/dynamoid/errors.rb
@@ -100,5 +100,11 @@ module Dynamoid
     class SubclassNotFound < Error; end
 
     class Rollback < Error; end
+
+    class ScanProhibited < Error
+      def initialize(_msg = nil)
+        super('Scan operations prohibited. Modify Dynamoid::Config.error_on_scan to change this behavior.')
+      end
+    end
   end
 end

--- a/spec/dynamoid/criteria_spec.rb
+++ b/spec/dynamoid/criteria_spec.rb
@@ -117,6 +117,23 @@ describe Dynamoid::Criteria do
     end
   end
 
+  context 'when scans using non-indexed fields and error_on_scan config option is true' do
+    before do
+      @error_on_scan = Dynamoid::Config.error_on_scan
+      Dynamoid::Config.error_on_scan = true
+    end
+
+    after do
+      Dynamoid::Config.error_on_scan = @error_on_scan
+    end
+
+    it 'raises an error' do
+      expect {
+        User.where(name: 'x', password: 'password').all
+      }.to raise_error(Dynamoid::Errors::ScanProhibited)
+    end
+  end
+
   context 'when doing intentional, full-table scan (query is empty) and warn_on_scan config option is true' do
     before do
       @warn_on_scan = Dynamoid::Config.warn_on_scan
@@ -131,6 +148,21 @@ describe Dynamoid::Criteria do
       expect(Dynamoid.logger).not_to receive(:warn)
 
       User.all
+    end
+  end
+
+  context 'when doing intentional, full-table scan (query is empty) and error_on_scan config option is true' do
+    before do
+      @error_on_scan = Dynamoid::Config.error_on_scan
+      Dynamoid::Config.error_on_scan = true
+    end
+
+    after do
+      Dynamoid::Config.error_on_scan = @error_on_scan
+    end
+
+    it 'does not raise an error' do
+      expect { User.all }.not_to raise_error(Dynamoid::Errors::ScanProhibited)
     end
   end
 end


### PR DESCRIPTION
Adds an optional configuration option to raise an error on scan. Prevents accidental expensive/slow scans in situations when only queries are desired