### PR TITLE
Implement optimistic locking for transactional operations

### DIFF
--- a/lib/dynamoid/persistence/save.rb
+++ b/lib/dynamoid/persistence/save.rb
@@ -30,12 +30,18 @@ module Dynamoid
 
         # Add an optimistic locking check if the lock_version column exists
         if @model.class.attributes[:lock_version]
-          @model.lock_version = (@model.lock_version || 0) + 1
+          if @model.lock_version.nil? && @model.new_record?
+            @model.lock_version = 1
+          end
+
+          if @model.lock_version && !@model.changes[:lock_version]
+            @model.lock_version += 1
+          end
         end
 
         if @model.new_record?
           attributes_dumped = Dumping.dump_attributes(@model.attributes, @model.class.attributes)
-          Dynamoid.adapter.write(@model.class.table_name, attributes_dumped, conditions_for_write)
+          Dynamoid.adapter.write(@model.class.table_name, attributes_dumped, conditions_to_create_item)
         else
           attributes_to_persist = @model.attributes.slice(*@model.changed.map(&:to_sym))
           partition_key_dumped = dump(@model.class.hash_key, @model.hash_key)
@@ -68,21 +74,13 @@ module Dynamoid
       end
 
       # Should be called after incrementing `lock_version` attribute
-      def conditions_for_write
+      def conditions_to_create_item
         conditions = {}
 
         # Add an 'exists' check to prevent overwriting existing records with new ones
         conditions[:unless_exists] = [@model.class.hash_key]
         if @model.range_key
           conditions[:unless_exists] << @model.range_key
-        end
-
-        # Add an optimistic locking check if the lock_version column exists
-        # Uses the original lock_version value from Dirty API
-        # in case user changed 'lock_version' manually
-        if @model.class.attributes[:lock_version] && @model.changes[:lock_version][0]
-          conditions[:if] ||= {}
-          conditions[:if][:lock_version] = @model.changes[:lock_version][0]
         end
 
         conditions
@@ -103,9 +101,18 @@ module Dynamoid
         # Add an optimistic locking check if the lock_version column exists
         # Uses the original lock_version value from Dirty API
         # in case user changed 'lock_version' manually
-        if @model.class.attributes[:lock_version] && @model.changes[:lock_version][0]
-          conditions[:if] ||= {}
-          conditions[:if][:lock_version] = @model.changes[:lock_version][0]
+        if @model.class.attributes[:lock_version]
+          lock_version = if @model.changes[:lock_version]
+                           @model.changes[:lock_version][0]
+                         else
+                           @model.lock_version
+                         end
+
+          # skip concurrency control when lock_version is nil
+          if lock_version
+            conditions[:if] ||= {}
+            conditions[:if][:lock_version] = lock_version
+          end
         end
 
         options[:conditions] = conditions

--- a/lib/dynamoid/transactions/mutation.rb
+++ b/lib/dynamoid/transactions/mutation.rb
@@ -187,10 +187,9 @@ module Dynamoid
       # There are the following differences between transactional and
       # non-transactional +#save!+:
       # - transactional +#save!+ doesn't support the +:touch+ option
-      # - transactional +#save!+ doesn't support +lock_version+ attribute so it
-      #   will not be incremented and will not be checked to detect concurrent
-      #   modification of a model and +Dynamoid::Errors::StaleObjectError+
-      #   exception will not be raised
+      # - transactional +#save!+ doesn't raise +Dynamoid::Errors::StaleObjectError+
+      #   when optimistic concurrency control detects a conflict. A generic
+      #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised instead.
       # - transactional +#save!+ doesn't raise +Dynamoid::Errors::RecordNotUnique+
       #   at saving new model when primary key is already used. A generic
       #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised instead.
@@ -245,10 +244,9 @@ module Dynamoid
       # There are the following differences between transactional and
       # non-transactional +#save+:
       # - transactional +#save+ doesn't support the +:touch+ option
-      # - transactional +#save+ doesn't support +lock_version+ attribute so it
-      #   will not be incremented and will not be checked to detect concurrent
-      #   modification of a model and +Dynamoid::Errors::StaleObjectError+
-      #   exception will not be raised
+      # - transactional +#save+ doesn't raise +Dynamoid::Errors::StaleObjectError+
+      #   when optimistic concurrency control detects a conflict. A generic
+      #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised instead.
       # - transactional +#save+ doesn't raise +Dynamoid::Errors::RecordNotUnique+
       #   at saving new model when primary key is already used. A generic
       #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised instead.
