### PR TITLE
Fix detecting dirty changes for :map fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dynamoid (3.12.1)
+    dynamoid (3.13.0)
       activemodel (>= 4)
       aws-sdk-dynamodb (~> 1.0)
       concurrent-ruby (>= 1.0)

--- a/lib/dynamoid/dirty.rb
+++ b/lib/dynamoid/dirty.rb
@@ -303,7 +303,16 @@ module Dynamoid
       value = read_attribute(name)
       type_options = self.class.attributes[name.to_sym]
 
-      unless type_options[:type].is_a?(Class) && !type_options[:comparable]
+      if self.class.attributes.dig(name.to_sym, :type) == :map && value.is_a?(Hash)
+        # A special case for the :map field type. attributes_from_database is a
+        # HashWithIndifferentAccess which has a side effect - it converts any
+        # nested Hash to HashWithIndifferentAccess as well.
+        # HashWithIndifferentAccess#== does not tolarate containing symbolized
+        # keys in an argument Hash. So if a value is a Hash and may have
+        # symbolized keys - wrap it into HashWithIndifferentAccess.
+        value_wrapped = value.with_indifferent_access
+        value_wrapped != value_from_database
+      elsif !type_options[:type].is_a?(Class) || type_options[:comparable]
         # common case
         value != value_from_database
       else

--- a/spec/dynamoid/dirty_spec.rb
+++ b/spec/dynamoid/dirty_spec.rb
@@ -856,4 +856,62 @@ describe Dynamoid::Dirty do
       end
     end
   end
+
+  # Regression test
+  # See https://github.com/Dynamoid/dynamoid/issues/1000
+  context 'field of type :map' do
+    let(:klass_with_map) do
+      new_class do
+        field :config, :map
+      end
+    end
+
+    it 'is not dirty after loading a model' do
+      obj = klass_with_map.create!(config: { 'a' => 1 })
+      obj = klass_with_map.find(obj.id)
+      expect(obj.changes).to eql({})
+    end
+  end
+
+  context 'field of type :raw' do
+    let(:klass_with_raw) do
+      new_class do
+        field :config, :raw
+      end
+    end
+
+    it 'is not dirty after loading a model' do
+      obj = klass_with_raw.create!(config: [{ 'a' => 1 }])
+      obj = klass_with_raw.find(obj.id)
+      expect(obj.changes).to eql({})
+    end
+  end
+
+  context 'field of type :array' do
+    let(:klass_with_array) do
+      new_class do
+        field :config, :array
+      end
+    end
+
+    it 'is not dirty after loading a model' do
+      obj = klass_with_array.create!(config: [{ 'a' => 1 }])
+      obj = klass_with_array.find(obj.id)
+      expect(obj.changes).to eql({})
+    end
+  end
+
+  context 'field of type :serialized' do
+    let(:klass_with_serialized) do
+      new_class do
+        field :config, :serialized
+      end
+    end
+
+    it 'is not dirty after loading a model' do
+      obj = klass_with_serialized.create!(config: [{ 'a' => 1 }])
+      obj = klass_with_serialized.find(obj.id)
+      expect(obj.changes).to eql({})
+    end
+  end
 end


### PR DESCRIPTION
Fixed an issue with `map` fields - just loaded model without any changes is reported as dirty.

Closes #1000

The issue was introduced in e2cfbabe8da733867df7f4d92eedfe1acdd5a8e9