### PR TITLE
Fix documentation workflow and resolve an issue with Gemfile and Gemfile.lock

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,6 +48,8 @@ jobs:
   # Generate API References
   build-reference:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/yard.gemfile
     steps:
       - uses: actions/checkout@v4
 

--- a/gemfiles/yard.gemfile
+++ b/gemfiles/yard.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'yard', '~> 0.9.0'


### PR DESCRIPTION
The fixed error manifests in the following way:
```
Some dependencies were deleted from your gemfile, but the lockfile can't be
updated because frozen mode is set

...
Run `bundle install` elsewhere and add the updated Gemfile.lock to version
control.

If this is a development machine, remove the Gemfile.lock freeze by running
`bundle config set frozen false`.

```