@@ -293,10 +291,6 @@ module Dynamoid
       #
       # There are the following differences between transactional and
       # non-transactional +#create+:
-      # - transactional +#create!+ doesn't support +lock_version+ attribute so it
-      #   will not be incremented and will not be checked to detect concurrent
-      #   modification of a model and +Dynamoid::Errors::StaleObjectError+
-      #   exception will not be raised
       # - transactional +#create!+ doesn't raise +Dynamoid::Errors::RecordNotUnique+
       #   at saving new model when primary key is already used. A generic
       #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised instead.
@@ -346,10 +340,6 @@ module Dynamoid
       #
       # There are the following differences between transactional and
       # non-transactional +#create+:
-      # - transactional +#create+ doesn't support +lock_version+ attribute so it
-      #   will not be incremented and will not be checked to detect concurrent
-      #   modification of a model and +Dynamoid::Errors::StaleObjectError+
-      #   exception will not be raised
       # - transactional +#create+ doesn't raise +Dynamoid::Errors::RecordNotUnique+
       #   at saving new model when primary key is already used. A generic
       #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised instead.
@@ -516,10 +506,11 @@ module Dynamoid
       #
       # There are the following differences between transactional and
       # non-transactional +#update_attributes+:
-      # - transactional +#update_attributes+ doesn't support +lock_version+ attribute so it
-      #   will not be incremented and will not be checked to detect concurrent
-      #   modification of a model and +Dynamoid::Errors::StaleObjectError+
-      #   exception will not be raised
+      # - transactional +#update_attributes+ doesn't raise
+      #   +Dynamoid::Errors::StaleObjectError+ when optimistic concurrency
+      #   control detects a conflict. A generic
+      #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised
+      #   instead.
       # - transactional +update_attributes+ doesn't raise
       #   +Dynamoid::Errors::StaleObjectError+ when a model that is being updated
       #   was concurrently deleted
@@ -551,10 +542,11 @@ module Dynamoid
       #
       # There are the following differences between transactional and
       # non-transactional +#update_attributes!+:
-      # - transactional +#update_attributes!+ doesn't support +lock_version+
-      #   attribute so it will not be incremented and will not be checked to detect
-      #   concurrent modification of a model and
-      #   +Dynamoid::Errors::StaleObjectError+ exception will not be raised
+      # - transactional +#update_attributes!+ doesn't raise
+      #   +Dynamoid::Errors::StaleObjectError+ when optimistic concurrency
+      #   control detects a conflict. A generic
+      #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised
+      #   instead.
       # - transactional +update_attributes!+ doesn't raise
       #   +Dynamoid::Errors::StaleObjectError+ when a model that is being updated
       #   was concurrently deleted
@@ -587,10 +579,11 @@ module Dynamoid
       #
       # There are the following differences between transactional and
       # non-transactional +#delete+: TBD
-      # - transactional +#delete+ doesn't support +lock_version+ attribute so it
-      #   will not be incremented and will not be checked to detect concurrent
-      #   modification of a model and +Dynamoid::Errors::StaleObjectError+
-      #   exception will not be raised
+      # - transactional +#delete+ doesn't raise
+      #   +Dynamoid::Errors::StaleObjectError+ when optimistic concurrency
+      #   control detects a conflict. A generic
+      #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised
+      #   instead.
       # - transactional +#delete+ doesn't disassociate a model from associated ones
       #   if there is any
       #
@@ -620,10 +613,11 @@ module Dynamoid
       #
       # There are the following differences between transactional and
       # non-transactional +#destroy!+:
-      # - transactional +#destroy!+ doesn't support +lock_version+ attribute so it
-      #   will not be incremented and will not be checked to detect concurrent
-      #   modification of a model and +Dynamoid::Errors::StaleObjectError+
-      #   exception will not be raised
+      # - transactional +#destroy!+ doesn't raise
+      #   +Dynamoid::Errors::StaleObjectError+ when optimistic concurrency
+      #   control detects a conflict. A generic
+      #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised
+      #   instead.
       # - transactional +#destroy!+ doesn't disassociate a model from associated ones
       #   if there are association declared in the model class
       #
@@ -644,10 +638,11 @@ module Dynamoid
       #
       # There are the following differences between transactional and
       # non-transactional +#destroy+:
