### PR TITLE
Fix documentation workflow and resolve an issue with running yardoc

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -60,7 +60,7 @@ jobs:
           bundler-cache: true
 
       - name: Build API Reference
-        run: yardoc # generates ./yardoc directory
+        run: bundle exec yardoc # generates ./yardoc directory
 
       - name: Upload Guides Raw Material
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The fixed issue:
```
Run yardoc
/home/runner/work/_temp/4fecbddd-d68e-43ea-9932-98397645bc78.sh: line 1: yardoc: command not found
Error: Process completed with exit code 127.
```