### PR TITLE
Add transactional inc method

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -448,6 +448,10 @@ module Dynamoid
       #   User.inc('1', age: 2, touch: :viewed_at)
       #   User.inc('1', age: 2, touch: [:viewed_at, :accessed_at])
       #
+      # Raises +Dynamoid::Errors::MissingHashKey+ if a partition key has value
+      # +nil+ and raises +Dynamoid::Errors::MissingRangeKey+ if a sort key is
+      # required but has value +nil+ or is missing.
+      #
       # @param hash_key_value [Scalar value] hash key
       # @param range_key_value [Scalar value] range key (optional)
       # @param counters [Hash] value to increase by

--- a/lib/dynamoid/persistence/inc.rb
+++ b/lib/dynamoid/persistence/inc.rb
@@ -16,11 +16,11 @@ module Dynamoid
         @partition_key = partition_key
         @sort_key = sort_key
         @counters = counters
+        @touch = @counters.delete(:touch)
       end
       # rubocop:enable Style/OptionalArguments
 
       def call
-        touch = @counters.delete(:touch)
         Dynamoid::Persistence::UpdateValidations.validate_attributes_exist(@model_class, @counters)
 
         partition_key_dumped = cast_and_dump(@model_class.hash_key, @partition_key)
@@ -33,10 +33,10 @@ module Dynamoid
             item_updater.add(name => value)
           end
 
-          if touch
+          if @touch
             value = DateTime.now.in_time_zone(Time.zone)
 
-            timestamp_attributes_to_touch(touch).each do |name|
+            timestamp_attributes_to_touch.each do |name|
               item_updater.set(name => value)
             end
           end
@@ -65,12 +65,12 @@ module Dynamoid
         options
       end
 
-      def timestamp_attributes_to_touch(touch)
-        return [] unless touch
+      def timestamp_attributes_to_touch
+        return [] unless @touch
 
         names = []
         names << :updated_at if @model_class.timestamps_enabled?
-        names += Array.wrap(touch) if touch != true
+        names += Array.wrap(@touch) if @touch != true
         names
       end
 

--- a/lib/dynamoid/persistence/inc.rb
+++ b/lib/dynamoid/persistence/inc.rb
@@ -21,6 +21,8 @@ module Dynamoid
 
       def call
         touch = @counters.delete(:touch)
+        Dynamoid::Persistence::UpdateValidations.validate_attributes_exist(@model_class, @counters)
+
         partition_key_dumped = cast_and_dump(@model_class.hash_key, @partition_key)
         options = update_item_options(partition_key_dumped)
 

--- a/lib/dynamoid/persistence/inc.rb
+++ b/lib/dynamoid/persistence/inc.rb
@@ -21,6 +21,7 @@ module Dynamoid
       # rubocop:enable Style/OptionalArguments
 
       def call
+        validate_primary_key!
         Dynamoid::Persistence::UpdateValidations.validate_attributes_exist(@model_class, @counters)
 
         partition_key_dumped = cast_and_dump(@model_class.hash_key, @partition_key)
@@ -45,6 +46,11 @@ module Dynamoid
       end
 
       private
+
+      def validate_primary_key!
+        raise Dynamoid::Errors::MissingHashKey if @partition_key.nil?
+        raise Dynamoid::Errors::MissingRangeKey if @model_class.range_key? && @sort_key.nil?
+      end
 
       def update_item_options(partition_key_dumped)
         options = {}

--- a/lib/dynamoid/transactions/mutation.rb
+++ b/lib/dynamoid/transactions/mutation.rb
@@ -8,6 +8,7 @@ require_relative 'mutation/save'
 require_relative 'mutation/update_fields'
 require_relative 'mutation/update_attributes'
 require_relative 'mutation/upsert'
+require_relative 'mutation/inc'
 require_relative 'mutation/item_updater'
 
 module Dynamoid
@@ -488,6 +489,58 @@ module Dynamoid
         end
 
         action = UpdateFields.new(model_class, hash_key, range_key, attributes, &block)
+        register_action action
+      end
+
+      # Increment numeric attributes.
+      #
+      # Doesn't run validations and callbacks.
+      #
+      #   Dynamoid::Transactions::Mutation.execute do |t|
+      #     t.inc(User, '1', age: 1)
+      #   end
+      #
+      # If range key is declared for a model it should be passed as well:
+      #
+      #   Dynamoid::Transactions::Mutation.execute do |t|
+      #     t.inc(User, '1', 'Tylor', age: 1)
+      #   end
+      #
+      # It also supports +touch+ option to update +updated_at+ attribute and
+      # optionally other specified attributes.
+      #
+      #   Dynamoid::Transactions::Mutation.execute do |t|
+      #     t.inc(User, '1', age: 1, touch: true)
+      #   end
+      #
+      # If attribute names are passed, they are updated along with updated_at
+      # attribute:
+      #
+      #   t.inc(User, '1', age: 2, touch: :viewed_at)
+      #   t.inc(User, '1', age: 2, touch: [:viewed_at, :accessed_at])
+      #
+      # It's an atomic operation. So incrementing or decrementing a numeric
+      # field is atomic and does not interfere with other write requests.
+      #
+      # Raises a +Dynamoid::Errors::UnknownAttribute+ exception if any of the
+      # attributes is not declared in the model class.
+      #
+      # Raises +Dynamoid::Errors::MissingHashKey+ if a partition key has value
+      # +nil+ and +Dynamoid::Errors::MissingRangeKey+ if a sort key is required
+      # but has value +nil+.
+      #
+      # @param model_class [Class] a model class
+      # @param hash_key [Scalar value] hash key value
+      # @param range_key [Scalar value] range key value (optional)
+      # @param counters [Hash]
+      # @return [nil]
+      def inc(model_class, hash_key, range_key = nil, counters = nil)
+        if range_key.is_a?(Hash) && !counters
+          counters = range_key
+          range_key = nil
+        end
+
+        action = Inc.new(model_class, hash_key, range_key, counters)
         register_action action
       end
 

--- a/lib/dynamoid/transactions/mutation/delete_with_primary_key.rb
+++ b/lib/dynamoid/transactions/mutation/delete_with_primary_key.rb
@@ -35,10 +35,10 @@ module Dynamoid
         end
 
         def action_request
-          key = { @model_class.hash_key => dump_attribute(@model_class.hash_key, @hash_key) }
+          key = { @model_class.hash_key => cast_and_dump(@model_class.hash_key, @hash_key) }
 
           if @model_class.range_key?