-      # - transactional +#destroy+ doesn't support +lock_version+ attribute so it
-      #   will not be incremented and will not be checked to detect concurrent
-      #   modification of a model and +Dynamoid::Errors::StaleObjectError+
-      #   exception will not be raised
+      # - transactional +#destroy+ doesn't raise
+      #   +Dynamoid::Errors::StaleObjectError+ when optimistic concurrency
+      #   control detects a conflict. A generic
+      #   +Aws::DynamoDB::Errors::TransactionCanceledException+ is raised
+      #   instead.
       # - transactional +#destroy+ doesn't disassociate a model from associated ones
       #   if there are association declared in the model class
       #

--- a/lib/dynamoid/transactions/mutation/delete_with_instance.rb
+++ b/lib/dynamoid/transactions/mutation/delete_with_instance.rb
@@ -54,8 +54,11 @@ module Dynamoid
                              @model.changes[:lock_version][0]
                            end
 
-            options[:condition_expression] = 'lock_version = :lock_version_value'
-            options[:expression_attribute_values] = { ':lock_version_value' => lock_version }
+            # skip concurrency control when lock_version is nil
+            if lock_version
+              options[:condition_expression] = 'lock_version = :lock_version_value'
+              options[:expression_attribute_values] = { ':lock_version_value' => lock_version }
+            end
           end
 
           { delete: options }

--- a/lib/dynamoid/transactions/mutation/delete_with_instance.rb
+++ b/lib/dynamoid/transactions/mutation/delete_with_instance.rb
@@ -42,12 +42,23 @@ module Dynamoid
             key[@model_class.range_key] = dump_attribute(@model_class.range_key, @model.range_value)
           end
 
