### PR TITLE
Restore Rubocop TargetRubyVersion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,8 +16,8 @@ plugins:
   - rubocop-rspec
   - rubocop-thread_safety
 
-# It's the lowest supported Ruby version
 AllCops:
+  TargetRubyVersion: 2.3 # It's the lowest supported Ruby version
   DisplayCopNames: true # Display the name of the failing cops
   NewCops: enable
 

--- a/lib/dynamoid/persistence/inc.rb
+++ b/lib/dynamoid/persistence/inc.rb
@@ -6,7 +6,7 @@ module Dynamoid
   module Persistence
     # @private
     class Inc
-      def self.call(model_class, partition_key, sort_key = nil, counters)
+      def self.call(model_class, partition_key, sort_key = nil, counters) # rubocop:disable Style/OptionalArguments
         new(model_class, partition_key, sort_key, counters).call
       end
 


### PR DESCRIPTION
Restores `TargetRubyVersion: 2.3` in .rubocop.yml.

Because we support Ruby 2.3, suggestions to use newer Ruby core methods and syntax are not viable. Specifying the target version resolves 123 false-positive RuboCop offenses (e.g., `Naming/BlockForwarding`, `Style/MapToHash`, `Style/CollectionCompact`, `Performance/Sum`, and Lint/RedundantDirGlobSort`).