-            key[@model_class.range_key] = dump_attribute(@model_class.range_key, @range_key)
+            key[@model_class.range_key] = cast_and_dump(@model_class.range_key, @range_key)
           end
 
           {
@@ -56,9 +56,10 @@ module Dynamoid
           raise Dynamoid::Errors::MissingRangeKey if @model_class.range_key? && @range_key.nil?
         end
 
-        def dump_attribute(name, value)
+        def cast_and_dump(name, value)
           options = @model_class.attributes[name]
-          Dumping.dump_field(value, options)
+          value_casted = TypeCasting.cast_field(value, options)
+          Dumping.dump_field(value_casted, options)
         end
       end
     end

--- a/lib/dynamoid/transactions/mutation/inc.rb
+++ b/lib/dynamoid/transactions/mutation/inc.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'update_request_builder'
+require 'dynamoid/persistence/update_validations'
+
+module Dynamoid
+  module Transactions
+    class Mutation
+      class Inc < Base
+        def initialize(model_class, hash_key, range_key, counters)
+          super()
+
+          @model_class = model_class
+          @hash_key = hash_key
+          @range_key = range_key
+          @counters = counters || {}
+          @touch = @counters.delete(:touch)
+        end
+
+        def on_registration
+          validate_primary_key!
+          Dynamoid::Persistence::UpdateValidations.validate_attributes_exist(@model_class, @counters)
+        end
+
+        def on_commit; end
+
+        def on_rollback; end
+
+        def aborted?
+          false
+        end
+
+        def skipped?
+          @counters.empty?
+        end
+
+        def observable_by_user_result
+          nil
+        end
+
+        def action_request
+          builder = UpdateRequestBuilder.new(@model_class)
+
+          # primary key to look up an item to update
+          builder.hash_key = cast_and_dump(@model_class.hash_key, @hash_key)
+          builder.range_key = cast_and_dump(@model_class.range_key, @range_key) if @model_class.range_key?
+
+          # require primary key to exist
+          builder.add_expression_attribute_name('#_h', @model_class.hash_key)
+          condition_expression = 'attribute_exists(#_h)'
+
+          if @model_class.range_key?
+            builder.add_expression_attribute_name('#_r', @model_class.range_key)
+            condition_expression += ' AND attribute_exists(#_r)'
+          end
+          builder.condition_expression = condition_expression
+
+          @counters.each do |name, value|
+            builder.add_value(name, cast_and_dump(name, value))
+          end
+
+          if @touch
+            timestamp = DateTime.now.in_time_zone(Time.zone)
+
+            timestamp_attributes_to_touch.each do |name|
+              builder.set_attributes(name => dump_attribute(name, timestamp))
+            end
+          end
+
+          builder.request
+        end
+
+        private
+
+        def validate_primary_key!
+          raise Dynamoid::Errors::MissingHashKey if @hash_key.nil?
+          raise Dynamoid::Errors::MissingRangeKey if @model_class.range_key? && @range_key.nil?
+        end
+
+        def timestamp_attributes_to_touch
+          names = []
+          names << :updated_at if @model_class.timestamps_enabled?
+          names += Array.wrap(@touch) if @touch != true
+          names
+        end
+
+        def cast_and_dump(name, value)
+          options = @model_class.attributes[name]
+          value_casted = TypeCasting.cast_field(value, options)
+          Dumping.dump_field(value_casted, options)
+        end
+
+        def dump_attribute(name, value)
+          options = @model_class.attributes[name]
+          Dumping.dump_field(value, options)
+        end
+      end
+    end
+  end
+end

--- a/lib/dynamoid/transactions/mutation/inc.rb
+++ b/lib/dynamoid/transactions/mutation/inc.rb
@@ -64,7 +64,7 @@ module Dynamoid
             timestamp = DateTime.now.in_time_zone(Time.zone)
 
             timestamp_attributes_to_touch.each do |name|
-              builder.set_attributes(name => dump_attribute(name, timestamp))
+              builder.set_attributes(name => dump(name, timestamp))
             end
           end
 
@@ -91,7 +91,7 @@ module Dynamoid
           Dumping.dump_field(value_casted, options)
         end
 
-        def dump_attribute(name, value)
+        def dump(name, value)
           options = @model_class.attributes[name]
           Dumping.dump_field(value, options)
         end

--- a/lib/dynamoid/transactions/mutation/save.rb
+++ b/lib/dynamoid/transactions/mutation/save.rb
@@ -111,16 +111,20 @@ module Dynamoid
           attributes_dumped = sanitize_item(attributes_dumped)
 
           # require primary key not to exist yet
-          condition = "attribute_not_exists(#{@model_class.hash_key})"
+          expression_attribute_names = { '#_h' => @model_class.hash_key }
+          condition = 'attribute_not_exists(#_h)'
+
           if @model_class.range_key?
-            condition += " AND attribute_not_exists(#{@model_class.range_key})"
+            expression_attribute_names['#_r'] = @model_class.range_key
+            condition += ' AND attribute_not_exists(#_r)'
           end
 
           {
             put: {
               item: attributes_dumped,
               table_name: @model_class.table_name,
-              condition_expression: condition
+              condition_expression: condition,
+              expression_attribute_names: expression_attribute_names
             }
           }
         end

--- a/lib/dynamoid/transactions/mutation/save.rb
+++ b/lib/dynamoid/transactions/mutation/save.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative 'update_request_builder'
 
 module Dynamoid
   module Transactions
@@ -136,30 +137,23 @@ module Dynamoid
           changes = @model.attributes.slice(*@model.changed.map(&:to_sym))
           changes_dumped = Dynamoid::Dumping.dump_attributes(changes, @model_class.attributes)
 
-          # primary key to look up an item to update
-          key = { @model_class.hash_key => dump_attribute(@model_class.hash_key, @model.hash_key) }
-          key[@model_class.range_key] = dump_attribute(@model_class.range_key, @model.range_value) if @model_class.range_key?
+          builder = UpdateRequestBuilder.new(@model_class)
+          builder.hash_key = dump_attribute(@model_class.hash_key, @model.hash_key)
+          builder.range_key = dump_attribute(@model_class.range_key, @model.range_value) if @model_class.range_key?
 
-          # Build UpdateExpression and keep names and values placeholders mapping
-          # in ExpressionAttributeNames and ExpressionAttributeValues.
-          set_expression_statements = []
-          remove_expression_statements = []
-          condition_expression_statements = []
-          expression_attribute_names = {}
-          expression_attribute_values = {}
+          attributes_to_set = {}
+          attributes_to_remove = []
 
-          changes_dumped.each_with_index do |(name, value), i|
-            name_placeholder = "#_n#{i}"
-            value_placeholder = ":_s#{i}"
-
+          changes_dumped.each do |name, value|
             if value || Dynamoid.config.store_attribute_with_nil_value
-              set_expression_statements << "#{name_placeholder} = #{value_placeholder}"
-              expression_attribute_values[value_placeholder] = value
+              attributes_to_set[name] = value
             else
-              remove_expression_statements << name_placeholder
+              attributes_to_remove << name
             end
-            expression_attribute_names[name_placeholder] = name
           end
+
+          builder.set_attributes(attributes_to_set)
+          builder.remove_attributes(attributes_to_remove)
 
           if @model_class.attributes[:lock_version]
             lock_version = if @model.changes[:lock_version].nil?
@@ -170,28 +164,13 @@ module Dynamoid
 
             # skip concurrency control when lock_version is nil
             if lock_version
-              lock_version_value_placeholder = ':lock_version_value'
-              expression_attribute_values[lock_version_value_placeholder] = lock_version
-              condition_expression_statements << "lock_version = #{lock_version_value_placeholder}"
+              builder.add_expression_attribute_name('#_lock_version', 'lock_version')
+              builder.add_expression_attribute_value(':lock_version_value', lock_version)
+              builder.condition_expression = '#_lock_version = :lock_version_value'
             end
           end
 
-          update_expression = ''
-          update_expression += "SET #{set_expression_statements.join(', ')}" if set_expression_statements.any?
-          update_expression += " REMOVE #{remove_expression_statements.join(', ')}" if remove_expression_statements.any?
-
-          condition_expression = condition_expression_statements.join(' AND ') if condition_expression_statements.any?
-
-          {
-            update: {
-              key: key,
-              table_name: @model_class.table_name,
-              update_expression: update_expression,
-              expression_attribute_names: expression_attribute_names,
-              expression_attribute_values: expression_attribute_values,
-              condition_expression: condition_expression,
-            }
-          }
+          builder.request
         end
 
         def touch_model_timestamps(skip_created_at:)

--- a/lib/dynamoid/transactions/mutation/update_fields.rb
+++ b/lib/dynamoid/transactions/mutation/update_fields.rb
@@ -48,8 +48,8 @@ module Dynamoid
           builder = UpdateRequestBuilder.new(@model_class)
 
           # primary key to look up an item to update
-          builder.hash_key = dump_attribute(@model_class.hash_key, @hash_key)
-          builder.range_key = dump_attribute(@model_class.range_key, @range_key) if @model_class.range_key?
+          builder.hash_key = cast_and_dump(@model_class.hash_key, @hash_key)
+          builder.range_key = cast_and_dump(@model_class.range_key, @range_key) if @model_class.range_key?
 
           # require primary key to exist
           builder.add_expression_attribute_name('#_h', @model_class.hash_key)
@@ -123,9 +123,10 @@ module Dynamoid
           result
         end
 
-        def dump_attribute(name, value)
+        def cast_and_dump(name, value)
           options = @model_class.attributes[name]
-          Dumping.dump_field(value, options)
+          value_casted = TypeCasting.cast_field(value, options)
+          Dumping.dump_field(value_casted, options)
         end
       end
     end

--- a/lib/dynamoid/transactions/mutation/update_fields.rb
+++ b/lib/dynamoid/transactions/mutation/update_fields.rb
@@ -51,9 +51,18 @@ module Dynamoid
           builder.hash_key = dump_attribute(@model_class.hash_key, @hash_key)
           builder.range_key = dump_attribute(@model_class.range_key, @range_key) if @model_class.range_key?
 
+          # require primary key to exist
+          builder.add_expression_attribute_name('#_h', @model_class.hash_key)
+          condition_expression = 'attribute_exists(#_h)'
+
+          if @model_class.range_key?
+            builder.add_expression_attribute_name('#_r', @model_class.range_key)
+            condition_expression += ' AND attribute_exists(#_r)'
+          end
+          builder.condition_expression = condition_expression
+
           # changed attributes to persist
-          changes = @attributes.dup
-          changes = add_timestamps(changes, skip_created_at: true)
+          changes = add_timestamps(@attributes, skip_created_at: true)
           changes_dumped = Dynamoid::Dumping.dump_attributes(changes, @model_class.attributes)
 
           if Dynamoid.config.store_attribute_with_nil_value
@@ -93,13 +102,6 @@ module Dynamoid
               builder.delete_value(name, value)
             end
           end
-
-          # require primary key to exist
-          condition_expression = "attribute_exists(#{@model_class.hash_key})"
-          if @model_class.range_key?
-            condition_expression += " AND attribute_exists(#{@model_class.range_key})"
-          end
-          builder.condition_expression = condition_expression
 
           builder.request
         end

--- a/lib/dynamoid/transactions/mutation/update_fields.rb
+++ b/lib/dynamoid/transactions/mutation/update_fields.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative 'update_request_builder'
 require 'dynamoid/persistence/update_validations'
 
 module Dynamoid
@@ -123,125 +124,6 @@ module Dynamoid
         def dump_attribute(name, value)
           options = @model_class.attributes[name]
           Dumping.dump_field(value, options)
-        end
-
-        class UpdateRequestBuilder
-          attr_writer :hash_key, :range_key, :condition_expression
-
-          def initialize(model_class)
-            @model_class = model_class
-
-            @attributes_to_set = {}
-            @attributes_to_add = {}
-            @attributes_to_delete = {}
-            @attributes_to_remove = []
-            @condition_expression = nil
-          end
-
-          def set_attributes(attributes) # rubocop:disable Naming/AccessorMethodName
-            @attributes_to_set.merge!(attributes)
-          end
-
-          def add_value(name, value)
-            @attributes_to_add[name] = value
-          end
-
-          def delete_value(name, value)
-            @attributes_to_delete[name] = value
-          end
-
-          def remove_attributes(names)
-            @attributes_to_remove.concat(names)
-          end
-
-          def request
-            key = { @model_class.hash_key => @hash_key }
-            key[@model_class.range_key] = @range_key if @model_class.range_key?
-
-            # Build UpdateExpression and keep names and values placeholders mapping
-            # in ExpressionAttributeNames and ExpressionAttributeValues.
-            update_expression_statements = []
-            expression_attribute_names = {}
-            expression_attribute_values = {}
-            name_placeholder = '#_n0'
-            value_placeholder = ':_v0'
-
-            unless @attributes_to_set.empty?
-              statements = []
-
-              @attributes_to_set.each do |name, value|
-                statements << "#{name_placeholder} = #{value_placeholder}"
-
-                expression_attribute_names[name_placeholder] = name
-                expression_attribute_values[value_placeholder] = value
-
-                name_placeholder = name_placeholder.succ
-                value_placeholder = value_placeholder.succ
-              end
-
-              update_expression_statements << "SET #{statements.join(', ')}"
-            end
-
-            unless @attributes_to_add.empty?
-              statements = []
-
-              @attributes_to_add.each do |name, value|
-                statements << "#{name_placeholder} #{value_placeholder}"
-
-                expression_attribute_names[name_placeholder] = name
-                expression_attribute_values[value_placeholder] = value
-
-                name_placeholder = name_placeholder.succ
-                value_placeholder = value_placeholder.succ
-              end
-
-              update_expression_statements << "ADD #{statements.join(', ')}"
-            end
-
-            unless @attributes_to_delete.empty?
-              statements = []
-
-              @attributes_to_delete.each do |name, value|
-                statements << "#{name_placeholder} #{value_placeholder}"
-
-                expression_attribute_names[name_placeholder] = name
-                expression_attribute_values[value_placeholder] = value
-
-                name_placeholder = name_placeholder.succ
-                value_placeholder = value_placeholder.succ
-              end
-
-              update_expression_statements << "DELETE #{statements.join(', ')}"
-            end
-
-            unless @attributes_to_remove.empty?
-              name_placeholders = []
-
-              @attributes_to_remove.each do |name|
-                name_placeholders << name_placeholder
-
-                expression_attribute_names[name_placeholder] = name
-
-                name_placeholder = name_placeholder.succ
-                value_placeholder = value_placeholder.succ
-              end
-
-              update_expression_statements << "REMOVE #{name_placeholders.join(', ')}"
-            end
-
-            update_expression = update_expression_statements.join(' ')
-
-            {
-              update: {
-                key: key,
-                table_name: @model_class.table_name,
-                update_expression: update_expression,
-                expression_attribute_names: expression_attribute_names,
-                expression_attribute_values: expression_attribute_values,
-                condition_expression: @condition_expression
-              }
-            }
-          end
         end
       end
     end

--- a/lib/dynamoid/transactions/mutation/update_request_builder.rb
+++ b/lib/dynamoid/transactions/mutation/update_request_builder.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module Transactions
+    class Mutation
+      # @private
+      class UpdateRequestBuilder
+        attr_writer :hash_key, :range_key, :condition_expression
+
+        def initialize(model_class)
+          @model_class = model_class
+
+          @attributes_to_set = {}
+          @attributes_to_add = {}
+          @attributes_to_delete = {}
+          @attributes_to_remove = []
+          @condition_expression = nil
+          @extra_attribute_names = {}
+        end
+
+        def add_expression_attribute_name(placeholder, name)
+          @extra_attribute_names[placeholder] = name
+        end
+
+        def set_attributes(attributes) # rubocop:disable Naming/AccessorMethodName
+          @attributes_to_set.merge!(attributes)
+        end
+
+        def add_value(name, value)
+          @attributes_to_add[name] = value
+        end
+
+        def delete_value(name, value)
+          @attributes_to_delete[name] = value
+        end
+
+        def remove_attributes(names)
+          @attributes_to_remove.concat(names)
+        end
+
+        def request
+          key = { @model_class.hash_key => @hash_key }
+          key[@model_class.range_key] = @range_key if @model_class.range_key?
+
+          # Build UpdateExpression and keep names and values placeholders mapping
+          # in ExpressionAttributeNames and ExpressionAttributeValues.
+          update_expression_statements = []
+          expression_attribute_names = @extra_attribute_names.dup
+          expression_attribute_values = {}
+          name_placeholder = '#_n0'
+          value_placeholder = ':_v0'
+
+          unless @attributes_to_set.empty?
+            statements = []
+
+            @attributes_to_set.each do |name, value|
+              statements << "#{name_placeholder} = #{value_placeholder}"
+
+              expression_attribute_names[name_placeholder] = name
+              expression_attribute_values[value_placeholder] = value
+
+              name_placeholder = name_placeholder.succ
+              value_placeholder = value_placeholder.succ
+            end
+
+            update_expression_statements << "SET #{statements.join(', ')}"
+          end
+
+          unless @attributes_to_add.empty?
+            statements = []
+
+            @attributes_to_add.each do |name, value|
+              statements << "#{name_placeholder} #{value_placeholder}"
+
+              expression_attribute_names[name_placeholder] = name
+              expression_attribute_values[value_placeholder] = value
+
+              name_placeholder = name_placeholder.succ
+              value_placeholder = value_placeholder.succ
+            end
+
+            update_expression_statements << "ADD #{statements.join(', ')}"
+          end
+
+          unless @attributes_to_delete.empty?
+            statements = []
+
+            @attributes_to_delete.each do |name, value|
+              statements << "#{name_placeholder} #{value_placeholder}"
+
+              expression_attribute_names[name_placeholder] = name
+              expression_attribute_values[value_placeholder] = value
+
+              name_placeholder = name_placeholder.succ
+              value_placeholder = value_placeholder.succ
+            end
+
+            update_expression_statements << "DELETE #{statements.join(', ')}"
+          end
+
+          unless @attributes_to_remove.empty?
+            name_placeholders = []
+
+            @attributes_to_remove.each do |name|
+              name_placeholders << name_placeholder
+
+              expression_attribute_names[name_placeholder] = name
+
+              name_placeholder = name_placeholder.succ
+              value_placeholder = value_placeholder.succ
+            end
+
+            update_expression_statements << "REMOVE #{name_placeholders.join(', ')}"
+          end
+
+          update_expression = update_expression_statements.join(' ')
+
+          {
+            update: {
+              key: key,
+              table_name: @model_class.table_name,
+              update_expression: update_expression,
+              expression_attribute_names: expression_attribute_names,
+              expression_attribute_values: expression_attribute_values,
+              condition_expression: @condition_expression
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/dynamoid/transactions/mutation/update_request_builder.rb
+++ b/lib/dynamoid/transactions/mutation/update_request_builder.rb
@@ -16,10 +16,15 @@ module Dynamoid
           @attributes_to_remove = []
           @condition_expression = nil
           @extra_attribute_names = {}
+          @extra_attribute_values = {}
         end
 
         def add_expression_attribute_name(placeholder, name)
           @extra_attribute_names[placeholder] = name
+        end
+
+        def add_expression_attribute_value(placeholder, value)
+          @extra_attribute_values[placeholder] = value
         end
 
         def set_attributes(attributes) # rubocop:disable Naming/AccessorMethodName
@@ -46,7 +51,7 @@ module Dynamoid
           # in ExpressionAttributeNames and ExpressionAttributeValues.
           update_expression_statements = []
           expression_attribute_names = @extra_attribute_names.dup
-          expression_attribute_values = {}
+          expression_attribute_values = @extra_attribute_values.dup
           name_placeholder = '#_n0'
           value_placeholder = ':_v0'
 

--- a/lib/dynamoid/transactions/mutation/upsert.rb
+++ b/lib/dynamoid/transactions/mutation/upsert.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative 'update_request_builder'
 require 'dynamoid/persistence/update_validations'
 
 module Dynamoid
@@ -44,48 +45,25 @@ module Dynamoid
           changes = add_timestamps(changes, skip_created_at: true)
           changes_dumped = Dynamoid::Dumping.dump_attributes(changes, @model_class.attributes)
 
-          # primary key to look up an item to update
-          partition_key_dumped = dump(@model_class.hash_key, @hash_key)
-          key = { @model_class.hash_key => partition_key_dumped }
+          builder = UpdateRequestBuilder.new(@model_class)
+          builder.hash_key = dump(@model_class.hash_key, @hash_key)
+          builder.range_key = dump(@model_class.range_key, @range_key) if @model_class.range_key?
 
-          if @model_class.range_key?
-            sort_key_dumped = dump(@model_class.range_key, @range_key)
-            key[@model_class.range_key] = sort_key_dumped
-          end
+          attributes_to_set = {}
+          attributes_to_remove = []
 
-          # Build UpdateExpression and keep names and values placeholders mapping
-          # in ExpressionAttributeNames and ExpressionAttributeValues.
-          set_expression_statements = []
-          remove_expression_statements = []
-          expression_attribute_names = {}
-          expression_attribute_values = {}
-
-          changes_dumped.each_with_index do |(name, value), i|
-            name_placeholder = "#_n#{i}"
-            value_placeholder = ":_s#{i}"
-
+          changes_dumped.each do |name, value|
             if value || Dynamoid.config.store_attribute_with_nil_value
-              set_expression_statements << "#{name_placeholder} = #{value_placeholder}"
-              expression_attribute_values[value_placeholder] = value
+              attributes_to_set[name] = value
             else
-              remove_expression_statements << name_placeholder
+              attributes_to_remove << name
             end
-            expression_attribute_names[name_placeholder] = name
           end
 
-          update_expression = ''
-          update_expression += "SET #{set_expression_statements.join(', ')}" if set_expression_statements.any?
-          update_expression += " REMOVE #{remove_expression_statements.join(', ')}" if remove_expression_statements.any?
+          builder.set_attributes(attributes_to_set)
+          builder.remove_attributes(attributes_to_remove)
 
-          {
-            update: {
-              key: key,
-              table_name: @model_class.table_name,
-              update_expression: update_expression,
-              expression_attribute_names: expression_attribute_names,
-              expression_attribute_values: expression_attribute_values
-            }
-          }
+          builder.request
         end
 
         private

--- a/lib/dynamoid/transactions/mutation/upsert.rb
+++ b/lib/dynamoid/transactions/mutation/upsert.rb
@@ -46,8 +46,8 @@ module Dynamoid
           changes_dumped = Dynamoid::Dumping.dump_attributes(changes, @model_class.attributes)
 
           builder = UpdateRequestBuilder.new(@model_class)
-          builder.hash_key = dump(@model_class.hash_key, @hash_key)
-          builder.range_key = dump(@model_class.range_key, @range_key) if @model_class.range_key?
+          builder.hash_key = cast_and_dump(@model_class.hash_key, @hash_key)
+          builder.range_key = cast_and_dump(@model_class.range_key, @range_key) if @model_class.range_key?
 
           attributes_to_set = {}
           attributes_to_remove = []
@@ -83,9 +83,10 @@ module Dynamoid
           result
         end
 
-        def dump(name, value)
+        def cast_and_dump(name, value)
           options = @model_class.attributes[name]
-          Dumping.dump_field(value, options)
+          value_casted = TypeCasting.cast_field(value, options)
+          Dumping.dump_field(value_casted, options)
         end
       end
     end

--- a/spec/dynamoid/fields_spec.rb
+++ b/spec/dynamoid/fields_spec.rb
@@ -580,7 +580,7 @@ describe Dynamoid::Fields do
       end
     end
 
-    it 'raises an UnknownAttribute error if the attribute is not on the model' do
+    it "raises UnknownAttribute when an attribute name isn't declared as a field" do
       obj = new_class.new
 
       expect {

--- a/spec/dynamoid/persistence/create_spec.rb
+++ b/spec/dynamoid/persistence/create_spec.rb
@@ -443,6 +443,24 @@ RSpec.describe Dynamoid::Persistence do
         end
       end
     end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as attribute names' do
+      klass = new_class do
+        field :name
+      end
+      obj = klass.create!(name: 'Alex')
+      expect(obj.reload.name).to eq 'Alex'
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+      end
+      obj = klass.create(order: 'order-1', count: 1)
+      expect(obj.reload.count).to eq 1
+    end
   end
 
   describe '.create!' do

--- a/spec/dynamoid/persistence/delete_spec.rb
+++ b/spec/dynamoid/persistence/delete_spec.rb
@@ -152,6 +152,15 @@ RSpec.describe Dynamoid::Persistence do
         }.to send_request_matching(:DeleteItem, { TableName: table.arn })
       end
     end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+      end
+      obj = klass.create!(order: 'order-1', count: 1)
+      expect { klass.delete('order-1', 1) }.to change { klass.exists?(order: 'order-1', count: 1) }.from(true).to(false)
+    end
   end
 
   describe '#delete' do
@@ -445,6 +454,15 @@ RSpec.describe Dynamoid::Persistence do
           payment.delete
         }.to send_request_matching(:DeleteItem, { TableName: table.arn })
       end
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+      end
+      obj = klass.create!(order: 'order-1', count: 1)
+      expect { obj.delete }.to change { klass.exists?(order: 'order-1', count: 1) }.from(true).to(false)
     end
   end
 end

--- a/spec/dynamoid/persistence/destroy_spec.rb
+++ b/spec/dynamoid/persistence/destroy_spec.rb
@@ -413,6 +413,15 @@ RSpec.describe Dynamoid::Persistence do
         }.to send_request_matching(:DeleteItem, { TableName: table.arn })
       end
     end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+      end
+      obj = klass.create!(order: 'order-1', count: 1)
+      expect { obj.destroy }.to change { klass.exists?(order: 'order-1', count: 1) }.from(true).to(false)
+    end
   end
 
   describe '#destroy!' do

--- a/spec/dynamoid/persistence/inc_spec.rb
+++ b/spec/dynamoid/persistence/inc_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'fixtures/persistence'
 
 RSpec.describe Dynamoid::Persistence do
   describe '.inc' do
@@ -98,7 +97,7 @@ RSpec.describe Dynamoid::Persistence do
         field :viewed_at, :datetime
       end
 
-      obj = klass.create!(age: 21, viewed_at: Time.now - 1.day, updated_at: Time.now - 2.days)
+      obj = klass.create!(viewed_at: Time.now - 1.day, updated_at: Time.now - 2.days)
 
       expect do
         expect do
@@ -115,7 +114,6 @@ RSpec.describe Dynamoid::Persistence do
       end
 
       obj = klass.create!(
-        age: 21,
         viewed_at: Time.now - 1.day,
         tagged_at: Time.now - 3.days,
         updated_at: Time.now - 2.days
@@ -169,6 +167,17 @@ RSpec.describe Dynamoid::Persistence do
       expect {
         document_class.inc(obj.id, unknown: 1)
       }.to raise_error(Dynamoid::Errors::UnknownAttribute)
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as attribute names' do
+      klass = new_class do
+        field :counter, :integer
+      end
+      obj = klass.create!(counter: 10)
+
+      klass.inc(obj.id, counter: 1)
+      expect(obj.reload.counter).to eq(11)
     end
 
     context 'when a model was concurrently deleted' do

--- a/spec/dynamoid/persistence/inc_spec.rb
+++ b/spec/dynamoid/persistence/inc_spec.rb
@@ -144,12 +144,12 @@ RSpec.describe Dynamoid::Persistence do
     describe 'type casting' do
       it 'uses casted value of sort key to call UpdateItem' do
         class_with_sort_key = new_class do
-          range :published_on, :date
+          range :count, :integer
           field :links_count, :integer
         end
 
-        obj = class_with_sort_key.create!(published_on: '2018-10-07'.to_date, links_count: 2)
-        class_with_sort_key.inc(obj.id, '2018-10-07', links_count: 5)
+        obj = class_with_sort_key.create!(count: 101, links_count: 2)
+        class_with_sort_key.inc(obj.id, '101', links_count: 5)
 
         expect(obj.reload.links_count).to eql(7)
       end

--- a/spec/dynamoid/persistence/inc_spec.rb
+++ b/spec/dynamoid/persistence/inc_spec.rb
@@ -163,6 +163,14 @@ RSpec.describe Dynamoid::Persistence do
       end
     end
 
+    it "raises UnknownAttribute when an attribute name isn't declared as a field" do
+      obj = document_class.create!
+
+      expect {
+        document_class.inc(obj.id, unknown: 1)
+      }.to raise_error(Dynamoid::Errors::UnknownAttribute)
+    end
+
     context 'when a model was concurrently deleted' do
       let(:klass) do
         new_class do

--- a/spec/dynamoid/persistence/inc_spec.rb
+++ b/spec/dynamoid/persistence/inc_spec.rb
@@ -161,6 +161,39 @@ RSpec.describe Dynamoid::Persistence do
       end
     end
 
+    describe 'primary key validation' do
+      context 'simple primary key' do
+        it 'requires partition key to be specified' do
+          expect {
+            document_class.inc(nil, links_count: 1)
+          }.to raise_exception(Dynamoid::Errors::MissingHashKey)
+        end
+      end
+
+      context 'composite key' do
+        let(:klass) do
+          new_class do
+            range :name
+            field :links_count, :integer
+          end
+        end
+
+        it 'requires partition key to be specified' do
+          expect {
+            klass.inc(nil, 'Alex', links_count: 1)
+          }.to raise_exception(Dynamoid::Errors::MissingHashKey)
+        end
+
+        it 'requires sort key to be specified' do
+          id_new = SecureRandom.uuid
+
+          expect {
+            klass.inc(id_new, nil, links_count: 1)
+          }.to raise_exception(Dynamoid::Errors::MissingRangeKey)
+        end
+      end
+    end
+
     it "raises UnknownAttribute when an attribute name isn't declared as a field" do
       obj = document_class.create!
 

--- a/spec/dynamoid/persistence/save_spec.rb
+++ b/spec/dynamoid/persistence/save_spec.rb
@@ -1206,6 +1206,53 @@ RSpec.describe Dynamoid::Persistence do
         end
       end
     end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as attribute names when new record' do
+      klass = new_class do
+        field :name
+      end
+      obj = klass.new(name: 'Alex')
+
+      obj.save
+
+      expect(obj.reload.name).to eq 'Alex'
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as attribute names when persisted model' do
+      klass = new_class do
+        field :name
+      end
+      obj = klass.create!(name: 'Alex')
+
+      obj.name = 'Updated'
+      obj.save
+
+      expect(obj.reload.name).to eq 'Updated'
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key when new record' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+      end
+      obj = klass.new(order: 'order-1', count: 1)
+      obj.save
+      expect(obj.reload.count).to eq 1
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key when persisted model' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+        field :name
+      end
+      obj = klass.create!(order: 'order-1', count: 1, name: 'Original')
+      obj.name = 'Updated'
+      obj.save
+      expect(obj.reload.name).to eq 'Updated'
+    end
   end
 
   describe '#save!' do

--- a/spec/dynamoid/persistence/touch_spec.rb
+++ b/spec/dynamoid/persistence/touch_spec.rb
@@ -182,5 +182,15 @@ RSpec.describe Dynamoid::Persistence do
         expect(klass_with_composite_key_and_custom_type.exists?(id: obj.id, tags: obj.tags)).to eql(false)
       end
     end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+      end
+      obj = klass.create!(order: 'order-1', count: 1)
+      obj.touch
+      expect(obj.reload.updated_at).to be_present
+    end
   end
 end

--- a/spec/dynamoid/persistence/update_attribute_spec.rb
+++ b/spec/dynamoid/persistence/update_attribute_spec.rb
@@ -494,6 +494,27 @@ RSpec.describe Dynamoid::Persistence do
         end
       end
     end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as attribute names' do
+      klass = new_class do
+        field :name
+      end
+      obj = klass.create!(name: 'Original')
+      obj.update_attribute(:name, 'Updated')
+      expect(klass.find(obj.id).name).to eq 'Updated'
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+        field :name
+      end
+      obj = klass.create!(order: 'order-1', count: 1, name: 'Alex')
+      obj.update_attribute(:name, 'Michael')
+      expect(obj.reload.name).to eq 'Michael'
+    end
   end
 
   describe '#update_attribute!' do

--- a/spec/dynamoid/persistence/update_attribute_spec.rb
+++ b/spec/dynamoid/persistence/update_attribute_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Dynamoid::Persistence do
       end
     end
 
-    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
+    it "raises UnknownAttribute when an attribute name isn't declared as a field" do
       klass = new_class do
         field :age, :integer
         field :name, :string

--- a/spec/dynamoid/persistence/update_attributes_spec.rb
+++ b/spec/dynamoid/persistence/update_attributes_spec.rb
@@ -315,6 +315,27 @@ RSpec.describe Dynamoid::Persistence do
         end
       end
     end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as attribute names' do
+      klass = new_class do
+        field :name
+      end
+      obj = klass.create!(name: 'Original')
+      obj.update_attributes(name: 'Updated')
+      expect(obj.reload.name).to eq 'Updated'
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+        field :name
+      end
+      obj = klass.create!(order: 'order-1', count: 1, name: 'Alex')
+      obj.update_attributes(name: 'Michael')
+      expect(obj.reload.name).to eq 'Michael'
+    end
   end
 
   describe '#update_attributes!' do

--- a/spec/dynamoid/persistence/update_attributes_spec.rb
+++ b/spec/dynamoid/persistence/update_attributes_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Dynamoid::Persistence do
       end
     end
 
-    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
+    it "raises UnknownAttribute when an attribute name isn't declared as a field" do
       obj = klass.create!(name: 'Alex', age: 26)
 
       expect {
@@ -371,7 +371,7 @@ RSpec.describe Dynamoid::Persistence do
       expect(klass.find(obj.id).age).to eql 26
     end
 
-    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
+    it "raises UnknownAttribute when an attribute name isn't declared as a field" do
       obj = klass.create!(name: 'Alex', age: 26)
 
       expect {

--- a/spec/dynamoid/persistence/update_fields_spec.rb
+++ b/spec/dynamoid/persistence/update_fields_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe Dynamoid::Persistence do
       end
     end
 
-    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
+    it "raises UnknownAttribute when an attribute name isn't declared as a field" do
       obj = klass.create(title: 'New Document')
 
       expect {

--- a/spec/dynamoid/persistence/update_fields_spec.rb
+++ b/spec/dynamoid/persistence/update_fields_spec.rb
@@ -470,5 +470,26 @@ RSpec.describe Dynamoid::Persistence do
         end
       end
     end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as attribute names' do
+      klass = new_class do
+        field :name
+      end
+      obj = klass.create!(name: 'Original')
+      klass.update_fields(obj.id, name: 'Updated')
+      expect(obj.reload.name).to eq 'Updated'
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+        field :name
+      end
+      obj = klass.create!(order: 'order-1', count: 1, name: 'Alex')
+      klass.update_fields('order-1', 1, name: 'Michael')
+      expect(obj.reload.name).to eq 'Michael'
+    end
   end
 end

--- a/spec/dynamoid/persistence/update_spec.rb
+++ b/spec/dynamoid/persistence/update_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Dynamoid::Persistence do
       end.to change { d.reload.name }.to('[Updated]')
     end
 
-    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
+    it "raises UnknownAttribute when an attribute name isn't declared as a field" do
       klass = new_class do
         field :name
       end
@@ -511,7 +511,7 @@ RSpec.describe Dynamoid::Persistence do
       end.to change { d.reload.name }.to('[Updated]')
     end
 
-    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
+    it "raises UnknownAttribute when an attribute name isn't declared as a field" do
       klass = new_class do
         field :name
       end

--- a/spec/dynamoid/persistence/update_spec.rb
+++ b/spec/dynamoid/persistence/update_spec.rb
@@ -1252,5 +1252,27 @@ RSpec.describe Dynamoid::Persistence do
         }.to send_request_matching(:UpdateItem, { TableName: table.arn })
       end
     end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as attribute names' do
+      klass = new_class do
+        field :name
+        field :status
+      end
+      obj = klass.create!(name: 'Original')
+      obj.update { |t| t.set(name: 'Updated') }
+      expect(obj.reload.name).to eq 'Updated'
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+        field :name
+      end
+      obj = klass.create!(order: 'order-1', count: 1, name: 'Alex')
+      obj.update { |t| t.set(name: 'Michael') }
+      expect(obj.reload.name).to eq 'Michael'
+    end
   end
 end

--- a/spec/dynamoid/persistence/upsert_spec.rb
+++ b/spec/dynamoid/persistence/upsert_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe Dynamoid::Persistence do
       end
     end
 
-    it 'raises an UnknownAttribute error when adding an attribute that is not on the model' do
+    it "raises UnknownAttribute when an attribute name isn't declared as a field" do
       obj = klass.create(title: 'New Document')
 
       expect {

--- a/spec/dynamoid/persistence/upsert_spec.rb
+++ b/spec/dynamoid/persistence/upsert_spec.rb
@@ -394,6 +394,28 @@ RSpec.describe Dynamoid::Persistence do
         }.to send_request_matching(:UpdateItem, { TableName: table.arn })
       end
     end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as attribute names' do
+      klass = new_class do
+        field :name
+        field :status
+      end
+      obj = klass.create!(name: 'Original')
+      klass.upsert(obj.id, name: 'Updated')
+      expect(obj.reload.name).to eq 'Updated'
+    end
+
+    # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+    it 'allows reserved words as partition key and sort key' do
+      klass = new_class(partition_key: { name: :order }) do
+        range :count, :integer
+        field :name
+      end
+      obj = klass.create!(order: 'order-1', count: 1, name: 'Alex')
+      klass.upsert('order-1', 1, name: 'Michael')
+      expect(obj.reload.name).to eq 'Michael'
+    end
   end
 
   # See https://github.com/Dynamoid/dynamoid/issues/885 for details

--- a/spec/dynamoid/transactions/mutation/create_spec.rb
+++ b/spec/dynamoid/transactions/mutation/create_spec.rb
@@ -636,6 +636,37 @@ describe Dynamoid::Transactions::Mutation, '.create' do # rubocop:disable RSpec/
       end
     end
   end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as attribute names' do
+    klass = new_class do
+      field :name
+    end
+    klass.create_table
+
+    obj = nil
+    described_class.execute do |txn|
+      obj = txn.create klass, name: 'Alex'
+    end
+
+    expect(obj.reload.name).to eql 'Alex'
+  end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as partition key and sort key' do
+    klass = new_class(partition_key: { name: :order, type: :string }) do
+      range :connection, :string
+      field :name
+    end
+    klass.create_table
+
+    obj = nil
+    described_class.execute do |txn|
+      obj = txn.create klass, order: 'order-1', connection: 'conn-1', name: 'Alex'
+    end
+
+    expect(obj.reload.name).to eql 'Alex'
+  end
 end
 
 describe Dynamoid::Transactions::Mutation, '.create!' do

--- a/spec/dynamoid/transactions/mutation/delete_spec.rb
+++ b/spec/dynamoid/transactions/mutation/delete_spec.rb
@@ -410,6 +410,20 @@ describe Dynamoid::Transactions::Mutation, '#delete(class, primary key)' do
     end
   end
 
+  it 'uses casted value of partition key and sort key' do
+    klass = new_class(partition_key: { name: :id, type: :integer }) do
+      range :count, :integer
+    end
+
+    obj = klass.create!(id: 1, count: 42)
+
+    expect {
+      described_class.execute do |t|
+        t.delete(klass, '1', '42')
+      end
+    }.to change(klass, :count).by(-1)
+  end
+
   it 'uses dumped value of partition key to delete item' do
     klass = new_class(partition_key: { name: :published_on, type: :date }) do
       field :name

--- a/spec/dynamoid/transactions/mutation/delete_spec.rb
+++ b/spec/dynamoid/transactions/mutation/delete_spec.rb
@@ -282,6 +282,20 @@ describe Dynamoid::Transactions::Mutation, '#delete(model)' do # rubocop:disable
       skip "dynamodb-local doesn't support this and returns 'Cannot do operations on a non-existent table'"
     end
   end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as partition key and sort key' do
+    klass = new_class(partition_key: { name: :order, type: :string }) do
+      range :connection, :string
+    end
+    obj = klass.create!(order: 'order-1', connection: 'conn-1')
+
+    expect {
+      described_class.execute do |t|
+        t.delete obj
+      end
+    }.to change(klass, :count).by(-1)
+  end
 end
 
 describe Dynamoid::Transactions::Mutation, '#delete(class, primary key)' do

--- a/spec/dynamoid/transactions/mutation/destroy_spec.rb
+++ b/spec/dynamoid/transactions/mutation/destroy_spec.rb
@@ -429,6 +429,20 @@ describe Dynamoid::Transactions::Mutation, '#destroy' do # rubocop:disable RSpec
       skip "dynamodb-local doesn't support this and returns 'Cannot do operations on a non-existent table'"
     end
   end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as partition key and sort key' do
+    klass = new_class(partition_key: { name: :order, type: :string }) do
+      range :connection, :string
+    end
+    obj = klass.create!(order: 'order-1', connection: 'conn-1')
+
+    expect {
+      described_class.execute do |t|
+        t.destroy obj
+      end
+    }.to change(klass, :count).by(-1)
+  end
 end
 
 describe Dynamoid::Transactions::Mutation, '.destroy!' do

--- a/spec/dynamoid/transactions/mutation/destroy_spec.rb
+++ b/spec/dynamoid/transactions/mutation/destroy_spec.rb
@@ -445,7 +445,7 @@ describe Dynamoid::Transactions::Mutation, '#destroy' do # rubocop:disable RSpec
   end
 end
 
-describe Dynamoid::Transactions::Mutation, '.destroy!' do
+describe Dynamoid::Transactions::Mutation, '#destroy!' do
   # The only difference in specs structure between #destroy and #destroy! is missing
   # a section for callbacks here
 

--- a/spec/dynamoid/transactions/mutation/inc_spec.rb
+++ b/spec/dynamoid/transactions/mutation/inc_spec.rb
@@ -1,0 +1,341 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Dynamoid::Transactions::Mutation, '.inc' do
+  let(:document_class) do
+    new_class do
+      field :links_count, :integer
+      field :mentions_count, :integer
+    end
+  end
+
+  let(:klass_with_composite_key) do
+    new_class do
+      range :name
+      field :links_count, :integer
+    end
+  end
+
+  it 'adds specified value' do
+    obj = document_class.create!(links_count: 2)
+
+    described_class.execute do |t|
+      t.inc(document_class, obj.id, links_count: 5)
+    end
+
+    expect(document_class.find(obj.id).links_count).to eq(7)
+  end
+
+  it 'accepts negative value' do
+    obj = document_class.create!(links_count: 10)
+
+    described_class.execute do |t|
+      t.inc(document_class, obj.id, links_count: -2)
+    end
+
+    expect(document_class.find(obj.id).links_count).to eq(8)
+  end
+
+  it 'treats nil value as zero' do
+    obj = document_class.create!(links_count: nil)
+
+    described_class.execute do |t|
+      t.inc(document_class, obj.id, links_count: 5)
+    end
+
+    expect(document_class.find(obj.id).links_count).to eq(5)
+  end
+
+  it 'supports passing several attributes at once' do
+    obj = document_class.create!(links_count: 2, mentions_count: 31)
+
+    described_class.execute do |t|
+      t.inc(document_class, obj.id, links_count: 5, mentions_count: 9)
+    end
+
+    expect(document_class.find(obj.id).links_count).to eql(7)
+    expect(document_class.find(obj.id).mentions_count).to eql(40)
+  end
+
+  it 'accepts sort key if it is declared' do
+    class_with_sort_key = new_class do
+      range :author_name
+      field :links_count, :integer
+    end
+
+    obj = class_with_sort_key.create!(author_name: 'Mike', links_count: 2)
+
+    described_class.execute do |t|
+      t.inc(class_with_sort_key, obj.id, 'Mike', links_count: 5)
+    end
+
+    expect(obj.reload.links_count).to eql(7)
+  end
+
+  it 'uses dumped value of partition key to update item' do
+    klass = new_class(partition_key: { name: :published_on, type: :date }) do
+      field :links_count, :integer
+    end
+
+    obj = klass.create!(published_on: '2018-10-07'.to_date, links_count: 2)
+
+    described_class.execute do |t|
+      t.inc(klass, '2018-10-07'.to_date, links_count: 5)
+    end
+
+    expect(obj.reload.links_count).to eql(7)
+  end
+
+  it 'uses dumped value of sort key to update item' do
+    class_with_sort_key = new_class do
+      range :published_on, :date
+      field :links_count, :integer
+    end
+
+    obj = class_with_sort_key.create!(published_on: '2018-10-07'.to_date, links_count: 2)
+
+    described_class.execute do |t|
+      t.inc(class_with_sort_key, obj.id, '2018-10-07'.to_date, links_count: 5)
+    end
+
+    expect(obj.reload.links_count).to eql(7)
+  end
+
+  it 'returns nil' do
+    obj = document_class.create!(links_count: 2)
+
+    result = true
+    described_class.execute do |t|
+      result = t.inc(document_class, obj.id, links_count: 5)
+    end
+
+    expect(result).to eql(nil)
+  end
+
+  it 'updates `updated_at` attribute when touch: true option passed' do
+    obj = document_class.create!(links_count: 2, updated_at: Time.now - 1.day)
+
+    described_class.execute do |t|
+      t.inc(document_class, obj.id, links_count: 5, touch: true)
+    end
+
+    expect(document_class.find(obj.id).updated_at).to be > (Time.now - 1.minute)
+  end
+
+  it 'updates `updated_at` and the specified attributes when touch: name option passed' do
+    klass = new_class do
+      field :links_count, :integer
+      field :viewed_at, :datetime
+    end
+
+    obj = klass.create!(viewed_at: Time.now - 1.day, updated_at: Time.now - 2.days)
+
+    described_class.execute do |t|
+      t.inc(klass, obj.id, links_count: 5, touch: :viewed_at)
+    end
+
+    item = klass.find(obj.id)
+    expect(item.viewed_at).to be > (Time.now - 1.minute)
+    expect(item.updated_at).to be > (Time.now - 1.minute)
+  end
+
+  it 'updates `updated_at` and the specified attributes when touch: [<name>*] option passed' do
+    klass = new_class do
+      field :links_count, :integer
+      field :viewed_at, :datetime
+      field :tagged_at, :datetime
+    end
+
+    obj = klass.create!(
+      viewed_at: Time.now - 1.day,
+      tagged_at: Time.now - 3.days,
+      updated_at: Time.now - 2.days
+    )
+
+    described_class.execute do |t|
+      t.inc(klass, obj.id, links_count: 5, touch: %i[viewed_at tagged_at])
+    end
+
+    item = klass.find(obj.id)
+    expect(item.updated_at).to be > (Time.now - 1.minute)
+    expect(item.viewed_at).to be > (Time.now - 1.minute)
+    expect(item.tagged_at).to be > (Time.now - 1.minute)
+  end
+
+  describe 'timestamps' do
+    it 'does not change updated_at', config: { timestamps: true } do
+      obj = document_class.create!
+      expect(obj.updated_at).to be_present
+
+      described_class.execute do |t|
+        t.inc(document_class, obj.id, links_count: 5)
+      end
+
+      expect(document_class.find(obj.id).updated_at).to eq(obj.updated_at)
+    end
+  end
+
+  describe 'type casting' do
+    it 'uses casted value of sort key to call UpdateItem' do
+      klass = new_class(partition_key: { name: :id, type: :integer }) do
+        range :count, :integer
+        field :links_count, :integer
+      end
+
+      obj = klass.create!(id: 1, count: 101, links_count: 2)
+
+      described_class.execute do |t|
+        t.inc(klass, '1', '101', links_count: 5)
+      end
+
+      expect(obj.reload.links_count).to eql(7)
+    end
+
+    it 'type casts attributes' do
+      obj = document_class.create!(links_count: 2)
+
+      described_class.execute do |t|
+        t.inc(document_class, obj.id, links_count: '5.12345')
+      end
+
+      expect(document_class.find(obj.id).links_count).to eq(7)
+    end
+  end
+
+  describe 'primary key validation' do
+    context 'simple primary key' do
+      it 'requires partition key to be specified' do
+        expect {
+          described_class.execute do |t|
+            t.inc document_class, nil, links_count: 1
+          end
+        }.to raise_exception(Dynamoid::Errors::MissingHashKey)
+      end
+    end
+
+    context 'composite key' do
+      it 'requires partition key to be specified' do
+        expect {
+          described_class.execute do |t|
+            t.inc klass_with_composite_key, nil, 'Alex', links_count: 1
+          end
+        }.to raise_exception(Dynamoid::Errors::MissingHashKey)
+      end
+
+      it 'requires sort key to be specified' do
+        id_new = SecureRandom.uuid
+
+        expect {
+          described_class.execute do |t|
+            t.inc klass_with_composite_key, id_new, nil, links_count: 1
+          end
+        }.to raise_exception(Dynamoid::Errors::MissingRangeKey)
+      end
+    end
+  end
+
+  it "raises UnknownAttribute when an attribute name isn't declared as a field" do
+    obj = document_class.create!
+
+    expect {
+      described_class.execute do |t|
+        t.inc(document_class, obj.id, unknown: 1)
+      end
+    }.to raise_error(Dynamoid::Errors::UnknownAttribute)
+  end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved keywords as attribute names' do
+    klass = new_class do
+      field :counter, :integer
+    end
+    obj = klass.create!(counter: 10)
+
+    described_class.execute do |t|
+      t.inc(klass, obj.id, counter: 1)
+    end
+
+    expect(obj.reload.counter).to eq(11)
+  end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as partition key and sort key' do
+    klass = new_class(partition_key: { name: :name, type: :string }) do
+      range :status, :string
+      field :age, :integer
+    end
+    obj = klass.create!(name: 'Alex', status: 'active', age: 3)
+
+    described_class.execute do |t|
+      t.inc klass, obj.name, obj.status, age: 4
+    end
+
+    expect(obj.reload.age).to eql(7)
+  end
+
+  context 'when a model was concurrently deleted' do
+    let(:klass) do
+      new_class do
+        field :age, :integer
+      end
+    end
+
+    let(:klass_with_composite_key) do
+      new_class do
+        range :name
+        field :age, :integer
+      end
+    end
+
+    let(:klass_with_composite_key_and_custom_type) do
+      new_class do
+        range :tags, :serialized
+        field :age, :integer
+      end
+    end
+
+    it 'does not persist changes when simple primary key' do
+      obj = klass.create!(age: 21)
+      klass.find(obj.id).delete
+
+      expect {
+        described_class.execute do |t|
+          t.inc klass, obj.id, age: 1
+        end
+      }.to raise_error(Aws::DynamoDB::Errors::TransactionCanceledException)
+    end
+
+    it 'does not persist changes when composite primary key' do
+      obj = klass_with_composite_key.create!(name: 'Alex', age: 21)
+      klass_with_composite_key.find(obj.id, range_key: obj.name).delete
+
+      expect {
+        described_class.execute do |t|
+          t.inc klass_with_composite_key, obj.id, obj.name, age: 1
+        end
+      }.to raise_error(Aws::DynamoDB::Errors::TransactionCanceledException)
+    end
+
+    it 'does not persist changes when composite primary key and sort key type is not supported by DynamoDB natively' do
+      obj = klass_with_composite_key_and_custom_type.create!(tags: %w[a b], age: 21)
+      klass_with_composite_key_and_custom_type.find(obj.id, range_key: obj.tags).delete
+
+      expect {
+        described_class.execute do |t|
+          t.inc klass_with_composite_key_and_custom_type, obj.id, obj.tags, age: 1
+        end
+      }.to raise_error(Aws::DynamoDB::Errors::TransactionCanceledException)
+    end
+  end
+
+  # dynamodb-local doesn't support ARN for TableName request
+  # attribute and the following error is returned:
+  #   Aws::DynamoDB::Errors::ResourceNotFoundException:
+  #    Cannot do operations on a non-existent table
+  context 'when table arn is specified' do
+    it 'uses given table ARN in requests instead of a table name' do
+      skip 'cannot test with dynamodb-local'
+    end
+  end
+end

--- a/spec/dynamoid/transactions/mutation/save_spec.rb
+++ b/spec/dynamoid/transactions/mutation/save_spec.rb
@@ -1683,6 +1683,68 @@ describe Dynamoid::Transactions::Mutation, '.save' do # rubocop:disable RSpec/Mu
       end
     end
   end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as attribute names when new record' do
+    klass = new_class do
+      field :name
+    end
+    klass.create_table
+
+    obj = klass.new(name: 'Alex')
+    described_class.execute do |t|
+      t.save obj
+    end
+
+    expect(obj.reload.name).to eql 'Alex'
+  end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as attribute names when persisted model' do
+    klass = new_class do
+      field :name
+    end
+
+    obj = klass.create!(name: 'Original')
+    obj.name = 'Updated'
+    described_class.execute do |t|
+      t.save obj
+    end
+    expect(obj.reload.name).to eql 'Updated'
+  end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as partition key and sort key when new record' do
+    klass = new_class(partition_key: { name: :order, type: :string }) do
+      range :connection, :string
+      field :name
+    end
+    klass.create_table
+
+    obj = klass.new(order: 'order-1', connection: 'conn-1', name: 'Alex')
+    described_class.execute do |txn|
+      txn.save obj
+    end
+
+    expect(obj.reload.name).to eql 'Alex'
+  end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as partition key and sort key when persisted model' do
+    klass = new_class(partition_key: { name: :order, type: :string }) do
+      range :connection, :string
+      field :name
+    end
+    klass.create_table
+
+    obj = klass.create!(order: 'order-1', connection: 'conn-1', name: 'Original')
+    obj.name = 'Updated'
+    described_class.execute do |txn|
+      txn.save obj
+    end
+
+    expect(obj.reload.name).to eql 'Updated'
+  end
 end
 
 describe Dynamoid::Transactions::Mutation, '.save!' do

--- a/spec/dynamoid/transactions/mutation/update_attributes_spec.rb
+++ b/spec/dynamoid/transactions/mutation/update_attributes_spec.rb
@@ -64,6 +64,36 @@ describe Dynamoid::Transactions::Mutation, '#update_attributes' do # rubocop:dis
     expect(obj.changed?).to eql false
   end
 
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as attribute names' do
+    klass = new_class do
+      field :order, :integer
+    end
+    obj = klass.create!(order: 10)
+
+    described_class.execute do |t|
+      t.update_attributes obj, order: 11
+    end
+
+    expect(obj.reload.order).to eql(11)
+  end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as partition key and sort key' do
+    klass = new_class(partition_key: { name: :name, type: :string }) do
+      range :status, :string
+      field :age, :integer
+    end
+    klass.create_table
+    obj = klass.create!(name: 'Alex', status: 'active', age: 3)
+
+    described_class.execute do |t|
+      t.update_attributes obj, age: 4
+    end
+
+    expect(obj.reload.age).to eql(4)
+  end
+
   # TODO: implement the test later
   it 'raises exception if a model is not persisted'
 

--- a/spec/dynamoid/transactions/mutation/update_fields_spec.rb
+++ b/spec/dynamoid/transactions/mutation/update_fields_spec.rb
@@ -45,7 +45,7 @@ describe Dynamoid::Transactions::Mutation, '#update_fields' do
     expect(result).to eql nil
   end
 
-  it 'raises an UnknownAttribute error when adding an attribute that is not declared in the model' do
+  it "raises UnknownAttribute when an attribute name isn't declared as a field" do
     obj = klass.create!(name: 'Alex')
 
     expect {

--- a/spec/dynamoid/transactions/mutation/update_fields_spec.rb
+++ b/spec/dynamoid/transactions/mutation/update_fields_spec.rb
@@ -117,6 +117,21 @@ describe Dynamoid::Transactions::Mutation, '#update_fields' do
     end
   end
 
+  it 'uses casted value of partition key and sort key' do
+    klass = new_class(partition_key: { name: :id, type: :integer }) do
+      range :count, :integer
+      field :name
+    end
+
+    obj = klass.create!(id: 1, count: 42, name: 'Original')
+
+    described_class.execute do |t|
+      t.update_fields(klass, '1', '42', name: 'Updated')
+    end
+
+    expect(obj.reload.name).to eql('Updated')
+  end
+
   it 'uses dumped value of partition key to update item' do
     klass = new_class(partition_key: { name: :published_on, type: :date }) do
       field :name

--- a/spec/dynamoid/transactions/mutation/update_fields_spec.rb
+++ b/spec/dynamoid/transactions/mutation/update_fields_spec.rb
@@ -144,6 +144,21 @@ describe Dynamoid::Transactions::Mutation, '#update_fields' do
     expect(obj.reload.name).to eql('Alex [Updated]')
   end
 
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as partition key and sort key' do
+    klass = new_class(partition_key: { name: :name, type: :string }) do
+      range :status, :string
+      field :age, :integer
+    end
+    obj = klass.create!(name: 'Alex', status: 'active', age: 3)
+
+    described_class.execute do |t|
+      t.update_fields klass, obj.name, obj.status, age: 4
+    end
+
+    expect(obj.reload.age).to eql(4)
+  end
+
   describe 'timestamps' do
     it 'sets updated_at if Config.timestamps=true', config: { timestamps: true } do
       obj = klass.create!

--- a/spec/dynamoid/transactions/mutation/upsert_spec.rb
+++ b/spec/dynamoid/transactions/mutation/upsert_spec.rb
@@ -64,7 +64,7 @@ describe Dynamoid::Transactions::Mutation, '.upsert' do
     }.to raise_error(ArgumentError)
   end
 
-  it 'raises an UnknownAttribute error when adding an attribute that is not declared in the model' do
+  it "raises UnknownAttribute when an attribute name isn't declared as a field" do
     obj = klass.create!(name: 'Alex')
 
     expect {

--- a/spec/dynamoid/transactions/mutation/upsert_spec.rb
+++ b/spec/dynamoid/transactions/mutation/upsert_spec.rb
@@ -43,6 +43,35 @@ describe Dynamoid::Transactions::Mutation, '.upsert' do
     expect(obj_loaded.name).to eql 'Alex [Updated]'
   end
 
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as attribute names' do
+    klass = new_class do
+      field :order, :integer
+    end
+    obj = klass.create!(order: 10)
+
+    described_class.execute do |t|
+      t.upsert klass, obj.id, order: 11
+    end
+
+    expect(obj.reload.order).to eql(11)
+  end
+
+  # see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  it 'allows reserved words as partition key and sort key' do
+    klass = new_class(partition_key: { name: :name, type: :string }) do
+      range :status, :string
+      field :age, :integer
+    end
+    obj = klass.create!(name: 'Alex', status: 'active', age: 3)
+
+    described_class.execute do |t|
+      t.upsert klass, obj.name, obj.status, age: 4
+    end
+
+    expect(obj.reload.age).to eql(4)
+  end
+
   it 'returns nil' do
     obj = klass.create!(name: 'Alex')
 

--- a/spec/dynamoid/transactions/mutation/upsert_spec.rb
+++ b/spec/dynamoid/transactions/mutation/upsert_spec.rb
@@ -349,6 +349,21 @@ describe Dynamoid::Transactions::Mutation, '.upsert' do
     end
   end
 
+  it 'uses casted value of partition key and sort key' do
+    klass = new_class(partition_key: { name: :id, type: :integer }) do
+      range :count, :integer
+      field :name
+    end
+
+    obj = klass.create!(id: 1, count: 42, name: 'Original')
+
+    described_class.execute do |t|
+      t.upsert(klass, '1', '42', name: 'Updated')
+    end
+
+    expect(obj.reload.name).to eql('Updated')
+  end
+
   it 'uses dumped value of partition key to update item' do
     klass = new_class(partition_key: { name: :published_on, type: :date }) do
       field :name


### PR DESCRIPTION
Changes:
- added transactional `inc` method
- fixed transactional `update_fields`, `save` methods to allow reserved words as partition and sort keys
- fixed non-transactional `inc` method to raise `UnknownAttribute` when given unknown field name as a parameter
- fixed non-transactional `inc` method to raise `MissingHashKey` and `MissingRangeKey` when either partition or sort key parameter is nil or not given
- fixed transactional `.delete`, `update_fields`, and `upsert` to type cast given partition and sort key values