-          {
-            delete: {
-              key: key,
-              table_name: @model_class.table_name
-            }
+          options = {
+            key: key,
+            table_name: @model_class.table_name
           }
+
+          if @model_class.attributes[:lock_version]
+            lock_version = if @model.changes[:lock_version].nil?
+                             @model.lock_version
+                           else
+                             @model.changes[:lock_version][0]
+                           end
+
+            options[:condition_expression] = 'lock_version = :lock_version_value'
+            options[:expression_attribute_values] = { ':lock_version_value' => lock_version }
+          end
+
+          { delete: options }
         end
 
         private

--- a/lib/dynamoid/transactions/mutation/destroy.rb
+++ b/lib/dynamoid/transactions/mutation/destroy.rb
@@ -73,8 +73,11 @@ module Dynamoid
                              @model.changes[:lock_version][0]
                            end
 
-            options[:condition_expression] = 'lock_version = :lock_version_value'
-            options[:expression_attribute_values] = { ':lock_version_value' => lock_version }
+            # skip concurrency control when lock_version is nil
+            if lock_version
+              options[:condition_expression] = 'lock_version = :lock_version_value'
+              options[:expression_attribute_values] = { ':lock_version_value' => lock_version }
+            end
           end
 
           { delete: options }

--- a/lib/dynamoid/transactions/mutation/destroy.rb
+++ b/lib/dynamoid/transactions/mutation/destroy.rb
@@ -61,12 +61,23 @@ module Dynamoid
             key[@model_class.range_key] = dump_attribute(@model_class.range_key, @model.range_value)
           end
 
-          {
-            delete: {
-              key: key,
-              table_name: @model_class.table_name
-            }
+          options = {
+            key: key,
+            table_name: @model_class.table_name
           }
+
+          if @model_class.attributes[:lock_version]
+            lock_version = if @model.changes[:lock_version].nil?
+                             @model.lock_version
+                           else
+                             @model.changes[:lock_version][0]
+                           end
+
+            options[:condition_expression] = 'lock_version = :lock_version_value'
+            options[:expression_attribute_values] = { ':lock_version_value' => lock_version }
+          end
+
+          { delete: options }
         end
 
         private

--- a/lib/dynamoid/transactions/mutation/save.rb
+++ b/lib/dynamoid/transactions/mutation/save.rb
@@ -50,8 +50,14 @@ module Dynamoid
             @model.hash_key = SecureRandom.uuid
           end
 
-          if @model_class.attributes[:lock_version]
-            @model.lock_version = (@model.lock_version || 0) + 1
+          if @model.class.attributes[:lock_version]
+            if @model.lock_version.nil? && @model.new_record?
+              @model.lock_version = 1
+            end
+
+            if @model.lock_version && !@model.changes[:lock_version]
+              @model.lock_version += 1
+            end
           end
         end
 
@@ -158,9 +164,12 @@ module Dynamoid
                              @model.changes[:lock_version][0]
                            end
 
-            lock_version_value_placeholder = ':lock_version_value'
-            expression_attribute_values[lock_version_value_placeholder] = lock_version
-            condition_expression_statements << "lock_version = #{lock_version_value_placeholder}"
+            # skip concurrency control when lock_version is nil
+            if lock_version
+              lock_version_value_placeholder = ':lock_version_value'
+              expression_attribute_values[lock_version_value_placeholder] = lock_version
+              condition_expression_statements << "lock_version = #{lock_version_value_placeholder}"
+            end
           end
 
           update_expression = ''

--- a/lib/dynamoid/transactions/mutation/save.rb
+++ b/lib/dynamoid/transactions/mutation/save.rb
@@ -49,6 +49,10 @@ module Dynamoid
           if @was_new_record && @model.hash_key.nil?
             @model.hash_key = SecureRandom.uuid
           end
+
+          if @model_class.attributes[:lock_version]
+            @model.lock_version = (@model.lock_version || 0) + 1
+          end
         end
 
         def on_commit
@@ -130,6 +134,7 @@ module Dynamoid
           # in ExpressionAttributeNames and ExpressionAttributeValues.
           set_expression_statements = []
           remove_expression_statements = []
+          condition_expression_statements = []
           expression_attribute_names = {}
           expression_attribute_values = {}
 
@@ -146,9 +151,23 @@ module Dynamoid
             expression_attribute_names[name_placeholder] = name
           end
 
+          if @model_class.attributes[:lock_version]
+            lock_version = if @model.changes[:lock_version].nil?
+                             @model.lock_version
+                           else
+                             @model.changes[:lock_version][0]
+                           end
+
+            lock_version_value_placeholder = ':lock_version_value'
+            expression_attribute_values[lock_version_value_placeholder] = lock_version
+            condition_expression_statements << "lock_version = #{lock_version_value_placeholder}"
+          end
+
           update_expression = ''
           update_expression += "SET #{set_expression_statements.join(', ')}" if set_expression_statements.any?
           update_expression += " REMOVE #{remove_expression_statements.join(', ')}" if remove_expression_statements.any?
+
+          condition_expression = condition_expression_statements.join(' AND ') if condition_expression_statements.any?
 
           {
             update: {
@@ -156,7 +175,8 @@ module Dynamoid
               table_name: @model_class.table_name,
               update_expression: update_expression,
               expression_attribute_names: expression_attribute_names,
-              expression_attribute_values: expression_attribute_values
+              expression_attribute_values: expression_attribute_values,
+              condition_expression: condition_expression,
             }
           }
         end

--- a/spec/dynamoid/persistence/delete_spec.rb
+++ b/spec/dynamoid/persistence/delete_spec.rb
@@ -244,33 +244,42 @@ RSpec.describe Dynamoid::Persistence do
       end
     end
 
-    context 'with lock version' do
-      let(:address) { Address.new }
-
-      it 'deletes a record if lock version matches' do
-        address.save!
-
-        expect { address.delete }.to change { Address.exists? address.id }.from(true).to(false)
+    context 'optimistic locking' do
+      let(:klass) do
+        new_class do
+          field :name
+          field :lock_version, :integer
+        end
       end
 
-      it 'does not delete a record if lock version does not match' do
-        address.save!
-        a1 = address
-        a2 = Address.find(address.id)
+      it 'raises Dynamoid::Errors::StaleObjectError when concurrent update happens before delete' do
+        obj = klass.create!(name: 'Original') # lock_version: 1
+        obj2 = klass.find(obj.id)
 
-        a1.city = 'Seattle'
-        a1.save!
+        obj.update_attributes!(name: 'Concurrent Update') # lock_version: 1 -> 2
 
-        expect { a2.delete }.to raise_error(Dynamoid::Errors::StaleObjectError)
-        expect(a2.destroyed?).to eql false
+        expect {
+          obj2.delete
+        }.to raise_error(Dynamoid::Errors::StaleObjectError)
+
+        expect(obj2.destroyed?).to eql false
       end
 
-      it 'uses the correct lock_version even if it is modified' do
-        address.save!
-        a1 = address
-        a1.lock_version = 100
+      it 'deletes a model if there is no concurrent update' do
+        obj = klass.create!(name: 'Original')
 
-        expect { a1.delete }.not_to raise_error
+        expect {
+          obj.delete
+        }.to change { klass.exists? obj.id }.from(true).to(false)
+      end
+
+      it 'uses the persisted lock_version value and ignores dirty changes' do
+        obj = klass.create!(name: 'Original')
+        obj.lock_version = obj.lock_version + 100
+
+        expect {
+          obj.delete
+        }.to change { klass.exists? obj.id }.from(true).to(false)
       end
     end
 

--- a/spec/dynamoid/persistence/destroy_spec.rb
+++ b/spec/dynamoid/persistence/destroy_spec.rb
@@ -98,37 +98,42 @@ RSpec.describe Dynamoid::Persistence do
       end
     end
 
-    context 'with lock version' do
-      let(:address) { Address.new }
-
-      it 'deletes a record if lock version matches' do
-        address.save!
-
-        expect {
-          address.destroy
-        }.to change { Address.where(id: address.id).first }.to(nil)
+    context 'optimistic locking' do
+      let(:klass) do
+        new_class do
+          field :name
+          field :lock_version, :integer
+        end
       end
 
-      it 'does not delete a record if lock version does not match' do
-        address.save!
-        a1 = address
-        a2 = Address.find(address.id)
+      it 'raises Dynamoid::Errors::StaleObjectError when concurrent update happens before delete' do
+        obj = klass.create!(name: 'Original') # lock_version: 1
+        obj2 = klass.find(obj.id)
 
-        a1.city = 'Seattle'
-        a1.save!
-
-        expect { a2.destroy }.to raise_exception(Dynamoid::Errors::StaleObjectError)
-        expect(a2.destroyed?).to eql(false) # FIXME
-      end
-
-      it 'uses the correct lock_version even if it is modified' do
-        address.save!
-        a1 = address
-        a1.lock_version = 100
+        obj.update_attributes!(name: 'Concurrent Update') # lock_version: 1 -> 2
 
         expect {
-          address.destroy
-        }.to change { Address.where(id: address.id).first }.to(nil)
+          obj2.destroy
+        }.to raise_error(Dynamoid::Errors::StaleObjectError)
+
+        expect(obj2.destroyed?).to eql false
+      end
+
+      it 'deletes a model if there is no concurrent update' do
+        obj = klass.create!(name: 'Original')
+
+        expect {
+          obj.destroy
+        }.to change { klass.exists? obj.id }.from(true).to(false)
+      end
+
+      it 'uses the persisted lock_version value and ignores dirty changes' do
+        obj = klass.create!(name: 'Original')
+        obj.lock_version = obj.lock_version + 100
+
+        expect {
+          obj.destroy
+        }.to change { klass.exists? obj.id }.from(true).to(false)
       end
     end
 

--- a/spec/dynamoid/persistence/save_spec.rb
+++ b/spec/dynamoid/persistence/save_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Dynamoid::Persistence do
       end
     end
 
-    describe 'pessimistic locking' do
+    describe 'optimistic locking' do
       let(:klass) do
         new_class do
           field :name
@@ -295,35 +295,32 @@ RSpec.describe Dynamoid::Persistence do
         end
       end
 
-      it 'generates "lock_version" if field declared' do
+      it 'raises Dynamoid::Errors::StaleObjectError when concurrent update happens' do
+        obj = klass.create(name: 'Original') # lock_version = 1
+
+        obj2 = klass.find(obj.id)
+        obj2.update_attributes!(name: 'Concurrent update') # lock_version 1 -> 2
+
+        expect {
+          obj.name = 'Updated'
+          obj.save
+        }.to raise_error(Dynamoid::Errors::StaleObjectError)
+      end
+
+      it 'initializes lock_version with value 1 when saving a new model' do
         obj = klass.new
         obj.save
 
         expect(obj.lock_version).to eq 1
-        expect(raw_attributes(obj)[:lock_version]).to eq 1
+        expect(obj.reload.lock_version).to eq 1
       end
 
-      it 'increments "lock_version" if it is declared' do
+      it 'increments lock_version when updating an existing model' do
         obj = klass.create
         obj.name = 'Alex'
 
         expect { obj.save }.to change { obj.lock_version }.from(1).to(2)
-      end
-
-      it 'prevents concurrent writes to tables with a lock_version' do
-        # version #1
-        obj = klass.create          # lock_version nil -> 1
-        obj2 = klass.find(obj.id)   # lock_version = 1
-
-        # version #2
-        obj.name = 'Alex'
-        obj.save # lock_version 1 -> 2
-        obj2.name = 'Bob'
-
-        # tries to create version #2 again
-        expect {
-          obj2.save # lock_version 1 -> 2
-        }.to raise_error(Dynamoid::Errors::StaleObjectError)
+        expect(obj.reload.lock_version).to eq 2
       end
     end
 

--- a/spec/dynamoid/persistence/save_spec.rb
+++ b/spec/dynamoid/persistence/save_spec.rb
@@ -322,6 +322,58 @@ RSpec.describe Dynamoid::Persistence do
         expect { obj.save }.to change { obj.lock_version }.from(1).to(2)
         expect(obj.reload.lock_version).to eq 2
       end
+
+      it 'preserves given value of lock_version' do
+        obj = klass.create!(name: 'Original')
+        expect(obj.lock_version).to eq(1)
+
+        obj.lock_version = 500
+        obj.save
+
+        expect(obj.lock_version).to eq(500)
+        expect(obj.reload.lock_version).to eq(500)
+      end
+
+      it 'preserves given nil value of lock_version' do
+        obj = klass.create!(name: 'Original')
+        expect(obj.lock_version).to eq(1)
+
+        obj.lock_version = nil
+        obj.save
+
+        expect(obj.lock_version).to be_nil
+        expect(obj.reload.lock_version).to be_nil
+      end
+
+      it 'preserves persisted nil value of lock_version' do
+        obj = klass.create!(name: 'Original')
+        obj.update_attributes!(lock_version: nil)
+
+        obj.name = 'Updated'
+        obj.save
+
+        expect(obj.lock_version).to be_nil
+        expect(obj.reload.lock_version).to be_nil
+      end
+
+      it 'skips optimistic locking when lock_version is nil' do
+        obj = klass.create!(name: 'Original') # lock_version: 1
+        obj.update_attributes!(lock_version: nil) # lock_version: 1 -> nil
+        expect(obj.reload.lock_version).to be_nil
+
+        obj = klass.find(obj.id)
+        obj2 = klass.find(obj.id)
+
+        obj.update_attributes!(name: 'Concurrent Update')
+        expect(obj.lock_version).to be_nil
+
+        obj2.name = 'My Update'
+        obj2.save
+
+        expect(obj2.lock_version).to be_nil
+        expect(obj2.reload.lock_version).to be_nil
+        expect(obj2.reload.name).to eq('My Update')
+      end
     end
 
     context 'primary key dumping' do

--- a/spec/dynamoid/transactions/mutation/delete_spec.rb
+++ b/spec/dynamoid/transactions/mutation/delete_spec.rb
@@ -105,6 +105,49 @@ describe Dynamoid::Transactions::Mutation, '#delete(model)' do # rubocop:disable
     end
   end
 
+  describe 'optimistic locking' do
+    let(:klass) do
+      new_class do
+        field :name
+        field :lock_version, :integer
+      end
+    end
+
+    it 'rolls back a transaction when concurrent update happens before delete' do
+      obj = klass.create(name: 'Original') # lock_version: 1
+
+      obj2 = klass.find(obj.id)
+      obj2.update_attributes!(name: 'Concurrent Update') # lock_version: 1 -> 2
+
+      expect {
+        klass.transaction do |t|
+          t.delete(obj)
+        end
+      }.to raise_error(Aws::DynamoDB::Errors::TransactionCanceledException)
+    end
+
+    it 'deletes a model if there is no concurrent update' do
+      obj = klass.create!(name: 'Original')
+
+      expect {
+        klass.transaction do |t|
+          t.delete(obj)
+        end
+      }.to change { klass.exists? obj.id }.from(true).to(false)
+    end
+
+    it 'uses the persisted lock_version value and ignores dirty changes' do
+      obj = klass.create!(name: 'Original')
+      obj.lock_version = obj.lock_version + 100
+
+      expect {
+        klass.transaction do |t|
+          t.delete(obj)
+        end
+      }.to change { klass.exists? obj.id }.from(true).to(false)
+    end
+  end
+
   context 'when an issue detected on the DynamoDB side' do
     it 'does not roll back the changes when a model to delete was concurrently deleted' do
       obj1 = klass.create!(name: 'one', id: '1')

--- a/spec/dynamoid/transactions/mutation/delete_spec.rb
+++ b/spec/dynamoid/transactions/mutation/delete_spec.rb
@@ -146,6 +146,23 @@ describe Dynamoid::Transactions::Mutation, '#delete(model)' do # rubocop:disable
         end
       }.to change { klass.exists? obj.id }.from(true).to(false)
     end
+
+    it 'skips optimistic locking when lock_version is nil' do
+      obj = klass.create(name: 'Original') # lock_version: 1
+      obj.update_attributes!(lock_version: nil) # lock_version: 1 -> nil
+      expect(obj.reload.lock_version).to be_nil
+
+      obj = klass.find(obj.id)
+      obj2 = klass.find(obj.id)
+
+      obj.update_attributes!(name: 'Concurrent Update')
+
+      expect {
+        klass.transaction do |t|
+          t.delete(obj2)
+        end
+      }.to change { klass.exists? obj2.id }.from(true).to(false)
+    end
   end
 
   context 'when an issue detected on the DynamoDB side' do

--- a/spec/dynamoid/transactions/mutation/destroy_spec.rb
+++ b/spec/dynamoid/transactions/mutation/destroy_spec.rb
@@ -160,6 +160,23 @@ describe Dynamoid::Transactions::Mutation, '#destroy' do # rubocop:disable RSpec
         end
       }.to change { klass.exists? obj.id }.from(true).to(false)
     end
+
+    it 'skips optimistic locking when lock_version is nil' do
+      obj = klass.create(name: 'Original') # lock_version: 1
+      obj.update_attributes!(lock_version: nil) # lock_version: 1 -> nil
+      expect(obj.reload.lock_version).to be_nil
+
+      obj = klass.find(obj.id)
+      obj2 = klass.find(obj.id)
+
+      obj.update_attributes!(name: 'Concurrent Update')
+
+      expect {
+        klass.transaction do |t|
+          t.destroy(obj2)
+        end
+      }.to change { klass.exists? obj2.id }.from(true).to(false)
+    end
   end
 
   context 'when an issue detected on the DynamoDB side' do

--- a/spec/dynamoid/transactions/mutation/destroy_spec.rb
+++ b/spec/dynamoid/transactions/mutation/destroy_spec.rb
@@ -119,6 +119,49 @@ describe Dynamoid::Transactions::Mutation, '#destroy' do # rubocop:disable RSpec
     end
   end
 
+  describe 'optimistic locking' do
+    let(:klass) do
+      new_class do
+        field :name
+        field :lock_version, :integer
+      end
+    end
+
+    it 'rolls back a transaction when concurrent update happens before delete' do
+      obj = klass.create(name: 'Original') # lock_version: 1
+
+      obj2 = klass.find(obj.id)
+      obj2.update_attributes!(name: 'Concurrent Update') # lock_version: 1 -> 2
+
+      expect {
+        klass.transaction do |t|
+          t.destroy(obj)
+        end
+      }.to raise_error(Aws::DynamoDB::Errors::TransactionCanceledException)
+    end
+
+    it 'deletes a model if there is no concurrent update' do
+      obj = klass.create!(name: 'Original')
+
+      expect {
+        klass.transaction do |t|
+          t.destroy(obj)
+        end
+      }.to change { klass.exists? obj.id }.from(true).to(false)
+    end
+
+    it 'uses the persisted lock_version value and ignores dirty changes' do
+      obj = klass.create!(name: 'Original')
+      obj.lock_version = obj.lock_version + 100
+
+      expect {
+        klass.transaction do |t|
+          t.destroy(obj)
+        end
+      }.to change { klass.exists? obj.id }.from(true).to(false)
+    end
+  end
+
   context 'when an issue detected on the DynamoDB side' do
     it 'does not raise exception and does not roll back the transaction when a model to destroy was concurrently deleted' do
       obj_to_destroy = klass.create!(name: 'one', id: '1')

--- a/spec/dynamoid/transactions/mutation/save_spec.rb
+++ b/spec/dynamoid/transactions/mutation/save_spec.rb
@@ -226,7 +226,7 @@ describe Dynamoid::Transactions::Mutation, '.save' do # rubocop:disable RSpec/Mu
     end
 
     it 'rolls back a transaction when concurrent update happens' do
-      obj = klass.create(name: 'Original') # lock_version: 1
+      obj = klass.create!(name: 'Original') # lock_version: 1
 
       obj2 = klass.find(obj.id)
       obj2.update_attributes!(name: 'Concurrent Update') # lock_version: 1 -> 2
@@ -250,7 +250,7 @@ describe Dynamoid::Transactions::Mutation, '.save' do # rubocop:disable RSpec/Mu
     end
 
     it 'increments lock_version when updating an existing model' do
-      obj = klass.create(name: 'Original')
+      obj = klass.create!(name: 'Original')
       expect(obj.lock_version).to eq(1)
 
       klass.transaction do |t|
@@ -260,6 +260,66 @@ describe Dynamoid::Transactions::Mutation, '.save' do # rubocop:disable RSpec/Mu
 
       expect(obj.lock_version).to eq(2)
       expect(obj.reload.lock_version).to eq(2)
+    end
+
+    it 'preserves given value of lock_version' do
+      obj = klass.create!(name: 'Original')
+      expect(obj.lock_version).to eq(1)
+
+      klass.transaction do |t|
+        obj.lock_version = 500
+        t.save(obj)
+      end
+
+      expect(obj.lock_version).to eq(500)
+      expect(obj.reload.lock_version).to eq(500)
+    end
+
+    it 'preserves given nil value of lock_version' do
+      obj = klass.create!(name: 'Original')
+      expect(obj.lock_version).to eq(1)
+
+      klass.transaction do |t|
+        obj.lock_version = nil
+        t.save(obj)
+      end
+
+      expect(obj.lock_version).to be_nil
+      expect(obj.reload.lock_version).to be_nil
+    end
+
+    it 'preserves persisted nil value of lock_version' do
+      obj = klass.create!(name: 'Original')
+      obj.update_attributes!(lock_version: nil)
+
+      klass.transaction do |t|
+        obj.name = 'Updated'
+        t.save(obj)
+      end
+
+      expect(obj.lock_version).to be_nil
+      expect(obj.reload.lock_version).to be_nil
+    end
+
+    it 'skips optimistic locking when lock_version is nil' do
+      obj = klass.create!(name: 'Original') # lock_version: 1
+      obj.update_attributes!(lock_version: nil) # lock_version: 1 -> nil
+      expect(obj.reload.lock_version).to be_nil
+
+      obj = klass.find(obj.id)
+      obj2 = klass.find(obj.id)
+
+      obj.update_attributes!(name: 'Concurrent Update')
+      expect(obj.lock_version).to be_nil
+
+      klass.transaction do |t|
+        obj2.name = 'My Update'
+        t.save(obj2)
+      end
+
+      expect(obj2.lock_version).to be_nil
+      expect(obj2.reload.lock_version).to be_nil
+      expect(obj2.reload.name).to eq('My Update')
     end
   end
 

--- a/spec/dynamoid/transactions/mutation/save_spec.rb
+++ b/spec/dynamoid/transactions/mutation/save_spec.rb
@@ -213,6 +213,56 @@ describe Dynamoid::Transactions::Mutation, '.save' do # rubocop:disable RSpec/Mu
     end
   end
 
+  describe 'optimistic locking' do
+    let(:klass) do
+      new_class do
+        field :name
+        field :lock_version, :integer
+      end
+    end
+
+    before do
+      klass.create_table
+    end
+
+    it 'rolls back a transaction when concurrent update happens' do
+      obj = klass.create(name: 'Original') # lock_version: 1
+
+      obj2 = klass.find(obj.id)
+      obj2.update_attributes!(name: 'Concurrent Update') # lock_version: 1 -> 2
+
+      expect {
+        klass.transaction do |t|
+          obj.name = 'My Update'
+          t.save(obj)
+        end
+      }.to raise_error(Aws::DynamoDB::Errors::TransactionCanceledException)
+    end
+
+    it 'initializes lock_version with value 1 when saving a new model' do
+      obj = klass.new(name: 'Original')
+      klass.transaction do |t|
+        t.save(obj)
+      end
+
+      expect(obj.lock_version).to eq(1)
+      expect(klass.find(obj.id).lock_version).to eq(1)
+    end
+
+    it 'increments lock_version when updating an existing model' do
+      obj = klass.create(name: 'Original')
+      expect(obj.lock_version).to eq(1)
+
+      klass.transaction do |t|
+        obj.name = 'Updated'
+        t.save(obj)
+      end
+
+      expect(obj.lock_version).to eq(2)
+      expect(obj.reload.lock_version).to eq(2)
+    end
+  end
+
   describe 'timestamps' do
     context 'new model' do
       before do


### PR DESCRIPTION
Implement optimistic locking for transactional methods using `lock_version` field.

The following methods are affected:
- `save`/`save!`,
- `create`/`create!`,
- `update_attributes`/`update_attributes!`,
- `update_attribute`,
- `delete`
- `destroy!` /`destroy!`

Also the following edge cases are fixed for non-transactional methods:
- don't change given lock_version value
- don't change persisted nil value of lock_version
- skip locking when nil value of lock_version is persisted